### PR TITLE
Reformatted the TCK tests 

### DIFF
--- a/tck/features/AggregationAcceptance.feature
+++ b/tck/features/AggregationAcceptance.feature
@@ -20,7 +20,7 @@ Feature: AggregationAcceptance
     Given an empty graph
     When executing query:
       """
-      MATCH (a { name: 'Andres' })<-[:FATHER]-(child)
+      MATCH (a {name: 'Andres'})<-[:FATHER]-(child)
       RETURN {foo: a.name='Andres', kids: collect(child.name)}
       """
     Then the result should be empty
@@ -153,7 +153,10 @@ Feature: AggregationAcceptance
 
   Scenario: Distinct on null
     Given an empty graph
-    And having executed: CREATE ()
+    And having executed:
+      """
+      CREATE ()
+      """
     When executing query:
       """
       MATCH (a)
@@ -209,13 +212,23 @@ Feature: AggregationAcceptance
 
   Scenario: Aggregates in aggregates
     Given any graph
-    When executing query: RETURN count(count(*))
+    When executing query:
+      """
+      RETURN count(count(*))
+      """
     Then a SyntaxError should be raised at compile time: NestedAggregation
 
   Scenario: Aggregates with arithmetics
     Given an empty graph
-    And having executed: CREATE ()
-    When executing query: MATCH () RETURN count(*) * 10 AS c
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH ()
+      RETURN count(*) * 10 AS c
+      """
     Then the result should be:
       | c  |
       | 10 |
@@ -223,7 +236,10 @@ Feature: AggregationAcceptance
 
   Scenario: Aggregates ordered by arithmetics
     Given an empty graph
-    And having executed: CREATE (:A), (:X), (:X)
+    And having executed:
+      """
+      CREATE (:A), (:X), (:X)
+      """
     When executing query:
       """
       MATCH (a:A), (b:X)
@@ -237,7 +253,10 @@ Feature: AggregationAcceptance
 
   Scenario: Multiple aggregates on same variable
     Given an empty graph
-    And having executed: CREATE ()
+    And having executed:
+      """
+      CREATE ()
+      """
     When executing query:
       """
       MATCH (n)
@@ -255,7 +274,11 @@ Feature: AggregationAcceptance
       UNWIND range(1, 100) AS i
       CREATE ()
       """
-    When executing query: MATCH () RETURN count(*)
+    When executing query:
+      """
+      MATCH ()
+      RETURN count(*)
+      """
     Then the result should be:
       | count(*) |
       | 100      |
@@ -307,7 +330,10 @@ Feature: AggregationAcceptance
 
   Scenario: Handle subexpression in aggregation also occurring as standalone expression with nested aggregation in a literal map
     Given an empty graph
-    And having executed: CREATE (:A), (:B {prop: 42})
+    And having executed:
+      """
+      CREATE (:A), (:B {prop: 42})
+      """
     When executing query:
       """
       MATCH (a:A), (b:B)
@@ -322,7 +348,10 @@ Feature: AggregationAcceptance
 
   Scenario: Projection during aggregation in WITH before MERGE and after WITH with predicate
     Given an empty graph
-    And having executed: CREATE (:A {prop: 42})
+    And having executed:
+      """
+      CREATE (:A {prop: 42})
+      """
     When executing query:
       """
       UNWIND [42] AS props
@@ -352,8 +381,15 @@ Feature: AggregationAcceptance
 
   Scenario: Counting with loops
     Given an empty graph
-    And having executed: CREATE (a), (a)-[:R]->(a)
-    When executing query: MATCH ()-[r]-() RETURN count(r)
+    And having executed:
+      """
+      CREATE (a), (a)-[:R]->(a)
+      """
+    When executing query:
+      """
+      MATCH ()-[r]-()
+      RETURN count(r)
+      """
     Then the result should be:
       | count(r) |
       | 1        |

--- a/tck/features/CineastDependent.feature
+++ b/tck/features/CineastDependent.feature
@@ -22,49 +22,82 @@ Feature: CineastDependent
     Given the cineast graph
 
   Scenario: Make query from existing database
-    When executing query: MATCH (n) RETURN count(n)
+    When executing query:
+      """
+      MATCH (n)
+      RETURN count(n)
+      """
     Then the result should be:
       | count(n) |
       | 63084    |
     And no side effects
 
   Scenario: Support multiple divisions in aggregate function
-    When executing query: MATCH (n) RETURN count(n)/60/60 AS count
+    When executing query:
+      """
+      MATCH (n)
+      RETURN count(n)/60/60 AS count
+      """
     Then the result should be:
       | count |
       | 17    |
     And no side effects
 
   Scenario: Support column renaming for aggregates as well
-    When executing query: MATCH (a) WHERE id(a) = 0 RETURN count(*) AS ColumnName
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) = 0
+      RETURN count(*) AS ColumnName
+      """
     Then the result should be:
       | ColumnName |
       | 1          |
     And no side effects
 
   Scenario: Run coalesce
-    When executing query: MATCH (a) WHERE id(a) = 0 RETURN coalesce(a.title, a.name)
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) = 0
+      RETURN coalesce(a.title, a.name)
+      """
     Then the result should be:
       | coalesce(a.title, a.name) |
       | 'Emil Eifrem'             |
     And no side effects
 
   Scenario: Allow addition
-    When executing query: MATCH (a) WHERE id(a) = 61263 RETURN a.version + 5
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) = 61263
+      RETURN a.version + 5
+      """
     Then the result should be:
       | a.version + 5 |
       | 1863          |
     And no side effects
 
   Scenario: Functions should return null if they get path containing unbound
-    When executing query: MATCH (a) WHERE id(a) = 1 OPTIONAL MATCH p=(a)-[r]->() RETURN length(nodes(p)), id(r), type(r), nodes(p), rels(p)
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) = 1
+      OPTIONAL MATCH p = (a)-[r]->()
+      RETURN length(nodes(p)), id(r), type(r), nodes(p), rels(p)
+      """
     Then the result should be:
       | length(nodes(p)) | id(r) | type(r) | nodes(p) | rels(p) |
       | null             | null  | null    | null     | null    |
     And no side effects
 
   Scenario: Aggregates inside normal functions
-    When executing query: MATCH (a) RETURN length(collect(a))
+    When executing query:
+      """
+      MATCH (a)
+      RETURN length(collect(a))
+      """
     Then the result should be:
       | length(collect(a)) |
       | 63084              |

--- a/tck/features/Create.feature
+++ b/tck/features/Create.feature
@@ -19,21 +19,30 @@ Feature: Create
 
   Scenario: Creating a node
     Given any graph
-    When executing query: CREATE ()
+    When executing query:
+      """
+      CREATE ()
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes | 1 |
 
   Scenario: Creating two nodes
     Given any graph
-    When executing query: CREATE (), ()
+    When executing query:
+      """
+      CREATE (), ()
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes | 2 |
 
   Scenario: Creating two nodes and a relationship
     Given any graph
-    When executing query: CREATE ()-[:TYPE]->()
+    When executing query:
+      """
+      CREATE ()-[:TYPE]->()
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes         | 2 |
@@ -41,7 +50,10 @@ Feature: Create
 
   Scenario: Creating a node with a label
     Given any graph
-    When executing query: CREATE (:Label)
+    When executing query:
+      """
+      CREATE (:Label)
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes  | 1 |
@@ -49,7 +61,10 @@ Feature: Create
 
   Scenario: Creating a node with a property
     Given any graph
-    When executing query: CREATE ({created: true})
+    When executing query:
+      """
+      CREATE ({created: true})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 1 |

--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -19,7 +19,10 @@ Feature: DeleteAcceptance
 
   Scenario: Delete nodes
     Given an empty graph
-    And having executed: CREATE ()
+    And having executed:
+      """
+      CREATE ()
+      """
     When executing query:
       """
       MATCH (n)
@@ -31,7 +34,10 @@ Feature: DeleteAcceptance
 
   Scenario: Detach delete node
     Given an empty graph
-    And having executed: CREATE ()
+    And having executed:
+      """
+      CREATE ()
+      """
     When executing query:
       """
       MATCH (n)
@@ -45,7 +51,7 @@ Feature: DeleteAcceptance
     Given an empty graph
     And having executed:
       """
-      UNWIND range(0,2) AS i
+      UNWIND range(0, 2) AS i
       CREATE ()-[:R]->()
       """
     When executing query:
@@ -103,7 +109,7 @@ Feature: DeleteAcceptance
       """
     When executing query:
       """
-      MATCH p=(:X)-->()-->()-->()
+      MATCH p = (:X)-->()-->()-->()
       DETACH DELETE p
       """
     Then the result should be empty
@@ -363,7 +369,7 @@ Feature: DeleteAcceptance
       """
     When executing query:
       """
-      MATCH p=(:User)-[r]->(:User)
+      MATCH p = (:User)-[r]->(:User)
       WITH {key: collect(p)} AS pathColls
       DELETE pathColls.key[0], pathColls.key[1]
       """

--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -29,14 +29,22 @@ Feature: ExpressionAcceptance
 
   Scenario: Execute n['name'] in read queries
     And having executed: CREATE ({name: 'Apa'})
-    When executing query: MATCH (n {name: 'Apa'}) RETURN n['nam' + 'e'] AS value
+    When executing query:
+      """
+      MATCH (n {name: 'Apa'})
+      RETURN n['nam' + 'e'] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
     And no side effects
 
   Scenario: Execute n['name'] in update queries
-    When executing query: CREATE (n {name: 'Apa'}) RETURN n['nam' + 'e'] AS value
+    When executing query:
+      """
+      CREATE (n {name: 'Apa'})
+      RETURN n['nam' + 'e'] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -48,7 +56,11 @@ Feature: ExpressionAcceptance
     And parameters are:
       | expr | {name: 'Apa'} |
       | idx  | 'name'        |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx] AS value
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -57,7 +69,11 @@ Feature: ExpressionAcceptance
   Scenario: Use dynamic property lookup based on parameters when there is lhs type information
     And parameters are:
       | idx | 'name' |
-    When executing query: CREATE (n {name: 'Apa'}) RETURN n[{idx}] AS value
+    When executing query:
+      """
+      CREATE (n {name: 'Apa'})
+      RETURN n[{idx}] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -69,7 +85,11 @@ Feature: ExpressionAcceptance
     And parameters are:
       | expr | {name: 'Apa'} |
       | idx  | 'name'        |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[toString(idx)] AS value
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[toString(idx)] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -79,7 +99,11 @@ Feature: ExpressionAcceptance
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx] AS value
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -88,7 +112,11 @@ Feature: ExpressionAcceptance
   Scenario: Use collection lookup based on parameters when there is lhs type information
     And parameters are:
       | idx | 0 |
-    When executing query: WITH ['Apa'] AS expr RETURN expr[{idx}] AS value
+    When executing query:
+      """
+      WITH ['Apa'] AS expr
+      RETURN expr[{idx}] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -98,7 +126,11 @@ Feature: ExpressionAcceptance
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[toInt(idx)] AS value
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[toInt(idx)] AS value
+      """
     Then the result should be:
       | value |
       | 'Apa' |
@@ -108,33 +140,53 @@ Feature: ExpressionAcceptance
     And parameters are:
       | expr | {name: 'Apa'} |
       | idx  | 0             |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx]
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx]
+      """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
 
   Scenario: Fail at runtime when trying to index into a map with a non-string
     And parameters are:
       | expr | {name: 'Apa'} |
       | idx  | 12.3          |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx]
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx]
+      """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
 
   Scenario: Fail at runtime when attempting to index with a String into a Collection
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 'name'  |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx]
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx]
+      """
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
 
   Scenario: Fail at runtime when trying to index into a list with a list
     And parameters are:
       | expr | ['Apa'] |
       | idx  | ['Apa'] |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx]
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx]
+      """
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
 
   Scenario: Fail at runtime when trying to index something which is not a map or collection
     And parameters are:
       | expr | 100 |
       | idx  | 0   |
-    When executing query: WITH {expr} AS expr, {idx} AS idx RETURN expr[idx]
+    When executing query:
+      """
+      WITH {expr} AS expr, {idx} AS idx
+      RETURN expr[idx]
+      """
     Then a TypeError should be raised at runtime: InvalidElementAccess

--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -21,14 +21,20 @@ Feature: ExpressionAcceptance
     Given any graph
 
   Scenario: Execute n[0]
-    When executing query: RETURN [1, 2, 3][0] AS value
+    When executing query:
+      """
+      RETURN [1, 2, 3][0] AS value
+      """
     Then the result should be:
       | value |
       | 1     |
     And no side effects
 
   Scenario: Execute n['name'] in read queries
-    And having executed: CREATE ({name: 'Apa'})
+    And having executed:
+      """
+      CREATE ({name: 'Apa'})
+      """
     When executing query:
       """
       MATCH (n {name: 'Apa'})

