### PR TITLE
Mark non-standardized parts of the grammar as legacy

### DIFF
--- a/grammar/README.adoc
+++ b/grammar/README.adoc
@@ -16,3 +16,16 @@ These four commands may then be used for generating the currently available arti
 
 What the `launch.sh` shell script will do is to invoke the `main` method in the class with the same name as the first argument.
 If preferred, the main method could be invoked manually from the code (in an IDE or similar).
+
+== Legacy grammar
+
+Not all grammar rules of Cypher the language will be standardised in their current form, meaning that they will not be part of openCypher as-is.
+Therefore, the openCypher grammar will not include some well-known Cypher constructs; these are called 'legacy'.
+To still enable tool authors or others interested in developing support for Cypher in its full current shape, these legacy rules are still present in the grammar specification.
+The artifacts that can be generated from the specification will by default ignore all legacy rules, but may optionally be instructed to include them.
+To use the legacy rules, supply the command `--INCLUDE_LEGACY=true` to the `launch.sh` script, the command line, or set the Java system property directly.
+
+For example, this command will generate the legacy version of the railroad diagram pages:
+----
+./tools/grammar/src/main/shell/launch.sh RailRoadDiagramPages --INCLUDE_LEGACY=true -outputDir=grammar/generated/railroad cypher.xml
+----

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -24,6 +24,7 @@
 <grammar language="Cypher Basic Grammar"
   xmlns="http://thobe.org/grammar"
   xmlns:rr="http://thobe.org/railroad"
+  xmlns:oc="http://thobe.org/opencypher"
   xmlns:ast="http://thobe.org/syntaxtree"
   xmlns:gen="http://thobe.org/stringgeneration">
 
@@ -57,7 +58,7 @@
     </alt>
   </production>
 
-  <production name="ShortestPathPattern" rr:inline="true">
+  <production name="ShortestPathPattern" rr:inline="true" oc:legacy="true">
     <alt>
       <seq>shortestPath ( <non-terminal ref="PatternElement"/> )</seq>
       <seq>allShortestPaths ( <non-terminal ref="PatternElement"/> )</seq>
@@ -134,7 +135,7 @@
     </alt>
   </production>
 
-  <production name="RelType" rr:inline="true">
+  <production name="RelType" rr:inline="true" oc:legacy="true">
     :<non-terminal ref="RelTypeName"/>
   </production>
 
@@ -273,7 +274,7 @@
     </alt>
   </production>
 
-  <production name="Reduce" rr:inline="true">
+  <production name="Reduce" rr:inline="true" oc:legacy="true">
     REDUCE &WS; ( &var; = &expr; , <non-terminal ref="IdInColl"/> | &expr; )
   </production>
 
@@ -334,7 +335,7 @@
     </alt>
   </production>
 
-  <production name="CaseExpression">
+  <production name="CaseExpression" oc:legacy="true">
     <alt>
       <seq>CASE <repeat min="1">&WS; <non-terminal ref="CaseAlternatives"/></repeat></seq>
       <seq>CASE &expr; <repeat min="1">&WS; <non-terminal ref="CaseAlternatives"/></repeat></seq>
@@ -343,7 +344,7 @@
     &WS; END
   </production>
 
-  <production name="CaseAlternatives" rr:inline="true">
+  <production name="CaseAlternatives" rr:inline="true" oc:legacy="true">
     WHEN &WS; &expr; &WS; THEN &WS; &expr;
   </production>
 

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -29,10 +29,11 @@
 <grammar language="Command"
   xmlns="http://thobe.org/grammar"
   xmlns:rr="http://thobe.org/railroad"
+  xmlns:oc="http://thobe.org/opencypher"
   xmlns:ast="http://thobe.org/syntaxtree"
   xmlns:gen="http://thobe.org/stringgeneration">
 
-  <production name="Command" rr:inline="true">
+  <production name="Command" rr:inline="true" oc:legacy="true">
     <alt>
       <non-terminal ref="CreateIndex"/>
       <non-terminal ref="DropIndex"/>
