### PR TITLE
Added an updated version of the state visibility CIP

### DIFF
--- a/cip/CIP2015-10-03-State-visibility-between-clauses.adoc
+++ b/cip/CIP2015-10-03-State-visibility-between-clauses.adoc
@@ -1,0 +1,73 @@
+= CIP20140109 - State visibility between clauses
+:numbered:
+:toc:
+:toc-placement: macro
+:source-highlighter: codemirror
+
+*Authors:* Andrés Taylor <andres@neotechnology.com>
+
+[abstract]
+.Abstract
+--
+This CIP tries to formalise how state changes work while inside a Cypher query. Currently, because this is not explicit enough, the behaviour is implementation dependent.
+--
+
+toc::[]
+
+=== Background
+Cypher allows queries to go through multiple steps, and it’s possible to interleave reading and writing to the graph. Some clauses can also do both - read the graph and write to it at the same time.
+
+To allow the user to understand what the outcome will be at an abstract, logical level, semantics for the visibility of these changes should be clear.
+
+This query is problematic, because if the results of the +CREATE+ clause are visible by the +MATCH+ clause, a never ending loop will be created. Today this is solved by eagerly fetching the full result of the +MATCH+ before doing any updates at all.
+
+=== Proposal
+Each clause lives in its own state, which includes all the changes of clauses coming before it, including changes performed by itself, *but none of the changes made by clauses listed later in the query.*
+
+The semantical data flow here is such that each clause operates on the entire result set before passing control to any subsequent clause.
+
+Updates between UNION subqueries are also treated in a sequential manner.
+Therefore subqueries coming later will see updates from subqueries before, but not the other way around.
+
+==== Examples
+Given a database containing two nodes, and the following query,
+the sequence below describes a non-obvious query execution.
+
+.Example query 1
+----
+MATCH ()
+CREATE ()
+WITH *
+MATCH ()
+CREATE ()
+----
+
+|===
+||Pre-existing nodes|Rows in|Nodes created|Rows out
+
+|`MATCH ()`|2|1||2 (N)
+|`CREATE ()`|2|2|2 ( R ) |2
+|`WITH *`|4|2||2
+|`MATCH ()`|4|2||8 (N * R)
+|`CREATE ()`|4|8|8|8
+|_Outcome_|*12 (2+2+8)*||*10*|*8*
+|===
+
+.Example query 2:
+The following query would lead to a never ending loop, if a lazy +MATCH+ clause was not isolated from the new nodes created by +CREATE+.
+
+_Query_
+----
+MATCH (a)
+CREATE ()
+----
+
+=== Benefits to this proposal
+Explicit state change visibility makes it possible to understand queries without having to worry about ordering of updates and reads.
+
+From an implementation perspective, these semantics also allow us to make some queries more performant than they can be today, by ignoring statement state for a lot of graph reading, and saving us from eagerly producing matching results before updates can be applied.
+
+This replaces the past definition in CIP20140109.
+
+=== Caveats to this proposal
+None known at the moment


### PR DESCRIPTION
Some github weirdness is making rendering the AsciiDocs problematic. Here is a link to the interesting bits:

https://github.com/systay/cypher/blob/c8d576cb2b4f08fd43b9cf43b15dc539f773c507/cip/CIP2015-10-03-State-visibility-between-clauses.adoc