--- a/tck/features/Literals.feature
+++ b/tck/features/Literals.feature
@@ -21,77 +21,110 @@ Feature: Literals
     Given any graph
 
   Scenario: Return an integer
-    When executing query: RETURN 1 AS literal
+    When executing query:
+      """
+      RETURN 1 AS literal
+      """
     Then the result should be:
       | literal |
       | 1       |
     And no side effects
 
   Scenario: Return a float
-    When executing query: RETURN 1.0 AS literal
+    When executing query:
+      """
+      RETURN 1.0 AS literal
+      """
     Then the result should be:
       | literal |
       | 1.0     |
     And no side effects
 
   Scenario: Return a float in exponent form
-    When executing query: RETURN -1e-9 AS literal
+    When executing query:
+      """
+      RETURN -1e-9 AS literal
+      """
     Then the result should be:
       | literal     |
       | -.000000001 |
     And no side effects
 
   Scenario: Return a boolean
-    When executing query: RETURN true AS literal
+    When executing query:
+      """
+      RETURN true AS literal
+      """
     Then the result should be:
       | literal |
       | true    |
     And no side effects
 
   Scenario: Return a single-quoted string
-    When executing query: RETURN '' AS literal
+    When executing query:
+      """
+      RETURN '' AS literal
+      """
     Then the result should be:
       | literal |
       | ''      |
     And no side effects
 
   Scenario: Return a double-quoted string
-    When executing query: RETURN "" AS literal
+    When executing query:
+      """
+      RETURN "" AS literal
+      """
     Then the result should be:
       | literal |
       | ''      |
     And no side effects
 
   Scenario: Return null
-    When executing query: RETURN null AS literal
+    When executing query:
+      """
+      RETURN null AS literal
+      """
     Then the result should be:
       | literal |
       | null    |
     And no side effects
 
   Scenario: Return an empty list
-    When executing query: RETURN [] AS literal
+    When executing query:
+      """
+      RETURN [] AS literal
+      """
     Then the result should be:
       | literal |
       | []      |
     And no side effects
 
   Scenario: Return a nonempty list
-    When executing query: RETURN [0,1,2] AS literal
+    When executing query:
+      """
+      RETURN [0, 1, 2] AS literal
+      """
     Then the result should be:
       | literal   |
       | [0, 1, 2] |
     And no side effects
 
   Scenario: Return an empty map
-    When executing query: RETURN {} AS literal
+    When executing query:
+      """
+      RETURN {} AS literal
+      """
     Then the result should be:
       | literal |
       | {}      |
     And no side effects
 
   Scenario: Return a nonempty map
-    When executing query: RETURN {k1: 0, k2: "string"} AS literal
+    When executing query:
+      """
+      RETURN {k1: 0, k2: 'string'} AS literal
+      """
     Then the result should be:
       | literal               |
       | {k1: 0, k2: 'string'} |

--- a/tck/features/MatchAcceptance.feature
+++ b/tck/features/MatchAcceptance.feature
@@ -19,7 +19,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Path query should return results in written order
     Given an empty graph
-    And having executed: CREATE (:Label1)<-[:TYPE]-(:Label2)
+    And having executed:
+      """
+      CREATE (:Label1)<-[:TYPE]-(:Label2)
+      """
     When executing query:
       """
       MATCH (a:Label1)
@@ -32,7 +35,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Longer path query should return results in written order
     Given an empty graph
-    And having executed: CREATE (:Label1)<-[:T1]-(:Label2)-[:T2]->(:Label3)
+    And having executed:
+      """
+      CREATE (:Label1)<-[:T1]-(:Label2)-[:T2]->(:Label3)
+      """
     When executing query:
       """
       MATCH (a:Label1)
@@ -130,7 +136,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Use params in pattern matching predicates
     Given an empty graph
-    And having executed: CREATE (:A)-[:T {foo: 'bar'}]->(:B {name: 'me'})
+    And having executed:
+      """
+      CREATE (:A)-[:T {foo: 'bar'}]->(:B {name: 'me'})
+      """
     And parameters are:
       | param | 'bar' |
     When executing query:
@@ -146,7 +155,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter out based on node prop name
     Given an empty graph
-    And having executed: CREATE ({name: 'Someone'})<-[:X]-()-[:X]->({name: 'Andres'})
+    And having executed:
+      """
+      CREATE ({name: 'Someone'})<-[:X]-()-[:X]->({name: 'Andres'})
+      """
     When executing query:
       """
       MATCH ()-[rel:X]-(a)
@@ -160,7 +172,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Honour the column name for RETURN items
     Given an empty graph
-    And having executed: CREATE ({name: 'Someone'})
+    And having executed:
+      """
+      CREATE ({name: 'Someone'})
+      """
     When executing query:
       """
       MATCH (a)
@@ -174,7 +189,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter based on rel prop name
     Given an empty graph
-    And having executed: CREATE (:A)<-[:KNOWS {name: 'monkey'}]-()-[:KNOWS {name: 'woot'}]->(:B)
+    And having executed:
+      """
+      CREATE (:A)<-[:KNOWS {name: 'monkey'}]-()-[:KNOWS {name: 'woot'}]->(:B)
+      """
     When executing query:
       """
       MATCH (node)-[r:KNOWS]->(a)
@@ -207,7 +225,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get neighbours
     Given an empty graph
-    And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})
+    And having executed:
+      """
+      CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})
+      """
     When executing query:
       """
       MATCH (n1)-[rel:KNOWS]->(n2)
@@ -239,7 +260,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get related to related to
     Given an empty graph
-    And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})-[:FRIEND]->(c:C {value: 3})
+    And having executed:
+      """
+      CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})-[:FRIEND]->(c:C {value: 3})
+      """
     When executing query:
       """
       MATCH (n)-->(a)-->(b)
@@ -277,7 +301,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return two subgraphs with bound undirected relationship
     Given an empty graph
-    And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r'}]->(b:B {value: 2})
+    And having executed:
+      """
+      CREATE (a:A {value: 1})-[:REL {name: 'r'}]->(b:B {value: 2})
+      """
     When executing query:
       """
       MATCH (a)-[r {name: 'r'}]-(b)
@@ -291,13 +318,16 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return two subgraphs with bound undirected relationship and optional relationship
     Given an empty graph
-    And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r1'}]->(b:B {value: 2})-[:REL {name: 'r2'}]->(c:C {value: 3})
+    And having executed:
+      """
+      CREATE (a:A {value: 1})-[:REL {name: 'r1'}]->(b:B {value: 2})-[:REL {name: 'r2'}]->(c:C {value: 3})
+      """
     When executing query:
       """
-      MATCH (a)-[r {name:'r1'}]-(b)
+      MATCH (a)-[r {name: 'r1'}]-(b)
       OPTIONAL MATCH (b)-[r2]-(c)
-      WHERE r<>r2
-      RETURN a,b,c
+      WHERE r <> r2
+      RETURN a, b, c
       """
     Then the result should be:
       | a               | b               | c               |
@@ -317,7 +347,7 @@ Feature: MatchAcceptanceTest
       """
     When executing query:
       """
-      MATCH (n {name:'A'})-[r]->(x)
+      MATCH (n {name: 'A'})-[r]->(x)
       WHERE type(r) = 'KNOWS'
       RETURN x
       """
@@ -371,10 +401,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a simple path
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+      """
     When executing query:
       """
-      MATCH p=(a {name:'A'})-->(b)
+      MATCH p = (a {name: 'A'})-->(b)
       RETURN p
       """
     Then the result should be:
@@ -384,10 +417,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a three node path
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:KNOWS]->(c:C {name: 'C'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:KNOWS]->(c:C {name: 'C'})
+      """
     When executing query:
       """
-      MATCH p = (a {name:'A'})-[rel1]->(b)-[rel2]->(c)
+      MATCH p = (a {name: 'A'})-[rel1]->(b)-[rel2]->(c)
       RETURN p
       """
     Then the result should be:
@@ -397,7 +433,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Do not return anything because path length does not match
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+      """
     When executing query:
       """
       MATCH p = (n)-->(x)
@@ -409,7 +448,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Pass the path length test
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+      """
     When executing query:
       """
       MATCH p = (n)-->(x)
@@ -423,7 +465,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter on path nodes
     Given an empty graph
-    And having executed: CREATE (a:A {foo: 'bar'})-[:REL]->(b:B {foo: 'bar'})-[:REL]->(c:C {foo: 'bar'})-[:REL]->(d:D {foo: 'bar'})
+    And having executed:
+      """
+      CREATE (a:A {foo: 'bar'})-[:REL]->(b:B {foo: 'bar'})-[:REL]->(c:C {foo: 'bar'})-[:REL]->(d:D {foo: 'bar'})
+      """
     When executing query:
       """
       MATCH p = (pA)-[:REL*3..3]->(pB)
@@ -437,7 +482,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by fetching them from the path - starting from the end
     Given an empty graph
-    And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+    And having executed:
+      """
+      CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+      """
     When executing query:
       """
       MATCH p = (a)-[:REL*2..2]->(b:End)
@@ -450,7 +498,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by fetching them from the path
     Given an empty graph
-    And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+    And having executed:
+      """
+      CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+      """
     When executing query:
       """
       MATCH p = (a:Start)-[:REL*2..2]->(b)
@@ -463,7 +514,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list - wrong way
     Given an empty graph
-    And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+    And having executed:
+      """
+      CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+      """
     When executing query:
       """
       MATCH (a)-[r:REL*2..2]->(b:End)
@@ -476,7 +530,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list - undirected
     Given an empty graph
-    And having executed: CREATE (a:End {value: 1})-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:End {value: 2})
+    And having executed:
+      """
+      CREATE (a:End {value: 1})-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:End {value: 2})
+      """
     When executing query:
       """
       MATCH (a)-[r:REL*2..2]-(b:End)
@@ -490,7 +547,10 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list
     Given an empty graph
-    And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+    And having executed:
+      """
+      CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+      """
     When executing query:
       """
       MATCH (a:Start)-[r:REL*2..2]-(b)
@@ -503,10 +563,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a var length path
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS {value: 1}]->(b:B {name: 'B'})-[:KNOWS {value: 2}]->(c:C {name: 'C'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS {value: 1}]->(b:B {name: 'B'})-[:KNOWS {value: 2}]->(c:C {name: 'C'})
+      """
     When executing query:
       """
-      MATCH p=(n {name:'A'})-[:KNOWS*1..2]->(x)
+      MATCH p = (n {name: 'A'})-[:KNOWS*1..2]->(x)
       RETURN p
       """
     Then the result should be:
@@ -517,10 +580,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a var length path of length zero
     Given an empty graph
-    And having executed: CREATE (a:A)-[:REL]->(b:B)
+    And having executed:
+      """
+      CREATE (a:A)-[:REL]->(b:B)
+      """
     When executing query:
       """
-      MATCH p=(a)-[*0..1]->(b)
+      MATCH p = (a)-[*0..1]->(b)
       RETURN a, b, length(p) AS l
       """
     Then the result should be:
@@ -532,10 +598,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a named var length path of length zero
     Given an empty graph
-    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:FRIEND]->(c:C {name: 'C'})
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:FRIEND]->(c:C {name: 'C'})
+      """
     When executing query:
       """