@@ -50,59 +51,59 @@
 
   <!-- / COMMANDS \ -->
 
-  <production name="CreateUniqueConstraint" rr:inline="true">
+  <production name="CreateUniqueConstraint" rr:inline="true" oc:legacy="true">
     CREATE &WS; <non-terminal ref="UniqueConstraint"/>
   </production>
 
-  <production name="CreateNodePropertyExistenceConstraint" rr:inline="true">
+  <production name="CreateNodePropertyExistenceConstraint" rr:inline="true" oc:legacy="true">
     CREATE &WS; <non-terminal ref="NodePropertyExistenceConstraint"/>
   </production>
 
-  <production name="CreateRelationshipPropertyExistenceConstraint" rr:inline="true">
+  <production name="CreateRelationshipPropertyExistenceConstraint" rr:inline="true" oc:legacy="true">
     CREATE &WS; <non-terminal ref="RelationshipPropertyExistenceConstraint"/>
   </production>
 
-  <production name="CreateIndex" rr:inline="true">
+  <production name="CreateIndex" rr:inline="true" oc:legacy="true">
     CREATE &SP; <non-terminal ref="Index"/>
   </production>
 
-  <production name="DropUniqueConstraint" rr:inline="true">
+  <production name="DropUniqueConstraint" rr:inline="true" oc:legacy="true">
     DROP &SP; <non-terminal ref="UniqueConstraint"/>
   </production>
 
-  <production name="DropNodePropertyExistenceConstraint" rr:inline="true">
+  <production name="DropNodePropertyExistenceConstraint" rr:inline="true" oc:legacy="true">
     DROP &SP; <non-terminal ref="NodePropertyExistenceConstraint"/>
   </production>
 
-  <production name="DropRelationshipPropertyExistenceConstraint" rr:inline="true">
+  <production name="DropRelationshipPropertyExistenceConstraint" rr:inline="true" oc:legacy="true">
     DROP &SP; <non-terminal ref="RelationshipPropertyExistenceConstraint"/>
   </production>
 
-  <production name="DropIndex" rr:inline="true">
+  <production name="DropIndex" rr:inline="true" oc:legacy="true">
     DROP &SP; <non-terminal ref="Index"/>
   </production>
 
-  <production name="Index">
+  <production name="Index" oc:legacy="true">
     INDEX &SP; ON &WS; &label; (<non-terminal ref="PropertyKeyName"/>)
   </production>
 
 
-  <production name="UniqueConstraint">
+  <production name="UniqueConstraint" oc:legacy="true">
     CONSTRAINT &SP; ON &WS; ( &var; &label; )
     ASSERT <non-terminal ref="PropertyExpression"/> IS &SP; UNIQUE
   </production>
 
-  <production name="NodePropertyExistenceConstraint">
+  <production name="NodePropertyExistenceConstraint" oc:legacy="true">
     CONSTRAINT &SP; ON &WS; ( &var; &label; )
     ASSERT &SP; EXISTS ( <non-terminal ref="PropertyExpression"/> )
   </production>
 
-  <production name="RelationshipPropertyExistenceConstraint">
+  <production name="RelationshipPropertyExistenceConstraint" oc:legacy="true">
     CONSTRAINT &SP; ON &WS; <non-terminal ref="RelationshipPatternSyntax"/>
     ASSERT &SP; EXISTS ( <non-terminal ref="PropertyExpression"/> )
   </production>
 
-  <production name="RelationshipPatternSyntax">
+  <production name="RelationshipPatternSyntax" oc:legacy="true">
     <alt>
       <seq>&node;&dash;[&var;&type;]&dash;&node;</seq>
       <seq>&node;&dash;[&var;&type;]&rarrow;&node;</seq>

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -24,6 +24,7 @@
 <grammar language="Cypher"
   xmlns="http://thobe.org/grammar"
   xmlns:rr="http://thobe.org/railroad"
+  xmlns:oc="http://thobe.org/opencypher"
   xmlns:ast="http://thobe.org/syntaxtree"
   xmlns:gen="http://thobe.org/stringgeneration"
   xmlns:scope="http://thobe.org/scope">
