### PR TITLE
Port WhereAcceptance to the TCK

### DIFF
--- a/tck/features/WhereAcceptance.feature
+++ b/tck/features/WhereAcceptance.feature
@@ -1,0 +1,49 @@
+#
+# Copyright 2016 "Neo Technology",
+# Network Engine for Objects in Lund AB (http://neotechnology.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Feature: WhereAcceptance
+
+  Scenario: NOT and false
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({name: 'a'})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      WHERE NOT(n.name = 'apa' AND false)
+      RETURN n
+      """
+    Then the result should be:
+      | n             |
+      | ({name: 'a'}) |
+    And no side effects
+
+  Scenario: Fail when trying to compare strings and numbers
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:Label {prop: '15'})
+      """
+    When executing query:
+      """
+      MATCH (n:Label)
+      WHERE n.prop < 10
+      RETURN n.prop AS prop
+      """
+    Then a SyntaxError should be raised at runtime: IncomparableValues

--- a/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
+++ b/tools/tck/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
@@ -50,6 +50,7 @@ object TCKErrorDetails {
   val NESTED_AGGREGATION = "NestedAggregation"
   val NEGATIVE_INTEGER_ARGUMENT = "NegativeIntegerArgument"
   val DELETE_CONNECTED_NODE = "DeleteConnectedNode"
+  val INCOMPARABLE_VALUES = "IncomparableValues"
 
   val ALL = Set(INVALID_ELEMENT_ACCESS,
                 MAP_ELEMENT_ACCESS_BY_NON_STRING,
@@ -57,6 +58,7 @@ object TCKErrorDetails {
                 CREATE_BLOCKED_BY_CONSTRAINT,
                 NESTED_AGGREGATION,
                 NEGATIVE_INTEGER_ARGUMENT,
-                DELETE_CONNECTED_NODE)
+                DELETE_CONNECTED_NODE,
+                INCOMPARABLE_VALUES)
 
 }


### PR DESCRIPTION
Adds a new error detail `IncomparableValues`.