-      MATCH p = (a {name:'A'})-[:KNOWS*0..1]->(b)-[:FRIEND*0..1]->(c)
+      MATCH p = (a {name: 'A'})-[:KNOWS*0..1]->(b)-[:FRIEND*0..1]->(c)
       RETURN p
       """
     Then the result should be:

--- a/tck/features/MatchAcceptance.feature
+++ b/tck/features/MatchAcceptance.feature
@@ -19,8 +19,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Path query should return results in written order
     Given an empty graph
-      And having executed: CREATE (:Label1)<-[:TYPE]-(:Label2)
-    When executing query: MATCH (a:Label1) RETURN (a)<--(:Label2) AS p
+    And having executed: CREATE (:Label1)<-[:TYPE]-(:Label2)
+    When executing query:
+      """
+      MATCH (a:Label1)
+      RETURN (a)<--(:Label2) AS p
+      """
     Then the result should be:
       | p                                |
       | [<(:Label1)<-[:TYPE]-(:Label2)>] |
@@ -28,8 +32,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Longer path query should return results in written order
     Given an empty graph
-      And having executed: CREATE (:Label1)<-[:T1]-(:Label2)-[:T2]->(:Label3)
-    When executing query: MATCH (a:Label1) RETURN (a)<--(:Label2)--() AS p
+    And having executed: CREATE (:Label1)<-[:T1]-(:Label2)-[:T2]->(:Label3)
+    When executing query:
+      """
+      MATCH (a:Label1)
+      RETURN (a)<--(:Label2)--() AS p
+      """
     Then the result should be:
       | p                                               |
       | [<(:Label1)<-[:T1]-(:Label2)-[:T2]->(:Label3)>] |
@@ -37,8 +45,18 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get node degree via length of pattern expression
     Given an empty graph
-      And having executed: CREATE (x:X), (x)-[:T]->(), (x)-[:T]->(), (x)-[:T]->()
-    When executing query: MATCH (a:X) RETURN length((a)-->()) AS length
+    And having executed:
+      """
+      CREATE (x:X),
+        (x)-[:T]->(),
+        (x)-[:T]->(),
+        (x)-[:T]->()
+      """
+    When executing query:
+      """
+      MATCH (a:X)
+      RETURN length((a)-->()) AS length
+      """
     Then the result should be:
       | length |
       | 3      |
@@ -46,8 +64,19 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get node degree via length of pattern expression that specifies a relationship type
     Given an empty graph
-      And having executed: CREATE (x:X), (x)-[:T]->(), (x)-[:T]->(), (x)-[:T]->(), (x)-[:OTHER]->()
-    When executing query: MATCH (a:X) RETURN length((a)-[:T]->()) AS length
+    And having executed:
+      """
+      CREATE (x:X),
+        (x)-[:T]->(),
+        (x)-[:T]->(),
+        (x)-[:T]->(),
+        (x)-[:OTHER]->()
+      """
+    When executing query:
+      """
+      MATCH (a:X)
+      RETURN length((a)-[:T]->()) AS length
+      """
     Then the result should be:
       | length |
       | 3      |
@@ -55,8 +84,19 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get node degree via length of pattern expression that specifies multiple relationship types
     Given an empty graph
-      And having executed: CREATE (x:X), (x)-[:T]->(), (x)-[:T]->(), (x)-[:T]->(), (x)-[:OTHER]->()
-    When executing query: MATCH (a:X) RETURN length((a)-[:T|OTHER]->()) AS length
+    And having executed:
+      """
+      CREATE (x:X),
+        (x)-[:T]->(),
+        (x)-[:T]->(),
+        (x)-[:T]->(),
+        (x)-[:OTHER]->()
+      """
+    When executing query:
+      """
+      MATCH (a:X)
+      RETURN length((a)-[:T|OTHER]->()) AS length
+      """
     Then the result should be:
       | length |
       | 4      |
@@ -64,8 +104,17 @@ Feature: MatchAcceptanceTest
 
   Scenario: Use multiple MATCH clauses to do a Cartesian product
     Given an empty graph
-      And having executed: CREATE ({value: 1}), ({value: 2}), ({value: 3})
-    When executing query: MATCH (n), (m) RETURN n.value AS n, m.value AS m
+    And having executed:
+      """
+      CREATE ({value: 1}),
+        ({value: 2}),
+        ({value: 3})
+      """
+    When executing query:
+      """
+      MATCH (n), (m)
+      RETURN n.value AS n, m.value AS m
+      """
     Then the result should be:
       | n | m |
       | 1 | 1 |
@@ -81,10 +130,15 @@ Feature: MatchAcceptanceTest
 
   Scenario: Use params in pattern matching predicates
     Given an empty graph
-      And having executed: CREATE (:A)-[:T {foo: 'bar'}]->(:B {name: 'me'})
-      And parameters are:
-        | param | 'bar' |
-    When executing query: MATCH (a)-[r]->(b) WHERE r.foo =~ {param} RETURN b
+    And having executed: CREATE (:A)-[:T {foo: 'bar'}]->(:B {name: 'me'})
+    And parameters are:
+      | param | 'bar' |
+    When executing query:
+      """
+      MATCH (a)-[r]->(b)
+      WHERE r.foo =~ {param}
+      RETURN b
+      """
     Then the result should be:
       | b                 |
       | (:B {name: 'me'}) |
@@ -92,8 +146,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter out based on node prop name
     Given an empty graph
-      And having executed: CREATE ({name: 'Someone'})<-[:X]-()-[:X]->({name: 'Andres'})
-    When executing query: MATCH ()-[rel:X]-(a) WHERE a.name = 'Andres' RETURN a
+    And having executed: CREATE ({name: 'Someone'})<-[:X]-()-[:X]->({name: 'Andres'})
+    When executing query:
+      """
+      MATCH ()-[rel:X]-(a)
+      WHERE a.name = 'Andres'
+      RETURN a
+      """
     Then the result should be:
       | a                  |
       | ({name: 'Andres'}) |
@@ -101,8 +160,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Honour the column name for RETURN items
     Given an empty graph
-      And having executed: CREATE ({name: 'Someone'})
-    When executing query: MATCH (a) WITH a.name AS a RETURN a
+    And having executed: CREATE ({name: 'Someone'})
+    When executing query:
+      """
+      MATCH (a)
+      WITH a.name AS a
+      RETURN a
+      """
     Then the result should be:
       | a         |
       | 'Someone' |
@@ -110,8 +174,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter based on rel prop name
     Given an empty graph
-      And having executed: CREATE (:A)<-[:KNOWS {name: 'monkey'}]-()-[:KNOWS {name: 'woot'}]->(:B)
-    When executing query: MATCH (node)-[r:KNOWS]->(a) WHERE r.name = 'monkey' RETURN a
+    And having executed: CREATE (:A)<-[:KNOWS {name: 'monkey'}]-()-[:KNOWS {name: 'woot'}]->(:B)
+    When executing query:
+      """
+      MATCH (node)-[r:KNOWS]->(a)
+      WHERE r.name = 'monkey'
+      RETURN a
+      """
     Then the result should be:
       | a    |
       | (:A) |
@@ -119,8 +188,17 @@ Feature: MatchAcceptanceTest
 
   Scenario: Cope with shadowed variables
     Given an empty graph
-      And having executed: CREATE ({value: 1, name: 'King Kong'}), ({value: 2, name: 'Ann Darrow'})
-    When executing query: MATCH (n) WITH n.name AS n RETURN n
+    And having executed:
+      """
+      CREATE ({value: 1, name: 'King Kong'}),
+        ({value: 2, name: 'Ann Darrow'})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      WITH n.name AS n
+      RETURN n
+      """
     Then the result should be:
       | n            |
       | 'Ann Darrow' |
@@ -129,8 +207,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get neighbours
     Given an empty graph
-      And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})
-    When executing query: MATCH (n1)-[rel:KNOWS]->(n2) RETURN n1, n2
+    And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})
+    When executing query:
+      """
+      MATCH (n1)-[rel:KNOWS]->(n2)
+      RETURN n1, n2
+      """
     Then the result should be:
       | n1              | n2              |
       | (:A {value: 1}) | (:B {value: 2}) |
@@ -138,8 +220,17 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get two related nodes
     Given an empty graph
-      And having executed: CREATE (a:A {value: 1}), (a)-[:KNOWS]->(b:B {value: 2}), (a)-[:KNOWS]->(c:C {value: 3})
-    When executing query: MATCH ()-[rel:KNOWS]->(x) RETURN x
+    And having executed:
+      """
+      CREATE (a:A {value: 1}),
+        (a)-[:KNOWS]->(b:B {value: 2}),
+        (a)-[:KNOWS]->(c:C {value: 3})
+      """
+    When executing query:
+      """
+      MATCH ()-[rel:KNOWS]->(x)
+      RETURN x
+      """
     Then the result should be:
       | x               |
       | (:B {value: 2}) |
@@ -148,8 +239,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Get related to related to
     Given an empty graph
-      And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})-[:FRIEND]->(c:C {value: 3})
-    When executing query: MATCH (n)-->(a)-->(b) RETURN b
+    And having executed: CREATE (a:A {value: 1})-[:KNOWS]->(b:B {value: 2})-[:FRIEND]->(c:C {value: 3})
+    When executing query:
+      """
+      MATCH (n)-->(a)-->(b)
+      RETURN b
+      """
     Then the result should be:
       | b               |
       | (:C {value: 3}) |
@@ -157,8 +252,23 @@ Feature: MatchAcceptanceTest
 
   Scenario: Handle comparison between node properties
     Given an empty graph
-      And having executed: CREATE (a:A {animal: 'monkey'}), (b:B {animal: 'cow'}), (c:C {animal: 'monkey'}), (d:D {animal: 'cow'}), (a)-[:KNOWS]->(b), (a)-[:KNOWS]->(c), (d)-[:KNOWS]->(b), (d)-[:KNOWS]->(c)
-    When executing query: MATCH (n)-[rel]->(x) WHERE n.animal = x.animal RETURN n, x
+    And having executed:
+      """
+      CREATE (a:A {animal: 'monkey'}),
+        (b:B {animal: 'cow'}),
+        (c:C {animal: 'monkey'}),
+        (d:D {animal: 'cow'}),
+        (a)-[:KNOWS]->(b),
+        (a)-[:KNOWS]->(c),
+        (d)-[:KNOWS]->(b),
+        (d)-[:KNOWS]->(c)
+      """
+    When executing query:
+      """
+      MATCH (n)-[rel]->(x)
+      WHERE n.animal = x.animal
+      RETURN n, x
+      """
     Then the result should be:
       | n                       | x                       |
       | (:A {animal: 'monkey'}) | (:C {animal: 'monkey'}) |
@@ -167,8 +277,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return two subgraphs with bound undirected relationship
     Given an empty graph
-      And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r'}]->(b:B {value: 2})
-    When executing query: MATCH (a)-[r {name: 'r'}]-(b) RETURN a, b
+    And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r'}]->(b:B {value: 2})
+    When executing query:
+      """
+      MATCH (a)-[r {name: 'r'}]-(b)
+      RETURN a, b
+      """
     Then the result should be:
       | a               | b               |
       | (:B {value: 2}) | (:A {value: 1}) |
@@ -177,8 +291,14 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return two subgraphs with bound undirected relationship and optional relationship
     Given an empty graph
-      And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r1'}]->(b:B {value: 2})-[:REL {name: 'r2'}]->(c:C {value: 3})
-    When executing query: MATCH (a)-[r {name:'r1'}]-(b) OPTIONAL MATCH (b)-[r2]-(c) WHERE r<>r2 RETURN a,b,c
+    And having executed: CREATE (a:A {value: 1})-[:REL {name: 'r1'}]->(b:B {value: 2})-[:REL {name: 'r2'}]->(c:C {value: 3})
+    When executing query:
+      """
+      MATCH (a)-[r {name:'r1'}]-(b)
+      OPTIONAL MATCH (b)-[r2]-(c)
+      WHERE r<>r2
+      RETURN a,b,c
+      """
     Then the result should be:
       | a               | b               | c               |
       | (:A {value: 1}) | (:B {value: 2}) | (:C {value: 3}) |
@@ -187,8 +307,20 @@ Feature: MatchAcceptanceTest
 
   Scenario: Rel type function works as expected
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'}), (b:B {name: 'B'}), (c:C {name: 'C'}), (a)-[:KNOWS]->(b), (a)-[:HATES]->(c)
-    When executing query: MATCH (n {name:'A'})-[r]->(x) WHERE type(r) = 'KNOWS' RETURN x
+    And having executed:
+      """
+      CREATE (a:A {name: 'A'}),
+        (b:B {name: 'B'}),
+        (c:C {name: 'C'}),
+        (a)-[:KNOWS]->(b),
+        (a)-[:HATES]->(c)
+      """
+    When executing query:
+      """
+      MATCH (n {name:'A'})-[r]->(x)
+      WHERE type(r) = 'KNOWS'
+      RETURN x
+      """
     Then the result should be:
       | x                |
       | (:B {name: 'B'}) |
@@ -196,8 +328,21 @@ Feature: MatchAcceptanceTest
 
   Scenario: Walk alternative relationships
     Given an empty graph
-      And having executed: CREATE (a {name: 'A'}), (b {name: 'B'}), (c {name: 'C'}), (a)-[:KNOWS]->(b), (a)-[:HATES]->(c), (a)-[:WONDERS]->(c)
-    When executing query: MATCH (n)-[r]->(x) WHERE type(r) = 'KNOWS' OR type(r) = 'HATES' RETURN r
+    And having executed:
+      """
+      CREATE (a {name: 'A'}),
+        (b {name: 'B'}),
+        (c {name: 'C'}),
+        (a)-[:KNOWS]->(b),
+        (a)-[:HATES]->(c),
+        (a)-[:WONDERS]->(c)
+      """
+    When executing query:
+      """
+      MATCH (n)-[r]->(x)
+      WHERE type(r) = 'KNOWS' OR type(r) = 'HATES'
+      RETURN r
+      """
     Then the result should be:
       | r        |
       | [:KNOWS] |
@@ -206,8 +351,18 @@ Feature: MatchAcceptanceTest
 
   Scenario: Handle OR in the WHERE clause
     Given an empty graph
-      And having executed: CREATE (a:A {p1: 12}), (b:B {p2: 13}), (c:C)
-    When executing query: MATCH (n) WHERE n.p1 = 12 OR n.p2 = 13 RETURN n
+    And having executed:
+      """
+      CREATE (a:A {p1: 12}),
+        (b:B {p2: 13}),
+        (c:C)
+      """
+    When executing query:
+      """
+      MATCH (n)
+      WHERE n.p1 = 12 OR n.p2 = 13
+      RETURN n
+      """
     Then the result should be:
       | n             |
       | (:A {p1: 12}) |
@@ -216,8 +371,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a simple path
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
-    When executing query: MATCH p=(a {name:'A'})-->(b) RETURN p
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    When executing query:
+      """
+      MATCH p=(a {name:'A'})-->(b)
+      RETURN p
+      """
     Then the result should be:
       | p                                             |
       | <(:A {name: 'A'})-[:KNOWS]->(:B {name: 'B'})> |
@@ -225,8 +384,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a three node path
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:KNOWS]->(c:C {name: 'C'})
-    When executing query: MATCH p = (a {name:'A'})-[rel1]->(b)-[rel2]->(c) RETURN p
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:KNOWS]->(c:C {name: 'C'})
+    When executing query:
+      """
+      MATCH p = (a {name:'A'})-[rel1]->(b)-[rel2]->(c)
+      RETURN p
+      """
     Then the result should be:
       | p                                                                        |
       | <(:A {name: 'A'})-[:KNOWS]->(:B {name: 'B'})-[:KNOWS]->(:C {name: 'C'})> |
@@ -234,15 +397,25 @@ Feature: MatchAcceptanceTest
 
   Scenario: Do not return anything because path length does not match
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
-    When executing query: MATCH p = (n)-->(x) WHERE length(p) = 10 RETURN x
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    When executing query:
+      """
+      MATCH p = (n)-->(x)
+      WHERE length(p) = 10
+      RETURN x
+      """
     Then the result should be empty
     And no side effects
 
   Scenario: Pass the path length test
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
-    When executing query: MATCH p = (n)-->(x) WHERE length(p)=1 RETURN x
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})
+    When executing query:
+      """
+      MATCH p = (n)-->(x)
+      WHERE length(p) = 1
+      RETURN x
+      """
     Then the result should be:
       | x                |
       | (:B {name: 'B'}) |
@@ -250,8 +423,13 @@ Feature: MatchAcceptanceTest
 
   Scenario: Filter on path nodes
     Given an empty graph
-      And having executed: CREATE (a:A {foo: 'bar'})-[:REL]->(b:B {foo: 'bar'})-[:REL]->(c:C {foo: 'bar'})-[:REL]->(d:D {foo: 'bar'})
-    When executing query: MATCH p = (pA)-[:REL*3..3]->(pB) WHERE all(i IN nodes(p) WHERE i.foo = 'bar') RETURN pB
+    And having executed: CREATE (a:A {foo: 'bar'})-[:REL]->(b:B {foo: 'bar'})-[:REL]->(c:C {foo: 'bar'})-[:REL]->(d:D {foo: 'bar'})
+    When executing query:
+      """
+      MATCH p = (pA)-[:REL*3..3]->(pB)
+      WHERE all(i IN nodes(p) WHERE i.foo = 'bar')
+      RETURN pB
+      """
     Then the result should be:
       | pB                |
       | (:D {foo: 'bar'}) |
@@ -259,8 +437,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by fetching them from the path - starting from the end
     Given an empty graph
-      And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
-    When executing query: MATCH p = (a)-[:REL*2..2]->(b:End) RETURN relationships(p)
+    And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+    When executing query:
+      """
+      MATCH p = (a)-[:REL*2..2]->(b:End)
+      RETURN relationships(p)
+      """
     Then the result should be:
       | relationships(p)                       |
       | [[:REL {value: 1}], [:REL {value: 2}]] |
@@ -268,8 +450,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by fetching them from the path
     Given an empty graph
-      And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
-    When executing query: MATCH p = (a:Start)-[:REL*2..2]->(b) RETURN relationships(p)
+    And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+    When executing query:
+      """
+      MATCH p = (a:Start)-[:REL*2..2]->(b)
+      RETURN relationships(p)
+      """
     Then the result should be:
       | relationships(p)                       |
       | [[:REL {value: 1}], [:REL {value: 2}]] |
@@ -277,8 +463,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list - wrong way
     Given an empty graph
-      And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
-    When executing query: MATCH (a)-[r:REL*2..2]->(b:End) RETURN r
+    And having executed: CREATE (a:A)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(e:End)
+    When executing query:
+      """
+      MATCH (a)-[r:REL*2..2]->(b:End)
+      RETURN r
+      """
     Then the result should be:
       | r                                      |
       | [[:REL {value: 1}], [:REL {value: 2}]] |
@@ -286,8 +476,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list - undirected
     Given an empty graph
-      And having executed: CREATE (a:End {value: 1})-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:End {value: 2})
-    When executing query: MATCH (a)-[r:REL*2..2]-(b:End) RETURN r
+    And having executed: CREATE (a:End {value: 1})-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:End {value: 2})
+    When executing query:
+      """
+      MATCH (a)-[r:REL*2..2]-(b:End)
+      RETURN r
+      """
     Then the result should be:
       | r                                    |
       | [[:REL {value:1}], [:REL {value:2}]] |
@@ -296,8 +490,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return relationships by collecting them as a list
     Given an empty graph
-      And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
-    When executing query: MATCH (a:Start)-[r:REL*2..2]-(b) RETURN r
+    And having executed: CREATE (s:Start)-[:REL {value: 1}]->(b:B)-[:REL {value: 2}]->(c:C)
+    When executing query:
+      """
+      MATCH (a:Start)-[r:REL*2..2]-(b)
+      RETURN r
+      """
     Then the result should be:
       | r                                      |
       | [[:REL {value: 1}], [:REL {value: 2}]] |
@@ -305,8 +503,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a var length path
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS {value: 1}]->(b:B {name: 'B'})-[:KNOWS {value: 2}]->(c:C {name: 'C'})
-    When executing query: MATCH p=(n {name:'A'})-[:KNOWS*1..2]->(x) RETURN p
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS {value: 1}]->(b:B {name: 'B'})-[:KNOWS {value: 2}]->(c:C {name: 'C'})
+    When executing query:
+      """
+      MATCH p=(n {name:'A'})-[:KNOWS*1..2]->(x)
+      RETURN p
+      """
     Then the result should be:
       | p                                                                                              |
       | <(:A {name: 'A'})-[:KNOWS {value: 1}]->(:B {name: 'B'})>                                       |
@@ -315,8 +517,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a var length path of length zero
     Given an empty graph
-      And having executed: CREATE (a:A)-[:REL]->(b:B)
-    When executing query: MATCH p=(a)-[*0..1]->(b) RETURN a,b, length(p) AS l
+    And having executed: CREATE (a:A)-[:REL]->(b:B)
+    When executing query:
+      """
+      MATCH p=(a)-[*0..1]->(b)
+      RETURN a, b, length(p) AS l
+      """
     Then the result should be:
       | a    | b    | l |
       | (:A) | (:A) | 0 |
@@ -326,8 +532,12 @@ Feature: MatchAcceptanceTest
 
   Scenario: Return a named var length path of length zero
     Given an empty graph
-      And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:FRIEND]->(c:C {name: 'C'})
-    When executing query: MATCH p=(a {name:'A'})-[:KNOWS*0..1]->(b)-[:FRIEND*0..1]->(c) RETURN p
+    And having executed: CREATE (a:A {name: 'A'})-[:KNOWS]->(b:B {name: 'B'})-[:FRIEND]->(c:C {name: 'C'})
+    When executing query:
+      """
+      MATCH p = (a {name:'A'})-[:KNOWS*0..1]->(b)-[:FRIEND*0..1]->(c)
+      RETURN p
+      """
     Then the result should be:
       | p                                                                         |
       | <(:A {name: 'A'})>                                                        |
@@ -337,6 +547,11 @@ Feature: MatchAcceptanceTest
 
   Scenario: Accept skip zero
     Given any graph
-    When executing query: MATCH (n) WHERE 1 = 0 RETURN n SKIP 0
+    When executing query:
+      """
+      MATCH (n)
+      WHERE 1 = 0
+      RETURN n SKIP 0
+      """
     Then the result should be empty
     And no side effects

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -77,7 +77,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label when it exists
     Given an empty graph
-    And having executed: CREATE (:Label)
+    And having executed:
+      """
+      CREATE (:Label)
+      """
     When executing query:
       """
       MERGE (a:Label)