@@ -61,7 +62,7 @@
     <repeat>&WS;<non-terminal ref="Union"/></repeat>
   </production>
 
-  <production name="BulkImportQuery">
+  <production name="BulkImportQuery" oc:legacy="true">
     <non-terminal ref="PeriodicCommitHint"/>
     &WS;
     <non-terminal ref="LoadCSVQuery"/>
@@ -72,12 +73,12 @@
     <repeat>&WS; <non-terminal ref="Clause"/></repeat>
   </production>
 
-  <production name="PeriodicCommitHint" rr:inline="true">
+  <production name="PeriodicCommitHint" rr:inline="true" oc:legacy="true">
     USING &SP; PERIODIC &SP; COMMIT
     <opt>&SP;<non-terminal ref="SignedIntegerLiteral"/></opt>
   </production>
 
-  <production name="LoadCSVQuery" rr:inline="true">
+  <production name="LoadCSVQuery" rr:inline="true" oc:legacy="true">
     <non-terminal ref="LoadCSV"/>
     <repeat>&WS;<non-terminal ref="Clause"/></repeat>
   </production>
@@ -114,7 +115,7 @@
 
   <!-- / CLAUSES \ -->
 
-  <production name="LoadCSV">
+  <production name="LoadCSV" oc:legacy="true">
     LOAD &SP; CSV &SP;
     <opt>WITH &SP; HEADERS &SP;</opt>
     FROM &SP; &expr; &SP;
@@ -189,7 +190,7 @@
     </alt>
   </production>
 
-  <production name="Foreach" scope:rule="nested">
+  <production name="Foreach" scope:rule="nested" oc:legacy="true">
     FOREACH &WS; ( &WS; &var; &SP; IN &SP; &expr; &WS; | <repeat min="1">&SP;<non-terminal ref="Clause"/></repeat> &WS; )
   </production>
 
@@ -254,7 +255,7 @@
     </alt>
   </production>
 
-  <production name="Hint">
+  <production name="Hint" oc:legacy="true">
     <alt>
       <seq>USING &SP; INDEX &SP; &var; <non-terminal ref="NodeLabel"/>(<non-terminal ref="PropertyKeyName"/>)</seq>
       <seq>USING &SP; JOIN &SP; ON &SP; &var; <repeat>&WS;,&WS;&var;</repeat></seq>

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -98,6 +98,7 @@
       <non-terminal ref="Unwind"/>
       <non-terminal ref="Merge"/>
       <non-terminal ref="Create"/>
+      <non-terminal ref="CreateUnique"/>
       <non-terminal ref="Set"/>
       <non-terminal ref="Delete"/>
       <non-terminal ref="Remove"/>
@@ -149,10 +150,11 @@
   </production>
 
   <production name="Create">
-    <alt>
-      <seq>CREATE &SP; UNIQUE &WS; <non-terminal ref="Pattern"/></seq>
-      <seq>CREATE &WS; <non-terminal ref="Pattern"/></seq>
-    </alt>
+    <seq>CREATE &WS; <non-terminal ref="Pattern"/></seq>
+  </production>
+
+  <production name="CreateUnique" oc:legacy="true">
+    <seq>CREATE &SP; UNIQUE &WS; <non-terminal ref="Pattern"/></seq>
   </production>
 
   <production name="Set">

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -127,7 +127,7 @@
   <production name="Match" scope:rule="new">
     <opt>OPTIONAL &SP;</opt>MATCH &WS;
     <non-terminal ref="Pattern"/>
-    <repeat>&WS; <non-terminal ref="Hint"/></repeat>
+    <repeat><non-terminal ref="Hint"/></repeat>
     <opt>&WS; <non-terminal ref="Where"/></opt>
   </production>
 
@@ -258,6 +258,7 @@
   </production>
 
   <production name="Hint" oc:legacy="true">
+    &WS;
     <alt>
       <seq>USING &SP; INDEX &SP; &var; <non-terminal ref="NodeLabel"/>(<non-terminal ref="PropertyKeyName"/>)</seq>
       <seq>USING &SP; JOIN &SP; ON &SP; &var; <repeat>&WS;,&WS;&var;</repeat></seq>

