### PR TITLE
Remove inline format

### DIFF
--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -24,21 +24,32 @@ Each TCK feature file is made up of scenarios (see the https://cucumber.io/docs/
 ----
 Scenario: Creating a node
     Given an empty graph // <1>
-      And after having executed CREATE () // <2>
-      And parameter values are: // <3>
-        | parameter | 0 |
-    When executing query: CREATE ({property: {parameter}}) // <4>
+    And after having executed:
+      """
+      CREATE () // <2>
+      """
+    And parameter values are: // <3>
+      | parameter | 0 |
+    When executing query:
+      """
+      CREATE ({property: {parameter}}) // <4>
+      """
     Then the result should be empty // <5>
     And the side effects should be: // <6>
-      +nodes: 1
-      +properties: 1
+      | +nodes      | 1 |
+      | +properties | 1 |
 ----
 [source,gherkin]
 .This scenario illustrates the effects of executing a query `Q` - matching all nodes and returning one of them - on the graph <GRAPH_NAME>.
 ----
 Scenario: Returning a single node
     Given the <GRAPH_NAME> graph // <1>
-    When executing query: MATCH (n) RETURN n LIMIT 1 // <4>
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n
+      LIMIT 1 // <4>
+      """
     Then the result should be: // <5>
       | n  |
       | () |

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -960,7 +960,7 @@ Feature: MergeNodeAcceptance
     Given an empty graph
     When executing query:
       """
-      MERGE (t:T {id:42})
+      MERGE (t:T {id: 42})
       CREATE (f:R)
       CREATE (t)-[:REL]->(f)
       """

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -248,7 +248,7 @@ Feature: ReturnAcceptanceTest
     Given an empty graph
     And having executed:
       """
-      CREATE (:l1), (:l2), (:l3)
+      CREATE (:L1), (:L2), (:L3)
       """
     When executing query:
       """
@@ -258,9 +258,9 @@ Feature: ReturnAcceptanceTest
       """
     Then the result should be:
       | a     | count(*) |
-      | (:l1) | 1        |
-      | (:l2) | 1        |
-      | (:l3) | 1        |
+      | (:L1) | 1        |
+      | (:L2) | 1        |
+      | (:L3) | 1        |
     And no side effects
 
   Scenario: Filter should work

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
@@ -42,8 +42,6 @@ class FeatureFormatChecker extends TCKCucumberTemplate {
 
   And(INIT_QUERY) { (query: String) => initStep(query) }
 
-  And(INIT_LONG_QUERY) { (query: String) => initStep(query) }
-
   private def initStep(query: String) =
     validateCodeStyle(query).map(msg => throw new InvalidFeatureFormatException(msg))
 
@@ -52,8 +50,6 @@ class FeatureFormatChecker extends TCKCucumberTemplate {
   }
 
   When(EXECUTING_QUERY) { (query: String) => whenStep(query)}
-
-  When(EXECUTING_LONG_QUERY) { (query: String) => whenStep(query)}
 
   private def whenStep(query: String) = {
     validateCodeStyle(query).map(msg => throw new InvalidFeatureFormatException(msg))

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
@@ -27,15 +27,13 @@ object TCKStepDefinitions {
   val NAMED_GRAPH = "^the (.*) graph$"
 
   // for And
-  val INIT_QUERY = "^having executed: (.*)$"
-  val INIT_LONG_QUERY = "^having executed:$"
+  val INIT_QUERY = "^having executed:$"
   val PARAMETERS = "^parameters are:$"
   val SIDE_EFFECTS = "^the side effects should be:$"
   val NO_SIDE_EFFECTS = "^no side effects$"
 
   // for When
-  val EXECUTING_QUERY = "^executing query: (.*)$"
-  val EXECUTING_LONG_QUERY = "^executing query:$"
+  val EXECUTING_QUERY = "^executing query:$"
 
   // for Then
   val EXPECT_RESULT = "^the result should be:$"

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
@@ -30,7 +30,10 @@ object validateCodeStyle extends (String => Option[String]) {
     val lowerCased2 = lowerCased.foldLeft(prettified1) {
       case (q, word) => q.replaceAll(s"(?i)(^|[^a-zA-Z])$word ", s"$$1$word ")
     }
-    val spaceAfterComma = lowerCased2.replaceAll(",([^ \\n])", ", $1")
+
+    val onlySingleQuotes = lowerCased2.replaceAll("\"(.+)\"", "'$1'")
+
+    val spaceAfterComma = onlySingleQuotes.replaceAll(",([^ \\n])", ", $1")
 
     val spaceAfterColon = spaceAfterComma.replaceAll(":([^A-Z ])", ": $1")
 

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
@@ -30,7 +30,9 @@ object validateCodeStyle extends (String => Option[String]) {
     val lowerCased2 = lowerCased.foldLeft(prettified1) {
       case (q, word) => q.replaceAll(s"(?i)(^|[^a-zA-Z])$word ", s"$$1$word ")
     }
-    val spaceAfterColon = lowerCased2.replaceAll(":([^A-Z ])", ": $1")
+    val spaceAfterComma = lowerCased2.replaceAll(",([^ \\n])", ", $1")
+
+    val spaceAfterColon = spaceAfterComma.replaceAll(":([^A-Z ])", ": $1")
 
     if (spaceAfterColon != query)
       Some( s"""A query did not follow style requirements:

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/validateCodeStyle.scala
@@ -30,19 +30,20 @@ object validateCodeStyle extends (String => Option[String]) {
     val lowerCased2 = lowerCased.foldLeft(prettified1) {
       case (q, word) => q.replaceAll(s"(?i)(^|[^a-zA-Z])$word ", s"$$1$word ")
     }
+    val spaceAfterColon = lowerCased2.replaceAll(":([^A-Z ])", ": $1")
 
-    if (lowerCased2 != query)
+    if (spaceAfterColon != query)
       Some( s"""A query did not follow style requirements:
                 |$query
                 |
                 |Prettified version:
-                |$lowerCased2""".stripMargin)
+                |$spaceAfterColon""".stripMargin)
     else None
   }
 
   // TODO: Write a proper style checker, that is able to interpret context and do proper parsing
   // The result will probably be similar to the class Prettifier in the neo4j repository, which
-  // currently does not fit our needs.
+  // we could use, but a dependency on neo4j that way would be very smelly.
 
   private val lowerCased = Set("true",
                                "false",

--- a/tools/tck/src/test/scala/org/opencypher/tools/tck/validateCodeStyleTest.scala
+++ b/tools/tck/src/test/scala/org/opencypher/tools/tck/validateCodeStyleTest.scala
@@ -48,4 +48,24 @@ class validateCodeStyleTest extends TckTestSupport {
     validateCodeStyle("MATCH ()-[:T]-()") shouldBe None
   }
 
+  test("should request space after comma") {
+    validateCodeStyle("WITH [1,2,3] AS list RETURN list,list") shouldBe
+      Some("""A query did not follow style requirements:
+             |WITH [1,2,3] AS list RETURN list,list
+             |
+             |Prettified version:
+             |WITH [1, 2, 3] AS list RETURN list, list""".stripMargin)
+  }
+
+  test("should accept space after comma when present") {
+    validateCodeStyle("WITH [1, 2, 3] AS list RETURN list, list") shouldBe None
+  }
+
+  test("should not request space after comma when line breaks") {
+    validateCodeStyle("""MATCH (a),
+                        |(b)
+                        |RETURN 1
+                      """.stripMargin) shouldBe None
+  }
+
 }

--- a/tools/tck/src/test/scala/org/opencypher/tools/tck/validateCodeStyleTest.scala
+++ b/tools/tck/src/test/scala/org/opencypher/tools/tck/validateCodeStyleTest.scala
@@ -31,4 +31,21 @@ class validateCodeStyleTest extends TckTestSupport {
     validateCodeStyle("MATCH (n) RETURN n") shouldBe None
   }
 
+  test("should request space after colon") {
+    validateCodeStyle("MATCH (n {name:'test'})") shouldBe
+      Some("""A query did not follow style requirements:
+             |MATCH (n {name:'test'})
+             |
+             |Prettified version:
+             |MATCH (n {name: 'test'})""".stripMargin)
+  }
+
+  test("should not request space after colon if it's a label") {
+    validateCodeStyle("MATCH (n:Label)") shouldBe None
+  }
+
+  test("should not request space after colon if it's a relationship type") {
+    validateCodeStyle("MATCH ()-[:T]-()") shouldBe None
+  }
+
 }


### PR DESCRIPTION
Removes support for the 'inline' format, and forces scenarios to use the multiline format. Also enforces space after comma and colon in the verification process (more complex rules are left for when more sophisticated analysis tools are available; the Cypher AST).

Update the readme, which was a bit obsolete.