@@ -90,7 +93,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node should create when it doesn't match, properties
     Given an empty graph
-    And having executed: CREATE ({prop: 42})
+    And having executed:
+      """
+      CREATE ({prop: 42})
+      """
     When executing query:
       """
       MERGE (a {prop: 43})
@@ -105,7 +111,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node should create when it doesn't match, properties and label
     Given an empty graph
-    And having executed: CREATE (:Label {prop: 42})
+    And having executed:
+      """
+      CREATE (:Label {prop: 42})
+      """
     When executing query:
       """
       MERGE (a:Label {prop: 43})
@@ -121,7 +130,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with prop and label
     Given an empty graph
-    And having executed: CREATE (:Label {prop: 42})
+    And having executed:
+      """
+      CREATE (:Label {prop: 42})
+      """
     When executing query:
       """
       MERGE (a:Label {prop: 42})
@@ -134,8 +146,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with prop and label and unique index
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
-    And having executed: CREATE (:Label {prop: 42})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Label {prop: 42})
+      """
     When executing query:
       """
       MERGE (a:Label {prop: 42})
@@ -148,8 +166,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with prop and label and unique index when no match
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
-    And having executed: CREATE (:Label {prop: 42})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Label {prop: 42})
+      """
     When executing query:
       """
       MERGE (a:Label {prop: 11})
@@ -165,7 +189,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label add label on match when it exists
     Given an empty graph
-    And having executed: CREATE (:Label)
+    And having executed:
+      """
+      CREATE (:Label)
+      """
     When executing query:
       """
       MERGE (a:Label)
@@ -180,7 +207,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label add property on update when it exists
     Given an empty graph
-    And having executed: CREATE (:Label)
+    And having executed:
+      """
+      CREATE (:Label)
+      """
     When executing query:
       """
       MERGE (a:Label)
@@ -194,7 +224,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node and set property on match
     Given an empty graph
-    And having executed: CREATE (:Label)
+    And having executed:
+      """
+      CREATE (:Label)
+      """
     When executing query:
       """
       MERGE (a:Label)
@@ -209,8 +242,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge using unique constraint should update existing node
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE (:Person {id: 23, country: 'Sweden'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23, country: 'Sweden'})
+      """
     When executing query:
       """
       MERGE (a:Person {id: 23, country: 'Sweden'})