--- a/grammar/pre-parser.xml
+++ b/grammar/pre-parser.xml
@@ -22,16 +22,17 @@
 <grammar language="Cypher Pre-Parser"
   xmlns="http://thobe.org/grammar"
   xmlns:rr="http://thobe.org/railroad"
+  xmlns:oc="http://thobe.org/opencypher"
   xmlns:ast="http://thobe.org/syntaxtree"
   xmlns:gen="http://thobe.org/stringgeneration">
 
   <!-- / PRE-PARSER \ -->
 
-  <production name="QueryOptions">
+  <production name="QueryOptions" oc:legacy="true">
     <repeat><non-terminal ref="AnyCypherOption"/> &WS;</repeat>
   </production>
 
-  <production name="AnyCypherOption" rr:inline="true">
+  <production name="AnyCypherOption" rr:inline="true" oc:legacy="true">
     <alt>
       <non-terminal ref="CypherOption"/>
       <non-terminal ref="Explain"/>
@@ -39,20 +40,20 @@
     </alt>
   </production>
 
-  <production name="CypherOption" rr:inline="true">
+  <production name="CypherOption" rr:inline="true" oc:legacy="true">
     CYPHER
     <opt>&SP;<non-terminal ref="VersionNumber"/></opt>
     <repeat>&SP;<non-terminal ref="ConfigurationOption"/></repeat>
   </production>
 
-  <production name="VersionNumber" rr:inline="true">
+  <production name="VersionNumber" rr:inline="true" oc:legacy="true">
     <non-terminal ref="DigitString"/>.<non-terminal ref="DigitString"/>
   </production>
 
-  <production name="Explain" rr:inline="true">EXPLAIN</production>
-  <production name="Profile" rr:inline="true">PROFILE</production>
+  <production name="Explain" rr:inline="true" oc:legacy="true">EXPLAIN</production>
+  <production name="Profile" rr:inline="true" oc:legacy="true">PROFILE</production>
 
-  <production name="ConfigurationOption" rr:inline="true">
+  <production name="ConfigurationOption" rr:inline="true" oc:legacy="true">
     <non-terminal ref="SymbolicName" ast:entry="key"/>
     &WS; = &WS;
     <non-terminal ref="SymbolicName" ast:entry="value"/>

--- a/grammar/start.xml
+++ b/grammar/start.xml
@@ -23,30 +23,31 @@
 <grammar language="Cypher Start Clause"
   xmlns="http://thobe.org/grammar"
   xmlns:rr="http://thobe.org/railroad"
+  xmlns:oc="http://thobe.org/opencypher"
   xmlns:ast="http://thobe.org/syntaxtree"
   xmlns:gen="http://thobe.org/stringgeneration">
 
   <!-- / START \ -->
 
-  <production name="Start">
+  <production name="Start" oc:legacy="true">
     START &SP;
     <non-terminal ref="StartPoint"/>
     <repeat>&WS;,&WS;<non-terminal ref="StartPoint"/></repeat>
     <opt><non-terminal ref="Where"/></opt>
   </production>
 
-  <production name="StartPoint" rr:inline="true">
+  <production name="StartPoint" rr:inline="true" oc:legacy="true">
     &var; &WS; = &WS; <non-terminal ref="Lookup"/>
   </production>
 
-  <production name="Lookup" rr:inline="true">
+  <production name="Lookup" rr:inline="true" oc:legacy="true">
     <alt>
       <non-terminal ref="NodeLookup"/>
       <non-terminal ref="RelationshipLookup"/>
     </alt>
   </production>
 
-  <production name="NodeLookup" rr:inline="true">
+  <production name="NodeLookup" rr:inline="true" oc:legacy="true">
     NODE
     <alt>
       <non-terminal ref="IdentifiedIndexLookup"/>
@@ -55,7 +56,7 @@
     </alt>
   </production>
 
