### PR TITLE
Port LabelsAcceptanceTest to the TCK

### DIFF
--- a/tck/features/LabelsAcceptance.feature
+++ b/tck/features/LabelsAcceptance.feature
@@ -1,0 +1,269 @@
+#
+# Copyright 2016 "Neo Technology",
+# Network Engine for Objects in Lund AB (http://neotechnology.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Feature: LabelsAcceptance
+
+  Background:
+    Given an empty graph
+
+  Scenario: Adding a single label
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n:Foo
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n) |
+      | ['Foo']   |
+    And the side effects should be:
+      | +labels | 1 |
+
+  Scenario: Ignore space before colon
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n :Foo
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n) |
+      | ['Foo']   |
+    And the side effects should be:
+      | +labels | 1 |
+
+  Scenario: Adding multiple labels
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n:Foo:Bar
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n)      |
+      | ['Foo', 'Bar'] |
+    And the side effects should be:
+      | +labels | 2 |
+
+  Scenario: Ignoring intermediate whitespace 1
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n :Foo :Bar
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n)      |
+      | ['Foo', 'Bar'] |
+    And the side effects should be:
+      | +labels | 2 |
+
+  Scenario: Ignoring intermediate whitespace 2
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n :Foo:Bar
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n)      |
+      | ['Foo', 'Bar'] |
+    And the side effects should be:
+      | +labels | 2 |
+
+  Scenario: Creating node without label
+    When executing query:
+      """
+      CREATE (node)
+      RETURN labels(node)
+      """
+    Then the result should be:
+      | labels(node) |
+      | []           |
+    And the side effects should be:
+      | +nodes | 1 |
+
+  Scenario: Creating node with two labels
+    When executing query:
+      """
+      CREATE (node:Foo:Bar {name: 'Mattias'})
+      RETURN labels(node)
+      """
+    Then the result should be:
+      | labels(node)   |
+      | ['Foo', 'Bar'] |
+    And the side effects should be:
+      | +nodes      | 1 |
+      | +labels     | 2 |
+      | +properties | 1 |
+
+  Scenario: Ignore space when creating node with labels
+    When executing query:
+      """
+      CREATE (node :Foo:Bar)
+      RETURN labels(node)
+      """
+    Then the result should be:
+      | labels(node)   |
+      | ['Foo', 'Bar'] |
+    And the side effects should be:
+      | +nodes  | 1 |
+      | +labels | 2 |
+
+  Scenario: Create node with label in pattern
+    When executing query:
+      """
+      CREATE (n:Person)-[:OWNS]->(:Dog)
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n)  |
+      | ['Person'] |
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +labels        | 2 |
+
+  Scenario: Fail when adding new label predicate on already bound node 1
+    When executing query:
+      """
+      CREATE (n:Foo)-[:T1]->(),
+             (n:Bar)-[:T2]->()
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  Scenario: Fail when adding new label predicate on already bound node 2
+    When executing query:
+      """
+      CREATE ()<-[:T2]-(n:Foo),
+             (n:Bar)<-[:T1]-()
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  Scenario: Fail when adding new label predicate on already bound node 3
+    When executing query:
+      """
+      CREATE (n:Foo)
+      CREATE (n:Bar)-[:OWNS]->(:Dog)
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  Scenario: Fail when adding new label predicate on already bound node 4
+    When executing query:
+      """
+      CREATE (n {})
+      CREATE (n:Bar)-[:OWNS]->(:Dog)
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  Scenario: Fail when adding new label predicate on already bound node 5
+    When executing query:
+      """
+      CREATE (n:Foo)
+      CREATE (n {})-[:OWNS]->(:Dog)
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  Scenario: Add labels inside FOREACH
+    When executing query:
+      """
+      CREATE (a), (b), (c)
+      WITH [a, b, c] AS nodes
+      FOREACH(n IN nodes |
+        SET n :Foo:Bar
+      )
+      """
+    Then the result should be empty
+    And the side effects should be:
+      | +nodes  | 3 |
+      | +labels | 6 |
+    When executing control query:
+      """
+      MATCH (n)
+      WHERE NOT(n:Foo AND n:Bar)
+      RETURN n
+      """
+    Then the result should be:
+      | n |
+
+  Scenario: Using `labels()` in return clauses
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n) |
+      | []        |
+    And no side effects
+
+  Scenario: Removing a label
+    And having executed:
+      """
+      CREATE (:Foo:Bar)
+      """
+    When executing query:
+      """
+      MATCH (n)
+      REMOVE n:Foo
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n) |
+      | ['Bar']   |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: Removing a non-existent label
+    And having executed:
+      """
+      CREATE (:Foo)
+      """
+    When executing query:
+      """
+      MATCH (n)
+      REMOVE n:Bar
+      RETURN labels(n)
+      """
+    Then the result should be:
+      | labels(n) |
+      | ['Foo']   |
+    And no side effects

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
@@ -51,6 +51,7 @@ object TCKErrorDetails {
   val NEGATIVE_INTEGER_ARGUMENT = "NegativeIntegerArgument"
   val DELETE_CONNECTED_NODE = "DeleteConnectedNode"
   val INCOMPARABLE_VALUES = "IncomparableValues"
+  val VARIABLE_ALREADY_BOUND = "VariableAlreadyBound"
 
   val ALL = Set(INVALID_ELEMENT_ACCESS,
                 MAP_ELEMENT_ACCESS_BY_NON_STRING,
@@ -59,6 +60,7 @@ object TCKErrorDetails {
                 NESTED_AGGREGATION,
                 NEGATIVE_INTEGER_ARGUMENT,
                 DELETE_CONNECTED_NODE,
-                INCOMPARABLE_VALUES)
+                INCOMPARABLE_VALUES,
+                VARIABLE_ALREADY_BOUND)
 
 }

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
@@ -34,6 +34,7 @@ object TCKStepDefinitions {
 
   // for When
   val EXECUTING_QUERY = "^executing query:$"
+  val EXECUTING_CONTROL_QUERY = "^executing control query:$"
 
   // for Then
   val EXPECT_RESULT = "^the result should be:$"


### PR DESCRIPTION
Introduces the notion of a 'control query' - a query used to make additional assertions on the graph state after an updating query was executed. This is a more sophisticated extension to just asserting on the somewhat primitive side effects.