@@ -225,7 +264,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge using unique constraint should create missing node
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
     When executing query:
       """
       MERGE (a:Person {id: 23, country: 'Sweden'})
@@ -242,9 +284,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should match on merge using multiple unique indexes if only found single node for both indexes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
-    And having executed: CREATE (:Person {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23, email: 'smth@neo.com'})
+      """
     When executing query:
       """
       MERGE (a:Person {id: 23, email: 'smth@neo.com'})
@@ -259,9 +310,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should match on merge using multiple unique indexes and labels if only found single node for both indexes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
-    And having executed: CREATE (:Person:User {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person:User {id: 23, email: 'smth@neo.com'})
+      """
     When executing query:
       """
       MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
@@ -276,9 +336,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should match on merge using multiple unique indexes using same key if only found single node for both indexes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
-    And having executed: CREATE (:Person:User {id: 23})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person:User {id: 23})
+      """
     When executing query:
       """
       MERGE (a:Person:User {id: 23})
@@ -293,8 +362,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should create on merge using multiple unique indexes if found no nodes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+      """
     When executing query:
       """
       MERGE (a:Person {id: 23, email: 'smth@neo.com'})
@@ -311,8 +386,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should create on merge using multiple unique indexes and labels if found no nodes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
+      """
     When executing query:
       """
       MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
@@ -329,54 +410,126 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should fail on merge using multiple unique indexes using same key if found different nodes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.id IS UNIQUE
-    And having executed: CREATE (:Person {id: 23}), (:User {id: 23})
-    When executing query: MERGE (a:Person:User {id: 23})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (u:User) ASSERT u.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23}), (:User {id: 23})
+      """
+    When executing query:
+      """
+      MERGE (a:Person:User {id: 23})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Should fail on merge using multiple unique indexes if found different nodes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
-    And having executed: CREATE (:Person {id: 23}), (:Person {email: 'smth@neo.com'})
-    When executing query: MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23}), (:Person {email: 'smth@neo.com'})
+      """
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Should fail on merge using multiple unique indexes if it found a node matching single property only
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
-    And having executed: CREATE (:Person {id: 23})
-    When executing query: MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23})
+      """
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Should fail on merge using multiple unique indexes if it found a node matching single property only flipped order
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
-    And having executed: CREATE (:Person {email: 'smth@neo.com'})
-    When executing query: MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {email: 'smth@neo.com'})
+      """
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Should fail on merge using multiple unique indexes and labels if found different nodes
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
-    And having executed: CREATE (:Person {id: 23}), (:User {email: 'smth@neo.com'})
-    When executing query: MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:Person {id: 23}), (:User {email: 'smth@neo.com'})
+      """
+    When executing query:
+      """
+      MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Merge with uniqueness constraints must properly handle multiple labels
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (l:L) ASSERT l.prop IS UNIQUE
-    And having executed: CREATE (:L {prop: 42})
-    When executing query: MERGE (:L:B {prop : 42})
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (l:L) ASSERT l.prop IS UNIQUE
+      """
+    And having executed:
+      """
+      CREATE (:L {prop: 42})
+      """
+    When executing query:
+      """
+      MERGE (:L:B {prop: 42})
+      """
     Then a ConstraintValidationFailed should be raised at runtime: CreateBlockedByConstraint
 
   Scenario: Should handle running merge inside a foreach loop
     Given an empty graph
-    When executing query: FOREACH(x IN [1,2,3] | MERGE ({property: x}))
+    When executing query:
+      """
+      FOREACH(x IN [1, 2, 3] | MERGE ({property: x}))
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 3 |
@@ -384,7 +537,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Unrelated nodes with same property should not clash
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
     And having executed:
       """
       CREATE (a:Item {id: 1}),
@@ -400,7 +556,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works fine with index
     Given an empty graph
-    And having executed: CREATE INDEX ON :Person(name)
+    And having executed:
+      """
+      CREATE INDEX ON :Person(name)
+      """
     When executing query:
       """
       MERGE (person:Person {name: 'Lasse'})
@@ -416,9 +575,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works fine with index and constraint
     Given an empty graph
-    And having executed: CREATE INDEX ON :Person(name)
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    When executing query: MERGE (person:Person {name: 'Lasse', id: 42})
+    And having executed:
+      """
+      CREATE INDEX ON :Person(name)
+      """
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
+      """
+    When executing query:
+      """
+      MERGE (person:Person {name: 'Lasse', id: 42})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 1 |
@@ -427,8 +595,14 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works with indexed and unindexed property
     Given an empty graph
-    And having executed: CREATE INDEX ON :Person(name)
-    When executing query: MERGE (person:Person {name: 'Lasse', id: 42})
+    And having executed:
+      """
+      CREATE INDEX ON :Person(name)
+      """
+    When executing query:
+      """
+      MERGE (person:Person {name: 'Lasse', id: 42})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 1 |
@@ -437,9 +611,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works with two indexed properties
     Given an empty graph
-    And having executed: CREATE INDEX ON :Person(name)
-    And having executed: CREATE INDEX ON :Person(id)
-    When executing query: MERGE (person:Person {name: 'Lasse', id: 42})
+    And having executed:
+      """
+      CREATE INDEX ON :Person(name)
+      """
+    And having executed:
+      """
+      CREATE INDEX ON :Person(id)
+      """
+    When executing query:
+      """
+      MERGE (person:Person {name: 'Lasse', id: 42})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 1 |
@@ -448,7 +631,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works with property repeated in literal map in set
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
+      """
     When executing query:
       """
       MERGE (person:Person {ssn: 42})
@@ -465,7 +651,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Works with property in map that gets set
     Given an empty graph
-    And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
+    And having executed:
+      """
+      CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
+      """
     And parameters are:
       | p | {ssn: 42, name: 'Robert Paulsen'} |
     When executing query:
@@ -539,7 +728,7 @@ Feature: MergeNodeAcceptance
     When executing query:
       """
       MATCH (person:Person)
-      MERGE (city: City {name: person.bornIn})
+      MERGE (city:City {name: person.bornIn})
       """
     Then the result should be empty
     And the side effects should be:
@@ -549,7 +738,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to merge using property from match with index
     Given an empty graph
-    And having executed: CREATE INDEX ON :City(name)
+    And having executed:
+      """
+      CREATE INDEX ON :City(name)
+      """
     And having executed:
       """
       CREATE (:Person {name: 'A', bornIn: 'New York'})
@@ -562,7 +754,7 @@ Feature: MergeNodeAcceptance
     When executing query:
       """
       MATCH (person:Person)
-      MERGE (city: City {name: person.bornIn})
+      MERGE (city:City {name: person.bornIn})
       """
     Then the result should be empty
     And the side effects should be:
@@ -580,7 +772,7 @@ Feature: MergeNodeAcceptance
     When executing query:
       """
       MATCH (person:Person)
-      MERGE (city: City)
+      MERGE (city:City)
         ON CREATE SET city.name = person.bornIn
       RETURN person.bornIn
       """
@@ -603,7 +795,7 @@ Feature: MergeNodeAcceptance
     When executing query:
       """
       MATCH (person:Person)
-      MERGE (city: City)
+      MERGE (city:City)
         ON MATCH SET city.name = person.bornIn
       RETURN person.bornIn
       """
@@ -626,7 +818,7 @@ Feature: MergeNodeAcceptance
     When executing query:
         """
         MATCH (person:Person)
-        MERGE (city: City)
+        MERGE (city:City)
           ON MATCH SET city.name = person.bornIn
           ON CREATE SET city.name = person.bornIn
         RETURN person.bornIn
@@ -642,7 +834,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to set labels on match
     Given an empty graph
-    And having executed: CREATE ()
+    And having executed:
+      """
+      CREATE ()
+      """
     When executing query:
       """
       MERGE (a)
@@ -654,7 +849,10 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to set labels on match and on create
     Given an empty graph
-    And having executed: CREATE (), ()
+    And having executed:
+      """
+      CREATE (), ()
+      """
     When executing query:
       """
       MATCH ()
@@ -705,7 +903,7 @@ Feature: MergeNodeAcceptance
     When executing query:
       """
       CREATE (a {name: 'Start'})
-      FOREACH(x IN [1,2,3] | MERGE (a)-[:X]->({id: x}))
+      FOREACH(x IN [1, 2, 3] | MERGE (a)-[:X]->({id: x}))
       RETURN a.name
       """
     Then the result should be:
@@ -718,10 +916,13 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge must properly handle multiple labels
     Given an empty graph
-    And having executed: CREATE (:L:A {prop: 42})
+    And having executed:
+      """
+      CREATE (:L:A {prop: 42})
+      """
     When executing query:
       """
-      MERGE (test:L:B {prop : 42})
+      MERGE (test:L:B {prop: 42})
       RETURN labels(test) AS labels
       """
     Then the result should be:
@@ -734,11 +935,17 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge with an index must properly handle multiple labels
     Given an empty graph
-    And having executed: CREATE INDEX ON :L(prop)
-    And having executed: CREATE (:L:A {prop: 42})
+    And having executed:
+      """
+      CREATE INDEX ON :L(prop)
+      """
+    And having executed:
+      """
+      CREATE (:L:A {prop: 42})
+      """
     When executing query:
       """
-      MERGE (test:L:B {prop : 42})
+      MERGE (test:L:B {prop: 42})
       RETURN labels(test) AS labels
       """
     Then the result should be:
@@ -768,7 +975,7 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     When executing query:
       """
-      UNWIND [1,2,3,4] AS int
+      UNWIND [1, 2, 3, 4] AS int
       MERGE (n {id: int})
       RETURN count(*)
       """

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -19,7 +19,11 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node when no nodes exist
     Given an empty graph
-    When executing query: MERGE (a) RETURN count(*) AS n
+    When executing query:
+      """
+      MERGE (a)
+      RETURN count(*) AS n
+      """
     Then the result should be:
       | n |
       | 1 |
@@ -28,7 +32,11 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label
     Given an empty graph
-    When executing query: MERGE (a:Label) RETURN labels(a)
+    When executing query:
+      """
+      MERGE (a:Label)
+      RETURN labels(a)
+      """
     Then the result should be:
       | labels(a) |
       | ['Label'] |
@@ -38,7 +46,12 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label add label on create
     Given an empty graph
-    When executing query: MERGE (a:Label) ON CREATE SET a:Foo RETURN labels(a)
+    When executing query:
+      """
+      MERGE (a:Label)
+        ON CREATE SET a:Foo
+      RETURN labels(a)
+      """
     Then the result should be:
       | labels(a)        |
       | ['Label', 'Foo'] |
@@ -48,7 +61,12 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge node with label add property on create
     Given an empty graph
-    When executing query: MERGE (a:Label) ON CREATE SET a.prop = 42 RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label)
+        ON CREATE SET a.prop = 42
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 42     |
@@ -60,7 +78,11 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node with label when it exists
     Given an empty graph
     And having executed: CREATE (:Label)
-    When executing query: MERGE (a:Label) RETURN id(a)
+    When executing query:
+      """
+      MERGE (a:Label)
+      RETURN id(a)
+      """
     Then the result should be:
       | id(a) |
       | 0     |
@@ -69,7 +91,11 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node should create when it doesn't match, properties
     Given an empty graph
     And having executed: CREATE ({prop: 42})
-    When executing query: MERGE (a {prop: 43}) RETURN a.prop
+    When executing query:
+      """
+      MERGE (a {prop: 43})
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 43     |
@@ -80,7 +106,11 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node should create when it doesn't match, properties and label
     Given an empty graph
     And having executed: CREATE (:Label {prop: 42})
-    When executing query: MERGE (a:Label {prop: 43}) RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label {prop: 43})
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 43     |
@@ -92,7 +122,11 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node with prop and label
     Given an empty graph
     And having executed: CREATE (:Label {prop: 42})
-    When executing query: MERGE (a:Label {prop: 42}) RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label {prop: 42})
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 42     |
@@ -102,7 +136,11 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
     And having executed: CREATE (:Label {prop: 42})
-    When executing query: MERGE (a:Label {prop: 42}) RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label {prop: 42})
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 42     |
@@ -112,7 +150,11 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (n:Label) ASSERT n.prop IS UNIQUE
     And having executed: CREATE (:Label {prop: 42})
-    When executing query: MERGE (a:Label {prop: 11}) RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label {prop: 11})
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 11     |
@@ -124,7 +166,12 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node with label add label on match when it exists
     Given an empty graph
     And having executed: CREATE (:Label)
-    When executing query: MERGE (a:Label) ON MATCH SET a:Foo RETURN labels(a)
+    When executing query:
+      """
+      MERGE (a:Label)
+        ON MATCH SET a:Foo
+      RETURN labels(a)
+      """
     Then the result should be:
       | labels(a)        |
       | ['Label', 'Foo'] |
@@ -134,7 +181,12 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node with label add property on update when it exists
     Given an empty graph
     And having executed: CREATE (:Label)
-    When executing query: MERGE (a:Label) ON CREATE SET a.prop = 42 RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label)
+        ON CREATE SET a.prop = 42
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | null   |
@@ -143,7 +195,12 @@ Feature: MergeNodeAcceptance
   Scenario: Merge node and set property on match
     Given an empty graph
     And having executed: CREATE (:Label)
-    When executing query: MERGE (a:Label) ON MATCH SET a.prop = 42 RETURN a.prop
+    When executing query:
+      """
+      MERGE (a:Label)
+        ON MATCH SET a.prop = 42
+      RETURN a.prop
+      """
     Then the result should be:
       | a.prop |
       | 42     |
@@ -154,7 +211,12 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE (:Person {id: 23, country: 'Sweden'})
-    When executing query: MERGE (a:Person {id: 23, country: 'Sweden'}) ON MATCH SET a.name = 'Emil' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, country: 'Sweden'})
+        ON MATCH SET a.name = 'Emil'
+      RETURN a
+      """
     Then the result should be:
       | a                                                   |
       | (:Person {id: 23, country: 'Sweden', name: 'Emil'}) |