-  <production name="RelationshipLookup" rr:inline="true">
+  <production name="RelationshipLookup" rr:inline="true" oc:legacy="true">
     <alt>RELATIONSHIP REL</alt>
     <alt>
       <non-terminal ref="IdentifiedIndexLookup"/>
@@ -64,7 +65,7 @@
     </alt>
   </production>
 
-  <production name="IdentifiedIndexLookup">
+  <production name="IdentifiedIndexLookup" oc:legacy="true">
     : <non-terminal ref="SymbolicName" rr:title="index name"/>
     ( <non-terminal ref="SymbolicName" rr:title="property key"/> =
     <alt>
@@ -73,7 +74,7 @@
     </alt>)
   </production>
 
-  <production name="IndexQuery">
+  <production name="IndexQuery" oc:legacy="true">
     : <non-terminal ref="SymbolicName" rr:title="index name"/>
     (<alt>
       <non-terminal ref="StringLiteral"/>
@@ -81,7 +82,7 @@
     </alt>)
   </production>
 
-  <production name="IdLookup">
+  <production name="IdLookup" oc:legacy="true">
     (<alt>
       <non-terminal ref="LiteralIds"/>
       <non-terminal ref="Parameter"/>
@@ -89,7 +90,7 @@
     </alt>)
   </production>
 
-  <production name="LiteralIds" rr:inline="true">
+  <production name="LiteralIds" rr:inline="true" oc:legacy="true">
     <non-terminal ref="UnsignedIntegerLiteral"/>
     <repeat>
       &WS;,&WS;<non-terminal ref="UnsignedIntegerLiteral"/>

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Container.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Container.java
@@ -66,12 +66,11 @@ abstract class Container extends Node implements Terms
     }
 
     @Override
-    final void resolve( ProductionNode origin, ProductionResolver resolver )
+    final boolean resolve( ProductionNode origin, ProductionResolver resolver )
     {
-        for ( Node node : nodes )
-        {
-            node.resolve( origin, resolver );
-        }
+        ArrayList<Node> nodes = new ArrayList<>( this.nodes );
+        nodes.stream().filter( node -> !node.resolve( origin, resolver ) ).forEach( this.nodes::remove );
+        return !nodes.isEmpty();
     }
 
     @Child

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Grammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Grammar.java
@@ -41,6 +41,7 @@ public interface Grammar
     String SCOPE_XML_NAMESPACE = "http://thobe.org/scope";
     String GENERATOR_XML_NAMESPACE = "http://thobe.org/stringgeneration";
     String RAILROAD_XML_NAMESPACE = "http://thobe.org/railroad";
+    String OPENCYPHER_XML_NAMESPACE = "http://thobe.org/opencypher";
 
     static Grammar parseXML( Path input, ParserOption... options )
             throws ParserConfigurationException, SAXException, IOException
@@ -273,7 +274,8 @@ public interface Grammar
     {
         FAIL_ON_UNKNOWN_XML_ATTRIBUTE( XmlParser.Option.FAIL_ON_UNKNOWN_ATTRIBUTE ),
         SKIP_UNUSED_PRODUCTIONS( Root.ResolutionOption.SKIP_UNUSED_PRODUCTIONS ),
-        ALLOW_ROOTLESS_GRAMMAR( Root.ResolutionOption.ALLOW_ROOTLESS );
+        ALLOW_ROOTLESS_GRAMMAR( Root.ResolutionOption.ALLOW_ROOTLESS ),
+        INCLUDE_LEGACY( Root.ResolutionOption.INCLUDE_LEGACY );
 
         private final Object option;
 

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Node.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Node.java
@@ -58,8 +58,9 @@ abstract class Node extends Grammar.Term implements LocationAware
         return sequenced;
     }
 
-    void resolve( ProductionNode origin, ProductionResolver resolver )
+    boolean resolve( ProductionNode origin, ProductionResolver resolver )
     {
+        return true;
     }
 
     Node replaceWithVerified()

--- a/tools/grammar/src/main/java/org/opencypher/grammar/NonTerminalNode.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/NonTerminalNode.java
@@ -67,7 +67,7 @@ final class NonTerminalNode extends Node implements NonTerminal
     }
 
     @Override