@@ -164,7 +226,12 @@ Feature: MergeNodeAcceptance
   Scenario: Merge using unique constraint should create missing node
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    When executing query: MERGE (a:Person {id: 23, country: 'Sweden'}) ON CREATE SET a.name = 'Emil' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, country: 'Sweden'})
+        ON CREATE SET a.name = 'Emil'
+      RETURN a
+      """
     Then the result should be:
       | a                                                   |
       | (:Person {id: 23, country: 'Sweden', name: 'Emil'}) |
@@ -178,7 +245,12 @@ Feature: MergeNodeAcceptance
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
     And having executed: CREATE (:Person {id: 23, email: 'smth@neo.com'})
-    When executing query: MERGE (a:Person {id: 23, email: 'smth@neo.com'}) ON MATCH SET a.country = 'Sweden' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+        ON MATCH SET a.country = 'Sweden'
+      RETURN a
+      """
     Then the result should be:
       | a                                                            |
       | (:Person {id: 23, country: 'Sweden', email: 'smth@neo.com'}) |
@@ -190,7 +262,12 @@ Feature: MergeNodeAcceptance
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
     And having executed: CREATE (:Person:User {id: 23, email: 'smth@neo.com'})
-    When executing query: MERGE (a:Person:User {id: 23, email: 'smth@neo.com'}) ON MATCH SET a.country = 'Sweden' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
+        ON MATCH SET a.country = 'Sweden'
+      RETURN a
+      """
     Then the result should be:
       | a                                                                 |
       | (:Person:User {id: 23, country: 'Sweden', email: 'smth@neo.com'}) |
@@ -202,7 +279,12 @@ Feature: MergeNodeAcceptance
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
     And having executed: CREATE (:Person:User {id: 23})
-    When executing query: MERGE (a:Person:User {id: 23}) ON MATCH SET a.country = 'Sweden' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person:User {id: 23})
+        ON MATCH SET a.country = 'Sweden'
+      RETURN a
+      """
     Then the result should be:
       | a                                          |
       | (:Person:User {id: 23, country: 'Sweden'}) |
@@ -213,7 +295,12 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.email IS UNIQUE
-    When executing query: MERGE (a:Person {id: 23, email: 'smth@neo.com'}) ON CREATE SET a.country = 'Sweden' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person {id: 23, email: 'smth@neo.com'})
+        ON CREATE SET a.country = 'Sweden'
+      RETURN a
+      """
     Then the result should be:
       | a                                                            |
       | (:Person {id: 23, email: 'smth@neo.com', country: 'Sweden'}) |
@@ -226,7 +313,12 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
     And having executed: CREATE CONSTRAINT ON (u:User) ASSERT u.email IS UNIQUE
-    When executing query: MERGE (a:Person:User {id: 23, email: 'smth@neo.com'}) ON CREATE SET a.country = 'Sweden' RETURN a
+    When executing query:
+      """
+      MERGE (a:Person:User {id: 23, email: 'smth@neo.com'})
+        ON CREATE SET a.country = 'Sweden'
+      RETURN a
+      """
     Then the result should be:
       | a                                                                 |
       | (:Person:User {id: 23, email: 'smth@neo.com', country: 'Sweden'}) |
@@ -293,15 +385,27 @@ Feature: MergeNodeAcceptance
   Scenario: Unrelated nodes with same property should not clash
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.id IS UNIQUE
-    And having executed: CREATE (a:Item {id: 1}), (b:Person {id: 1})
-    When executing query: MERGE (a:Item {id: 1}) MERGE (b:Person {id: 1})
+    And having executed:
+      """
+      CREATE (a:Item {id: 1}),
+        (b:Person {id: 1})
+      """
+    When executing query:
+      """
+      MERGE (a:Item {id: 1})
+      MERGE (b:Person {id: 1})
+      """
     Then the result should be empty
     And no side effects
 
   Scenario: Works fine with index
     Given an empty graph
     And having executed: CREATE INDEX ON :Person(name)
-    When executing query: MERGE (person:Person {name: 'Lasse'}) RETURN person.name
+    When executing query:
+      """
+      MERGE (person:Person {name: 'Lasse'})
+      RETURN person.name
+      """
     Then the result should be:
       | person.name |
       | 'Lasse'     |
@@ -345,7 +449,12 @@ Feature: MergeNodeAcceptance
   Scenario: Works with property repeated in literal map in set
     Given an empty graph
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
-    When executing query: MERGE (person:Person {ssn: 42}) ON CREATE SET person = {ssn: 42, name: 'Robert Paulsen'} RETURN person.ssn
+    When executing query:
+      """
+      MERGE (person:Person {ssn: 42})
+        ON CREATE SET person = {ssn: 42, name: 'Robert Paulsen'}
+      RETURN person.ssn
+      """
     Then the result should be:
       | person.ssn |
       | 42         |
@@ -359,7 +468,12 @@ Feature: MergeNodeAcceptance
     And having executed: CREATE CONSTRAINT ON (p:Person) ASSERT p.ssn IS UNIQUE
     And parameters are:
       | p | {ssn: 42, name: 'Robert Paulsen'} |
-    When executing query: MERGE (person:Person {ssn: {p}.ssn}) ON CREATE SET person = {p} RETURN person.ssn
+    When executing query:
+      """
+      MERGE (person:Person {ssn: {p}.ssn})
+        ON CREATE SET person = {p}
+      RETURN person.ssn
+      """
     Then the result should be:
       | person.ssn |
       | 42         |
@@ -370,7 +484,12 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should work when finding multiple elements
     Given an empty graph
-    When executing query: CREATE (:X) CREATE (:X) MERGE (:X)
+    When executing query:
+      """
+      CREATE (:X)
+      CREATE (:X)
+      MERGE (:X)
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes  | 2 |
@@ -378,8 +497,16 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should handle argument properly
     Given an empty graph
-    And having executed: CREATE ({x: 42}), ({x: 'not42'})
-    When executing query: WITH 42 AS x MERGE (c:N {x: x})
+    And having executed:
+      """
+      CREATE ({x: 42}),
+        ({x: 'not42'})
+      """
+    When executing query:
+      """
+      WITH 42 AS x
+      MERGE (c:N {x: x})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 1 |
@@ -388,7 +515,11 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should handle arguments properly with only write clauses
     Given an empty graph
-    When executing query: CREATE (a {p: 1}) MERGE ({v: a.p})
+    When executing query:
+      """
+      CREATE (a {p: 1})
+      MERGE ({v: a.p})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 2 |
@@ -397,15 +528,19 @@ Feature: MergeNodeAcceptance
   Scenario: Should be able to merge using property from match
     Given an empty graph
     And having executed:
-          """
-          CREATE (:Person {name: 'A', bornIn: 'New York'})
-          CREATE (:Person {name: 'B', bornIn: 'Ohio'})
-          CREATE (:Person {name: 'C', bornIn: 'New Jersey'})
-          CREATE (:Person {name: 'D', bornIn: 'New York'})
-          CREATE (:Person {name: 'E', bornIn: 'Ohio'})
-          CREATE (:Person {name: 'F', bornIn: 'New Jersey'})
-          """
-    When executing query: MATCH (person:Person) MERGE (city: City {name: person.bornIn})
+      """
+      CREATE (:Person {name: 'A', bornIn: 'New York'})
+      CREATE (:Person {name: 'B', bornIn: 'Ohio'})
+      CREATE (:Person {name: 'C', bornIn: 'New Jersey'})
+      CREATE (:Person {name: 'D', bornIn: 'New York'})
+      CREATE (:Person {name: 'E', bornIn: 'Ohio'})
+      CREATE (:Person {name: 'F', bornIn: 'New Jersey'})
+      """
+    When executing query:
+      """
+      MATCH (person:Person)
+      MERGE (city: City {name: person.bornIn})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 3 |
@@ -416,15 +551,19 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE INDEX ON :City(name)
     And having executed:
-          """
-          CREATE (:Person {name: 'A', bornIn: 'New York'})
-          CREATE (:Person {name: 'B', bornIn: 'Ohio'})
-          CREATE (:Person {name: 'C', bornIn: 'New Jersey'})
-          CREATE (:Person {name: 'D', bornIn: 'New York'})
-          CREATE (:Person {name: 'E', bornIn: 'Ohio'})
-          CREATE (:Person {name: 'F', bornIn: 'New Jersey'})
-          """
-    When executing query: MATCH (person:Person) MERGE (city: City {name: person.bornIn})
+      """
+      CREATE (:Person {name: 'A', bornIn: 'New York'})
+      CREATE (:Person {name: 'B', bornIn: 'Ohio'})
+      CREATE (:Person {name: 'C', bornIn: 'New Jersey'})
+      CREATE (:Person {name: 'D', bornIn: 'New York'})
+      CREATE (:Person {name: 'E', bornIn: 'Ohio'})
+      CREATE (:Person {name: 'F', bornIn: 'New Jersey'})
+      """
+    When executing query:
+      """
+      MATCH (person:Person)
+      MERGE (city: City {name: person.bornIn})
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 3 |
@@ -433,8 +572,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to use properties from match in ON CREATE
     Given an empty graph
-    And having executed: CREATE (:Person {bornIn: 'New York'}), (:Person {bornIn: 'Ohio'})
-    When executing query: MATCH (person:Person) MERGE (city: City) ON CREATE SET city.name = person.bornIn RETURN person.bornIn
+    And having executed:
+      """
+      CREATE (:Person {bornIn: 'New York'}),
+        (:Person {bornIn: 'Ohio'})
+      """
+    When executing query:
+      """
+      MATCH (person:Person)
+      MERGE (city: City)
+        ON CREATE SET city.name = person.bornIn
+      RETURN person.bornIn
+      """
     Then the result should be:
       | person.bornIn |
       | 'New York'    |
@@ -446,8 +595,18 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to use properties from match in ON MATCH
     Given an empty graph
-    And having executed: CREATE (:Person {bornIn: 'New York'}), (:Person {bornIn: 'Ohio'})
-    When executing query: MATCH (person:Person) MERGE (city: City) ON MATCH SET city.name = person.bornIn RETURN person.bornIn
+    And having executed:
+      """
+      CREATE (:Person {bornIn: 'New York'}),
+        (:Person {bornIn: 'Ohio'})
+      """
+    When executing query:
+      """
+      MATCH (person:Person)
+      MERGE (city: City)
+        ON MATCH SET city.name = person.bornIn
+      RETURN person.bornIn
+      """
     Then the result should be:
       | person.bornIn |
       | 'New York'    |
@@ -459,7 +618,11 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should be able to use properties from match in ON MATCH and ON CREATE
     Given an empty graph
-    And having executed: CREATE (:Person {bornIn: 'New York'}), (:Person {bornIn: 'Ohio'})
+    And having executed:
+      """
+      CREATE (:Person {bornIn: 'New York'}),
+        (:Person {bornIn: 'Ohio'})
+      """
     When executing query:
         """
         MATCH (person:Person)
@@ -480,7 +643,11 @@ Feature: MergeNodeAcceptance
   Scenario: Should be able to set labels on match
     Given an empty graph
     And having executed: CREATE ()
-    When executing query: MERGE (a) ON MATCH SET a:L
+    When executing query:
+      """
+      MERGE (a)
+        ON MATCH SET a:L
+      """
     Then the result should be empty
     And the side effects should be:
       | +labels | 1 |
@@ -488,7 +655,13 @@ Feature: MergeNodeAcceptance
   Scenario: Should be able to set labels on match and on create
     Given an empty graph
     And having executed: CREATE (), ()
-    When executing query: MATCH () MERGE (a:L) ON MATCH SET a:M1 ON CREATE SET a:M2
+    When executing query:
+      """
+      MATCH ()
+      MERGE (a:L)
+        ON MATCH SET a:M1
+        ON CREATE SET a:M2
+      """
     Then the result should be empty
     And the side effects should be:
       | +nodes  | 1 |
@@ -496,7 +669,12 @@ Feature: MergeNodeAcceptance
 
   Scenario: Should support updates while merging
     Given an empty graph
-    And having executed: UNWIND [0, 1, 2] AS x UNWIND [0, 1, 2] AS y CREATE ({x: x, y: y})
+    And having executed:
+      """
+      UNWIND [0, 1, 2] AS x
+      UNWIND [0, 1, 2] AS y
+      CREATE ({x: x, y: y})
+      """
     When executing query:
       """
       MATCH (foo)
@@ -524,7 +702,12 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merge inside foreach should see variables introduced by update actions outside foreach
     Given an empty graph
-    When executing query: CREATE (a {name: 'Start'}) FOREACH(x IN [1,2,3] | MERGE (a)-[:X]->({id: x})) RETURN a.name
+    When executing query:
+      """
+      CREATE (a {name: 'Start'})
+      FOREACH(x IN [1,2,3] | MERGE (a)-[:X]->({id: x}))
+      RETURN a.name
+      """
     Then the result should be:
       | a.name  |
       | 'Start' |
@@ -536,7 +719,11 @@ Feature: MergeNodeAcceptance
   Scenario: Merge must properly handle multiple labels
     Given an empty graph
     And having executed: CREATE (:L:A {prop: 42})
-    When executing query: MERGE (test:L:B {prop : 42}) RETURN labels(test) AS labels
+    When executing query:
+      """
+      MERGE (test:L:B {prop : 42})
+      RETURN labels(test) AS labels
+      """
     Then the result should be:
       | labels     |
       | ['L', 'B'] |
@@ -549,7 +736,11 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     And having executed: CREATE INDEX ON :L(prop)
     And having executed: CREATE (:L:A {prop: 42})
-    When executing query: MERGE (test:L:B {prop : 42}) RETURN labels(test) AS labels
+    When executing query:
+      """
+      MERGE (test:L:B {prop : 42})
+      RETURN labels(test) AS labels
+      """
     Then the result should be:
       | labels     |
       | ['L', 'B'] |
@@ -590,7 +781,11 @@ Feature: MergeNodeAcceptance
 
   Scenario: Merges should not be able to match on deleted nodes
     Given an empty graph
-    And having executed: CREATE (:A {value: 1}), (:A {value: 2})
+    And having executed:
+      """
+      CREATE (:A {value: 1}),
+        (:A {value: 2})
+      """
     When executing query:
       """
       MATCH (a:A)

--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -180,7 +180,7 @@ Feature: OrderByAcceptance
   Scenario: ORDER BY should order ints in the expected order
     When executing query:
       """
-      UNWIND [1,3,2] AS ints
+      UNWIND [1, 3, 2] AS ints
       RETURN ints
       ORDER BY ints
       """
@@ -194,7 +194,7 @@ Feature: OrderByAcceptance
   Scenario: ORDER BY DESC should order ints in the expected order
     When executing query:
       """
-      UNWIND [1,3,2] AS ints
+      UNWIND [1, 3, 2] AS ints
       RETURN ints
       ORDER BY ints DESC
       """
@@ -208,7 +208,7 @@ Feature: OrderByAcceptance
   Scenario: ORDER BY should order floats in the expected order
     When executing query:
       """
-      UNWIND [1.5,1.3,999.99] AS floats
+      UNWIND [1.5, 1.3, 999.99] AS floats
       RETURN floats
       ORDER BY floats
       """
@@ -222,7 +222,7 @@ Feature: OrderByAcceptance
   Scenario: ORDER BY DESC should order floats in the expected order
     When executing query:
       """
-      UNWIND [1.5,1.3,999.99] AS floats
+      UNWIND [1.5, 1.3, 999.99] AS floats
       RETURN floats
       ORDER BY floats DESC
       """

--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -21,8 +21,18 @@ Feature: OrderByAcceptance
     Given any graph
 
   Scenario: ORDER BY should return results in ascending order
-    And having executed: CREATE (n1 {prop: 1}), (n2 {prop: 3}), (n3 {prop: -5})
-    When executing query: MATCH (n) RETURN n.prop AS prop ORDER BY n.prop
+    And having executed:
+      """
+      CREATE (n1 {prop: 1}),
+        (n2 {prop: 3}),
+        (n3 {prop: -5})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n.prop AS prop
+      ORDER BY n.prop
+      """
     Then the result should be, in order:
       | prop |
       | -5   |
@@ -31,8 +41,18 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY DESC should return results in descending order
-    And having executed: CREATE (n1 {prop: 1}), (n2 {prop: 3}), (n3 {prop: -5})
-    When executing query: MATCH (n) RETURN n.prop AS prop ORDER BY n.prop DESC
+    And having executed:
+      """
+      CREATE (n1 {prop: 1}),
+        (n2 {prop: 3}),
+        (n3 {prop: -5})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n.prop AS prop
+      ORDER BY n.prop DESC
+      """
     Then the result should be, in order:
       | prop |
       | 3    |
@@ -41,7 +61,15 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY of a column introduced in RETURN should return salient results in ascending order
-    When executing query: WITH [0, 1] AS prows, [[2], [3, 4]] AS qrows UNWIND prows AS p UNWIND qrows[p] AS q WITH p, count(q) AS rng RETURN p ORDER BY rng
+    When executing query:
+      """
+      WITH [0, 1] AS prows, [[2], [3, 4]] AS qrows
+      UNWIND prows AS p
+      UNWIND qrows[p] AS q
+      WITH p, count(q) AS rng
+      RETURN p
+      ORDER BY rng
+      """
     Then the result should be, in order:
       | p |
       | 0 |
@@ -49,8 +77,18 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: Renaming columns before ORDER BY should return results in ascending order
-    And having executed: CREATE (n1 {prop: 1}), (n2 {prop: 3}), (n3 {prop: -5})
-    When executing query: MATCH (n) RETURN n.prop AS n ORDER BY n + 2
+    And having executed:
+      """
+      CREATE (n1 {prop: 1}),
+        (n2 {prop: 3}),
+        (n3 {prop: -5})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n.prop AS n
+      ORDER BY n + 2
+      """
     Then the result should be, in order:
       | n  |
       | -5 |
@@ -59,8 +97,21 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: Handle projections with ORDER BY - GH#4937
-    And having executed: CREATE (c1:Crew {name: 'Neo', rank: 1}), (c2:Crew {name: 'Neo', rank: 2}), (c3:Crew {name: 'Neo', rank: 3}), (c4:Crew {name: 'Neo', rank: 4}), (c5:Crew {name: 'Neo', rank: 5})
-    When executing query: MATCH (c:Crew {name: 'Neo'}) WITH c, 0 AS relevance RETURN c.rank AS rank ORDER BY relevance, c.rank
+    And having executed:
+      """
+      CREATE (c1:Crew {name: 'Neo', rank: 1}),
+        (c2:Crew {name: 'Neo', rank: 2}),
+        (c3:Crew {name: 'Neo', rank: 3}),
+        (c4:Crew {name: 'Neo', rank: 4}),
+        (c5:Crew {name: 'Neo', rank: 5})
+      """
+    When executing query:
+      """
+      MATCH (c:Crew {name: 'Neo'})
+      WITH c, 0 AS relevance
+      RETURN c.rank AS rank
+      ORDER BY relevance, c.rank
+      """
     Then the result should be, in order:
       | rank |
       | 1    |
@@ -71,7 +122,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY should order booleans in the expected order
-    When executing query: UNWIND [true, false] AS bools RETURN bools ORDER BY bools
+    When executing query:
+      """
+      UNWIND [true, false] AS bools
+      RETURN bools
+      ORDER BY bools
+      """
     Then the result should be, in order:
       | bools |
       | false |
@@ -79,7 +135,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY DESC should order booleans in the expected order
-    When executing query: UNWIND [true, false] AS bools RETURN bools ORDER BY bools DESC
+    When executing query:
+      """
+      UNWIND [true, false] AS bools
+      RETURN bools
+      ORDER BY bools DESC
+      """
     Then the result should be, in order:
       | bools |
       | true  |
@@ -87,7 +148,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY should order strings in the expected order
-    When executing query: UNWIND ['.*', '', ' ', 'one'] AS strings RETURN strings ORDER BY strings
+    When executing query:
+      """
+      UNWIND ['.*', '', ' ', 'one'] AS strings
+      RETURN strings
+      ORDER BY strings
+      """
     Then the result should be, in order:
       | strings |
       | ''      |
@@ -97,7 +163,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY DESC should order strings in the expected order
-    When executing query: UNWIND ['.*', '', ' ', 'one'] AS strings RETURN strings ORDER BY strings DESC
+    When executing query:
+      """
+      UNWIND ['.*', '', ' ', 'one'] AS strings
+      RETURN strings
+      ORDER BY strings DESC
+      """
     Then the result should be, in order:
       | strings |
       | 'one'   |
@@ -107,7 +178,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY should order ints in the expected order
-    When executing query: UNWIND [1,3,2] AS ints RETURN ints ORDER BY ints
+    When executing query:
+      """
+      UNWIND [1,3,2] AS ints
+      RETURN ints
+      ORDER BY ints
+      """
     Then the result should be, in order:
       | ints |
       | 1    |
@@ -116,7 +192,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY DESC should order ints in the expected order
-    When executing query: UNWIND [1,3,2] AS ints RETURN ints ORDER BY ints DESC
+    When executing query:
+      """
+      UNWIND [1,3,2] AS ints
+      RETURN ints
+      ORDER BY ints DESC
+      """
     Then the result should be, in order:
       | ints |
       | 3    |
@@ -125,7 +206,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY should order floats in the expected order
-    When executing query: UNWIND [1.5,1.3,999.99] AS floats RETURN floats ORDER BY floats
+    When executing query:
+      """
+      UNWIND [1.5,1.3,999.99] AS floats
+      RETURN floats
+      ORDER BY floats
+      """
     Then the result should be, in order:
       | floats |
       | 1.3    |
@@ -134,7 +220,12 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: ORDER BY DESC should order floats in the expected order
-    When executing query: UNWIND [1.5,1.3,999.99] AS floats RETURN floats ORDER BY floats DESC
+    When executing query:
+      """
+      UNWIND [1.5,1.3,999.99] AS floats
+      RETURN floats
+      ORDER BY floats DESC
+      """
     Then the result should be, in order:
       | floats |
       | 999.99 |
@@ -143,16 +234,31 @@ Feature: OrderByAcceptance
     And no side effects
 
   Scenario: Handle ORDER BY with LIMIT 1
-    And having executed: CREATE (s:Person {name: 'Steven'}), (c:Person {name: 'Craig'})
-
-    When executing query: MATCH (p:Person) RETURN p.name AS name ORDER BY p.name LIMIT 1
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+        (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY p.name
+      LIMIT 1
+      """
     Then the result should be, in order:
       | name    |
       | 'Craig' |
     And no side effects
 
   Scenario: ORDER BY with LIMIT 0 should not generate errors
-    When executing query: MATCH (p:Person) RETURN p.name AS name ORDER BY p.name LIMIT 0
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY p.name
+      LIMIT 0
+      """
     Then the result should be, in order:
       | name |
     And no side effects
@@ -160,12 +266,28 @@ Feature: OrderByAcceptance
   Scenario: ORDER BY with negative parameter for LIMIT should not generate errors
     And parameters are:
       | limit | -1 |
-    When executing query: MATCH (p:Person) RETURN p.name AS name ORDER BY p.name LIMIT {limit}
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY p.name
+      LIMIT {limit}
+      """
     Then the result should be, in order:
       | name |
     And no side effects
 
   Scenario: ORDER BY with a negative LIMIT should fail with a syntax exception