-    void resolve( ProductionNode origin, ProductionResolver resolver )
+    boolean resolve( ProductionNode origin, ProductionResolver resolver )
     {
         production = resolver.resolveProduction( origin, requireNonNull( ref, "non-terminal reference" ) );
         if ( production != null )
@@ -78,7 +78,9 @@ final class NonTerminalNode extends Node implements NonTerminal
                 this.origin = origin;
                 index = resolver.nextNonTerminalIndex();
             }
+            return true;
         }
+        return false;
     }
 
     @Override

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Production.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Production.java
@@ -37,6 +37,8 @@ public interface Production
 
     boolean inline();
 
+    boolean legacy();
+
     Collection<NonTerminal> references();
 
     default Collection<Production> referencedFrom()

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ProductionNode.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ProductionNode.java
@@ -39,6 +39,8 @@ final class ProductionNode extends Located implements Production
     String description;
     @Attribute(uri = Grammar.RAILROAD_XML_NAMESPACE, optional = true)
     boolean skip, inline;
+    @Attribute(uri = Grammar.OPENCYPHER_XML_NAMESPACE, optional = true)
+    boolean legacy;
     private List<NonTerminal> references;
 
     public ProductionNode( Root root )
@@ -116,6 +118,12 @@ final class ProductionNode extends Located implements Production
     public boolean inline()
     {
         return inline;
+    }
+
+    @Override
+    public boolean legacy()
+    {
+        return legacy;
     }
 
     void addReference( NonTerminalNode nonTerminal )

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ProductionResolver.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ProductionResolver.java
@@ -24,23 +24,28 @@ class ProductionResolver
     private final Map<String, ProductionNode> productions;
     private final Dependencies dependencies;
     private final Set<String> unused;
+    private final Set<Root.ResolutionOption> options;
+    private final Set<String> legacyProductions;
     private int nonTerminalIndex;
 