-    And having executed: CREATE (s:Person {name: 'Steven'}), (c:Person {name: 'Craig'})
-    When executing query: MATCH (p:Person) RETURN p.name AS name ORDER BY p.name LIMIT -1
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+        (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY p.name
+      LIMIT -1
+      """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument

--- a/tck/features/RemoveAcceptance.feature
+++ b/tck/features/RemoveAcceptance.feature
@@ -19,7 +19,10 @@ Feature: RemoveAcceptance
 
   Scenario: Should ignore nulls
     Given an empty graph
-    And having executed: CREATE ({prop: 42})
+    And having executed:
+      """
+      CREATE ({prop: 42})
+      """
     When executing query:
       """
       MATCH (n)
@@ -34,7 +37,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove a single label
     Given an empty graph
-    And having executed: CREATE (:L {prop: 42})
+    And having executed:
+      """
+      CREATE (:L {prop: 42})
+      """
     When executing query:
       """
       MATCH (n)
@@ -49,7 +55,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove multiple labels
     Given an empty graph
-    And having executed: CREATE (:L1:L2:L3 {prop: 42})
+    And having executed:
+      """
+      CREATE (:L1:L2:L3 {prop: 42})
+      """
     When executing query:
       """
       MATCH (n)
@@ -64,7 +73,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove a single node property
     Given an empty graph
-    And having executed: CREATE (:L {prop: 42})
+    And having executed:
+      """
+      CREATE (:L {prop: 42})
+      """
     When executing query:
       """
       MATCH (n)
@@ -79,7 +91,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove multiple node properties
     Given an empty graph
-    And having executed: CREATE (:L {prop: 42, a: 'a', b: 'B'})
+    And having executed:
+      """
+      CREATE (:L {prop: 42, a: 'a', b: 'B'})
+      """
     When executing query:
       """
       MATCH (n)
@@ -94,7 +109,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove a single relationship property
     Given an empty graph
-    And having executed: CREATE (a), (b), (a)-[:X {prop: 42}]->(b)
+    And having executed:
+      """
+      CREATE (a), (b), (a)-[:X {prop: 42}]->(b)
+      """
     When executing query:
       """
       MATCH ()-[r]->()
@@ -109,7 +127,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove a single relationship property
     Given an empty graph
-    And having executed: CREATE (a), (b), (a)-[:X {prop: 42}]->(b)
+    And having executed:
+      """
+      CREATE (a), (b), (a)-[:X {prop: 42}]->(b)
+      """
     When executing query:
       """
       MATCH ()-[r]->()
@@ -124,7 +145,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove multiple relationship properties
     Given an empty graph
-    And having executed: CREATE (a), (b), (a)-[:X {prop: 42, a: 'a', b: 'B'}]->(b)
+    And having executed:
+      """
+      CREATE (a), (b), (a)-[:X {prop: 42, a: 'a', b: 'B'}]->(b)
+      """
     When executing query:
       """
       MATCH ()-[r]->()
@@ -139,7 +163,10 @@ Feature: RemoveAcceptance
 
   Scenario: Remove a missing property should be a valid operation
     Given an empty graph
-    And having executed: CREATE (), (), ()
+    And having executed:
+      """
+      CREATE (), (), ()
+      """
     When executing query:
       """
       MATCH (n)

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -80,7 +80,7 @@ Feature: ReturnAcceptanceTest
       MATCH (n)
       RETURN n
       ORDER BY n.name ASC
-      SKIP { skipAmount }
+      SKIP {skipAmount}
       """
     Then the result should be, in order:
       | n             |
@@ -102,7 +102,7 @@ Feature: ReturnAcceptanceTest
     When executing query:
       """
       MATCH (n)
-      WHERE id(n) IN [0,1,2,3,4]
+      WHERE id(n) IN [0, 1, 2, 3, 4]
       RETURN n
       ORDER BY n.name ASC
       SKIP 2
@@ -130,11 +130,11 @@ Feature: ReturnAcceptanceTest
     When executing query:
       """
       MATCH (n)
-      WHERE id(n) IN [0,1,2,3,4]
+      WHERE id(n) IN [0, 1, 2, 3, 4]
       RETURN n
       ORDER BY n.name ASC
-      SKIP { s }
-      LIMIT { l }
+      SKIP {s}
+      LIMIT {l}
       """
     Then the result should be, in order:
       | n             |
@@ -154,7 +154,7 @@ Feature: ReturnAcceptanceTest
     When executing query:
       """
       MATCH (n)
-      WHERE id(n) IN [0,1,2,3]
+      WHERE id(n) IN [0, 1, 2, 3]
       RETURN n.division, max(n.age)
       ORDER BY max(n.age)
       """
@@ -176,7 +176,7 @@ Feature: ReturnAcceptanceTest
     When executing query:
       """
       MATCH (a)
-      WHERE id(a) IN [0,1,2,0]
+      WHERE id(a) IN [0, 1, 2, 0]
       RETURN DISTINCT a
       ORDER BY a.name
       """
@@ -189,7 +189,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Support column renaming
     Given an empty graph
-    And having executed: CREATE (:Singleton)
+    And having executed:
+      """
+      CREATE (:Singleton)
+      """
     When executing query:
       """
       MATCH (a)
@@ -203,7 +206,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Support ordering by a property after being distinct-ified
     Given an empty graph
-    And having executed: CREATE (:A)-[:T]->(:B)
+    And having executed:
+      """
+      CREATE (:A)-[:T]->(:B)
+      """
     When executing query:
       """
       MATCH (a)-->(b)
@@ -218,7 +224,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Arithmetic precedence test
     Given any graph
-    When executing query: RETURN 12 / 4 * 3 - 2 * 4
+    When executing query:
+      """
+      RETURN 12 / 4 * 3 - 2 * 4
+      """
     Then the result should be:
       | 12 / 4 * 3 - 2 * 4 |
       | 1                  |
@@ -226,7 +235,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Arithmetic precedence with parenthesis test
     Given any graph
-    When executing query: RETURN 12 / 4 * (3 - 2 * 4)
+    When executing query:
+      """
+      RETURN 12 / 4 * (3 - 2 * 4)
+      """
     Then the result should be:
       | 12 / 4 * (3 - 2 * 4) |
       | -15                  |
@@ -274,7 +286,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Absolute function
     Given any graph
-    When executing query: RETURN abs(-1)
+    When executing query:
+      """
+      RETURN abs(-1)
+      """
     Then the result should be:
       | abs(-1) |
       | 1       |
@@ -282,7 +297,10 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Return collection size
     Given any graph
-    When executing query: RETURN size([1,2,3]) AS n
+    When executing query:
+      """
+      RETURN size([1, 2, 3]) AS n
+      """
     Then the result should be:
       | n |
       | 3 |

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -19,8 +19,20 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Limit to two hits
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'}), ({name: 'D'}), ({name: 'E'})
-    When executing query: MATCH (n) RETURN n LIMIT 2
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'}),
+        ({name: 'D'}),
+        ({name: 'E'})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n
+      LIMIT 2
+      """
     Then the result should be:
       | n             |
       | ({name: 'A'}) |
@@ -29,8 +41,21 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Start the result from the second row
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'}), ({name: 'D'}), ({name: 'E'})
-    When executing query: MATCH (n) RETURN n ORDER BY n.name ASC SKIP 2
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'}),
+        ({name: 'D'}),
+        ({name: 'E'})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n
+      ORDER BY n.name ASC
+      SKIP 2
+      """
     Then the result should be, in order:
       | n             |
       | ({name: 'C'}) |
@@ -40,10 +65,23 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Start the result from the second row by param
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'}), ({name: 'D'}), ({name: 'E'})
-      And parameters are:
-        | skipAmount | 2 |
-    When executing query: MATCH (n) RETURN n ORDER BY n.name ASC SKIP { skipAmount }
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'}),
+        ({name: 'D'}),
+        ({name: 'E'})
+      """
+    And parameters are:
+      | skipAmount | 2 |
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n
+      ORDER BY n.name ASC
+      SKIP { skipAmount }
+      """
     Then the result should be, in order:
       | n             |
       | ({name: 'C'}) |
@@ -53,8 +91,23 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Get rows in the middle
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'}), ({name: 'D'}), ({name: 'E'})
-    When executing query: MATCH (n) WHERE id(n) IN [0,1,2,3,4] RETURN n ORDER BY n.name ASC SKIP 2 LIMIT 2
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'}),
+        ({name: 'D'}),
+        ({name: 'E'})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      WHERE id(n) IN [0,1,2,3,4]
+      RETURN n
+      ORDER BY n.name ASC
+      SKIP 2
+      LIMIT 2
+      """
     Then the result should be, in order:
       | n             |
       | ({name: 'C'}) |
@@ -63,11 +116,26 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Get rows in the middle by param
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'}), ({name: 'D'}), ({name: 'E'})
-      And parameters are:
-        | s | 2 |
-        | l | 2 |
-    When executing query: MATCH (n) WHERE id(n) IN [0,1,2,3,4] RETURN n ORDER BY n.name ASC SKIP { s } LIMIT { l }
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'}),
+        ({name: 'D'}),
+        ({name: 'E'})
+      """
+    And parameters are:
+      | s | 2 |
+      | l | 2 |
+    When executing query:
+      """
+      MATCH (n)
+      WHERE id(n) IN [0,1,2,3,4]
+      RETURN n
+      ORDER BY n.name ASC
+      SKIP { s }
+      LIMIT { l }
+      """
     Then the result should be, in order:
       | n             |
       | ({name: 'C'}) |
@@ -76,8 +144,20 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Sort on aggregated function
     Given an empty graph
-      And having executed: CREATE ({division: 'A', age: 22}), ({division: 'B', age: 33}), ({division: 'B', age: 44}), ({division: 'C', age: 55})
-    When executing query: MATCH (n) WHERE id(n) IN [0,1,2,3] RETURN n.division, max(n.age) ORDER BY max(n.age)
+    And having executed:
+      """
+      CREATE ({division: 'A', age: 22}),
+        ({division: 'B', age: 33}),
+        ({division: 'B', age: 44}),
+        ({division: 'C', age: 55})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      WHERE id(n) IN [0,1,2,3]
+      RETURN n.division, max(n.age)
+      ORDER BY max(n.age)
+      """
     Then the result should be, in order:
       | n.division | max(n.age) |
       | 'A'        | 22         |
@@ -87,8 +167,19 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Support sort and distinct
     Given an empty graph
-      And having executed: CREATE ({name: 'A'}), ({name: 'B'}), ({name: 'C'})
-    When executing query: MATCH (a) WHERE id(a) IN [0,1,2,0] RETURN DISTINCT a ORDER BY a.name
+    And having executed:
+      """
+      CREATE ({name: 'A'}),
+        ({name: 'B'}),
+        ({name: 'C'})
+      """
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) IN [0,1,2,0]
+      RETURN DISTINCT a
+      ORDER BY a.name
+      """
     Then the result should be, in order:
       | a             |
       | ({name: 'A'}) |
@@ -98,8 +189,13 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Support column renaming
     Given an empty graph
-      And having executed: CREATE (:Singleton)
-    When executing query: MATCH (a) WHERE id(a) = 0 RETURN a AS ColumnName
+    And having executed: CREATE (:Singleton)
+    When executing query:
+      """
+      MATCH (a)
+      WHERE id(a) = 0
+      RETURN a AS ColumnName
+      """
     Then the result should be:
       | ColumnName   |
       | (:Singleton) |
@@ -107,8 +203,14 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Support ordering by a property after being distinct-ified
     Given an empty graph
-      And having executed: CREATE (:A)-[:T]->(:B)
-    When executing query: MATCH (a)-->(b) WHERE id(a) = 0 RETURN DISTINCT b ORDER BY b.name
+    And having executed: CREATE (:A)-[:T]->(:B)
+    When executing query:
+      """
+      MATCH (a)-->(b)
+      WHERE id(a) = 0
+      RETURN DISTINCT b
+      ORDER BY b.name
+      """
     Then the result should be, in order:
       | b    |
       | (:B) |
@@ -132,8 +234,16 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Count star should count everything in scope
     Given an empty graph
-      And having executed: CREATE (:l1), (:l2), (:l3)
-    When executing query: MATCH (a) RETURN a, count(*) ORDER BY count(*)
+    And having executed:
+      """
+      CREATE (:l1), (:l2), (:l3)
+      """
+    When executing query:
+      """
+      MATCH (a)
+      RETURN a, count(*)
+      ORDER BY count(*)
+      """
     Then the result should be:
       | a     | count(*) |
       | (:l1) | 1        |
@@ -143,8 +253,18 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Filter should work
     Given an empty graph
-      And having executed: CREATE (a {foo: 1})-[:T]->({foo: 1}), (a)-[:T]->({foo: 2}), (a)-[:T]->({foo: 3})
-    When executing query: MATCH (a {foo: 1}) MATCH p=(a)-->() RETURN filter(x IN nodes(p) WHERE x.foo > 2) AS n
+    And having executed:
+      """
+      CREATE (a {foo: 1})-[:T]->({foo: 1}),
+        (a)-[:T]->({foo: 2}),
+        (a)-[:T]->({foo: 3})
+      """
+    When executing query:
+      """
+      MATCH (a {foo: 1})
+      MATCH p=(a)-->()
+      RETURN filter(x IN nodes(p) WHERE x.foo > 2) AS n
+      """
     Then the result should be:
       | n            |
       | [({foo: 3})] |

--- a/tck/features/UnionAcceptance.feature
+++ b/tck/features/UnionAcceptance.feature
@@ -19,7 +19,10 @@ Feature: UnionAcceptance
 
   Scenario: Should be able to create text output from union queries
     Given an empty graph
-    And having executed: CREATE (:A), (:B)
+    And having executed:
+      """
+      CREATE (:A), (:B)
+      """
     When executing query:
       """
       MATCH (a:A)


### PR DESCRIPTION
The tests are now more in line with the Cypher style guidelines, not to mention improving readability for some of the longer, more complex queries. 

Additionally, all queries now follow the multiline format.