-    public ProductionResolver( Map<String, ProductionNode> productions, Dependencies dependencies, Set<String> unused )
+    public ProductionResolver( Map<String,ProductionNode> productions, Dependencies dependencies, Set<String> unused,
+            Set<Root.ResolutionOption> options, Set<String> legacyProductions )
     {
         this.productions = productions;
         this.dependencies = dependencies;
         this.unused = unused;
+        this.options = options;
+        this.legacyProductions = legacyProductions;
     }
 
     public ProductionNode resolveProduction( ProductionNode origin, String name )
     {
         ProductionNode production = productions.get( name.toLowerCase() );
-        if ( production == null )
+        if ( production == null && !options.contains( Root.ResolutionOption.INCLUDE_LEGACY ) && !legacyProductions.contains( name.toLowerCase() ) )
         {
             dependencies.missingProduction( name, origin );
         }
-        else if ( production.name.equals( name ) )
+        else if ( production != null && production.name.equals( name ) )
         {
             unused.remove( name );
             dependencies.usedFrom( name, origin );

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Root.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Root.java
@@ -128,17 +128,7 @@ class Root implements Iterable<ProductionNode>
         // filter out unused productions
         if ( !unused.isEmpty() )
         {
-            if ( options.contains( ResolutionOption.SKIP_UNUSED_PRODUCTIONS ) )
-            {
-                while ( false && !unused.isEmpty() )
-                {
-                    for ( String name : new ArrayList<>( unused ) )
-                    {
-                        ProductionNode production = productions.remove( name );
-                    }
-                }
-            }
-            else if ( !options.contains( ResolutionOption.IGNORE_UNUSED_PRODUCTIONS ) )
+            if ( !options.contains( ResolutionOption.IGNORE_UNUSED_PRODUCTIONS ) )
             {
                 System.err.println( "WARNING! Unused productions:" );
                 for ( String name : unused )

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Sequenced.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Sequenced.java
@@ -38,12 +38,9 @@ abstract class Sequenced extends Node
     }
 
     @Override
-    final void resolve( ProductionNode origin, ProductionResolver resolver )
+    final boolean resolve( ProductionNode origin, ProductionResolver resolver )
     {
-        if ( term != null )
-        {
-            term.resolve( origin, resolver );
-        }
+        return term == null || term.resolve( origin, resolver );
     }
 
     @Override

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4Massager.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4Massager.java
@@ -22,14 +22,26 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.opencypher.grammar.Grammar.ParserOption.INCLUDE_LEGACY;
+
 // TODO: we should try to make these rules more generic, to not depend on specific names or positions in the result file
 class Antlr4Massager
 {
 
     static String postProcess( String original )
     {
-        int startOfKeywords = original.indexOf(
-                "CYPHER : ( 'C' | 'c' ) ( 'Y' | 'y' ) ( 'P' | 'p' ) ( 'H' | 'h' ) ( 'E' | 'e' ) ( 'R' | 'r' )  ;" );
+        String firstKeyword;
+        if ( Boolean.parseBoolean( System.getProperty( INCLUDE_LEGACY.name() ) ) )
+        {
+            firstKeyword =
+                    "CYPHER : ( 'C' | 'c' ) ( 'Y' | 'y' ) ( 'P' | 'p' ) ( 'H' | 'h' ) ( 'E' | 'e' ) ( 'R' | 'r' )  ;";
+        }
+        else
+        {
+            firstKeyword = "UNION : ( 'U' | 'u' ) ( 'N' | 'n' ) ( 'I' | 'i' ) ( 'O' | 'o' ) ( 'N' | 'n' )  ;";
+            original = original.replace( "( ws )* ", " " );
+        }
+        int startOfKeywords = original.indexOf( firstKeyword );
         int endOfKeywords = original.indexOf( "fragment" );
 
         String everythingAfterKeywords = original.substring( endOfKeywords );

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4Massager.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4Massager.java
@@ -39,7 +39,6 @@ class Antlr4Massager
         else
         {
             firstKeyword = "UNION : ( 'U' | 'u' ) ( 'N' | 'n' ) ( 'I' | 'i' ) ( 'O' | 'o' ) ( 'N' | 'n' )  ;";
-            original = original.replace( "( ws )* ", " " );
         }
         int startOfKeywords = original.indexOf( firstKeyword );
         int endOfKeywords = original.indexOf( "fragment" );

--- a/tools/grammar/src/main/shell/launch.sh
+++ b/tools/grammar/src/main/shell/launch.sh
@@ -38,7 +38,7 @@ PARAMETERS=
 while [[ $# -gt 1 ]]; do
     case "$1" in
         --*=*)
-            PARAMETERS="$PARAMETERS -D$COMMAND.${1:2}"
+            PARAMETERS="$PARAMETERS -D${1:2}"
         ;;
         -*=*)
             PARAMETERS="$PARAMETERS -D$COMMAND.${1:1}"

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4ParserTest.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4ParserTest.java
@@ -117,14 +117,14 @@ public class Antlr4ParserTest
         public void reportAttemptingFullContext( Parser parser, DFA dfa, int i, int i1, BitSet bitSet,
                 ATNConfigSet atnConfigSet )
         {
-            System.err.println( "attempting full context due to SLL conflict in query: " + query );
+//            System.err.println( "attempting full context due to SLL conflict in query: " + query );
         }
 
         @Override
         public void reportContextSensitivity( Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atnConfigSet )
         {
             // We're fine with context sensitivity, right?
-            System.err.println( "context sensitivity in query: " + query );
+//            System.err.println( "context sensitivity in query: " + query );
         }
     }
 

--- a/tools/grammar/src/test/resources/cypher-legacy.txt
+++ b/tools/grammar/src/test/resources/cypher-legacy.txt
@@ -1,0 +1,43 @@
+CREATE ()§
+CREATE( )§
+CYPHER 3.0 MATCH (n) RETURN n§
+CREATE (n:Person { name : 'Andres', title : 'Developer' })§
+MATCH (node1:Label1)
+
+WHERE node1.propertyA = {value}
+
+RETURN node2.propertyA, node2.propertyB§
+MATCH (tom:Person)-[:ACTED_IN]->(tomHanksMovies) RETURN tom§
+MATCH (tom:Person)  -[:ACTED_IN]->(tomHanksMovies) RETURN tom§
+MATCH (tom:Person  )-[:ACTED_IN]->(tomHanksMovies) RETURN tom§
+match(n)return n        §
+WITH range(2011, 2014) AS years, range(1,12) as months
+FOREACH(year IN years |
+  MERGE (y:Year {year: year})
+  FOREACH(month IN months |
+    CREATE (m:Month {month: month})
+    MERGE (y)-[:HAS_MONTH]->(m)
+    FOREACH(day IN (CASE
+                      WHEN month IN [1,3,5,7,8,10,12] THEN range(1,31)
+                      WHEN month = 2 THEN
+                        CASE
+                          WHEN year % 4 <> 0 THEN range(1,28)
+                          WHEN year % 100 <> 0 THEN range(1,29)
+                          WHEN year % 400 <> 0 THEN range(1,29)
+                          ELSE range(1,28)
+                        END
+                      ELSE range(1,30)
+                    END) |
+      CREATE (dd:Day {day: day})
+      MERGE (m)-[:HAS_DAY]->(dd))))
+
+WITH *
+
+MATCH (year:Year)-[:HAS_MONTH]->(month)-[:HAS_DAY]->(day)
+WITH year,month,day
+ORDER BY year.year, month.month, day.day
+WITH collect(day) as days
+FOREACH(i in RANGE(0, length(days) - 2) |
+    FOREACH(day1 in [days[i]] |
+        FOREACH(day2 in [days[i + 1]] |
+            CREATE UNIQUE (day1)-[:NEXT]->(day2))))§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -1,6 +1,5 @@
 CREATE ()§
 CREATE( )§
-CYPHER 3.0 MATCH (n) RETURN n§
 CREATE (n:Person { name : 'Andres', title : 'Developer' })§
 MATCH (node1:Label1)
 
@@ -11,33 +10,3 @@ MATCH (tom:Person)-[:ACTED_IN]->(tomHanksMovies) RETURN tom§
 MATCH (tom:Person)  -[:ACTED_IN]->(tomHanksMovies) RETURN tom§
 MATCH (tom:Person  )-[:ACTED_IN]->(tomHanksMovies) RETURN tom§
 match(n)return n        §
-WITH range(2011, 2014) AS years, range(1,12) as months
-FOREACH(year IN years |
-  MERGE (y:Year {year: year})
-  FOREACH(month IN months |
-    CREATE (m:Month {month: month})
-    MERGE (y)-[:HAS_MONTH]->(m)
-    FOREACH(day IN (CASE
-                      WHEN month IN [1,3,5,7,8,10,12] THEN range(1,31)
-                      WHEN month = 2 THEN
-                        CASE
-                          WHEN year % 4 <> 0 THEN range(1,28)
-                          WHEN year % 100 <> 0 THEN range(1,29)
-                          WHEN year % 400 <> 0 THEN range(1,29)
-                          ELSE range(1,28)
-                        END
-                      ELSE range(1,30)
-                    END) |
-      CREATE (dd:Day {day: day})
-      MERGE (m)-[:HAS_DAY]->(dd))))
-
-WITH *
-
-MATCH (year:Year)-[:HAS_MONTH]->(month)-[:HAS_DAY]->(day)
-WITH year,month,day
-ORDER BY year.year, month.month, day.day
-WITH collect(day) as days
-FOREACH(i in RANGE(0, length(days) - 2) |
-    FOREACH(day1 in [days[i]] |
-        FOREACH(day2 in [days[i + 1]] |
-            CREATE UNIQUE (day1)-[:NEXT]->(day2))))§


### PR DESCRIPTION
The openCypher grammar should reflect which parts of the Cypher language
that are standardized. To allow tool authors to still write tools for the de facto
grammar used by the only known Cypher implementation (Neo4j), rules are
not removed, but marked.

The default use is to ignore legacy rules, but supplying an option
`-DINCLUDE_LEGACY="true"` (or set the java property directly) will include
legacy rules.