### PR TITLE
Update TCK and grammar with new parameter syntax

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -130,6 +130,7 @@
     <alt>
       <non-terminal ref="MapLiteral"/>
       <non-terminal ref="Parameter"/>
+      <non-terminal ref="LegacyParameter"/>
     </alt>
   </production>
 
@@ -249,6 +250,7 @@
       <non-terminal ref="NumberLiteral"/>
       <non-terminal ref="StringLiteral"/>
       <non-terminal ref="Parameter"/>
+      <non-terminal ref="LegacyParameter"/>
       TRUE
       FALSE
       NULL
@@ -402,13 +404,21 @@
     }
   </production>
 
-  <production name="Parameter">
+  <production name="LegacyParameter" oc:legacy="true">
     { &WS;
     <alt>
       <non-terminal ref="SymbolicName"/>
       <non-terminal ref="DecimalInteger"/>
     </alt>
     &WS; }
+  </production>
+
+  <production name="Parameter">
+    $
+    <alt>
+      <non-terminal ref="SymbolicName"/>
+      <non-terminal ref="DecimalInteger"/>
+    </alt>
   </production>
 
   <production name="PropertyExpression">

--- a/grammar/start.xml
+++ b/grammar/start.xml
@@ -68,7 +68,7 @@
     ( <non-terminal ref="SymbolicName" rr:title="property key"/> =
     <alt>
       <non-terminal ref="StringLiteral"/>
-      <non-terminal ref="Parameter"/>
+      <non-terminal ref="LegacyParameter"/>
     </alt>)
   </production>
 
@@ -76,14 +76,14 @@
     : <non-terminal ref="SymbolicName" rr:title="index name"/>
     (<alt>
       <non-terminal ref="StringLiteral"/>
-      <non-terminal ref="Parameter"/>
+      <non-terminal ref="LegacyParameter"/>
     </alt>)
   </production>
 
   <production name="IdLookup" oc:legacy="true">
     (<alt>
       <non-terminal ref="LiteralIds"/>
-      <non-terminal ref="Parameter"/>
+      <non-terminal ref="LegacyParameter"/>
       *
     </alt>)
   </production>

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -32,7 +32,7 @@ Scenario: Creating a node
       | parameter | 0 |
     When executing query:
       """
-      CREATE ({property: {parameter}}) // <4>
+      CREATE ({property: $parameter}) // <4>
       """
     Then the result should be empty // <5>
     And the side effects should be: // <6>

--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -236,7 +236,7 @@ Feature: DeleteAcceptance
       """
       MATCH (:User)-[:FRIEND]->(n)
       WITH collect(n) AS friends
-      DETACH DELETE friends[{friendIndex}]
+      DETACH DELETE friends[$friendIndex]
       """
     Then the result should be empty
     And the side effects should be:
@@ -259,7 +259,7 @@ Feature: DeleteAcceptance
       """
       MATCH (:User)-[:FRIEND]->(n)
       WITH collect(n) AS friends
-      DETACH DELETE friends[{friendIndex}]
+      DETACH DELETE friends[$friendIndex]
       """
     Then the result should be empty
     And the side effects should be:
@@ -282,7 +282,7 @@ Feature: DeleteAcceptance
       """
       MATCH (:User)-[r:FRIEND]->()
       WITH collect(r) AS friendships
-      DETACH DELETE friendships[{friendIndex}]
+      DETACH DELETE friendships[$friendIndex]
       """
     Then the result should be empty
     And the side effects should be:

--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -64,7 +64,7 @@ Feature: ExpressionAcceptance
       | idx  | 'name'        |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx] AS value
       """
     Then the result should be:
@@ -78,7 +78,7 @@ Feature: ExpressionAcceptance
     When executing query:
       """
       CREATE (n {name: 'Apa'})
-      RETURN n[{idx}] AS value
+      RETURN n[$idx] AS value
       """
     Then the result should be:
       | value |
@@ -93,7 +93,7 @@ Feature: ExpressionAcceptance
       | idx  | 'name'        |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[toString(idx)] AS value
       """
     Then the result should be:
@@ -107,7 +107,7 @@ Feature: ExpressionAcceptance
       | idx  | 0       |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx] AS value
       """
     Then the result should be:
@@ -121,7 +121,7 @@ Feature: ExpressionAcceptance
     When executing query:
       """
       WITH ['Apa'] AS expr
-      RETURN expr[{idx}] AS value
+      RETURN expr[$idx] AS value
       """
     Then the result should be:
       | value |
@@ -134,7 +134,7 @@ Feature: ExpressionAcceptance
       | idx  | 0       |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[toInteger(idx)] AS value
       """
     Then the result should be:
@@ -148,7 +148,7 @@ Feature: ExpressionAcceptance
       | idx  | 0             |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
@@ -159,7 +159,7 @@ Feature: ExpressionAcceptance
       | idx  | 12.3          |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
@@ -170,7 +170,7 @@ Feature: ExpressionAcceptance
       | idx  | 'name'  |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
@@ -181,7 +181,7 @@ Feature: ExpressionAcceptance
       | idx  | ['Apa'] |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
@@ -200,7 +200,7 @@ Feature: ExpressionAcceptance
       | idx  | 0   |
     When executing query:
       """
-      WITH {expr} AS expr, {idx} AS idx
+      WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: InvalidElementAccess

--- a/tck/features/FunctionsAcceptance.feature
+++ b/tck/features/FunctionsAcceptance.feature
@@ -215,7 +215,7 @@ Feature: FunctionsAcceptance
     When executing query:
       """
       MATCH (n)
-      RETURN percentileDisc(n.prop, {percentile}) AS p
+      RETURN percentileDisc(n.prop, $percentile) AS p
       """
     Then the result should be:
       | p        |
@@ -241,7 +241,7 @@ Feature: FunctionsAcceptance
     When executing query:
       """
       MATCH (n)
-      RETURN percentileCont(n.prop, {percentile}) AS p
+      RETURN percentileCont(n.prop, $percentile) AS p
       """
     Then the result should be:
       | p        |
@@ -265,7 +265,7 @@ Feature: FunctionsAcceptance
     When executing query:
       """
       MATCH (n)
-      RETURN percentileCont(n.prop, {param})
+      RETURN percentileCont(n.prop, $param)
       """
     Then a ArgumentError should be raised at runtime: NumberOutOfRange
 
@@ -286,7 +286,7 @@ Feature: FunctionsAcceptance
     When executing query:
       """
       MATCH (n)
-      RETURN percentileDisc(n.prop, {param})
+      RETURN percentileDisc(n.prop, $param)
       """
     Then a ArgumentError should be raised at runtime: NumberOutOfRange
 

--- a/tck/features/KeysAcceptance.feature
+++ b/tck/features/KeysAcceptance.feature
@@ -154,7 +154,7 @@ Feature: KeysAcceptance
       | param | {name: 'Alice', age: 38, address: {city: 'London', residential: true}} |
     When executing query:
       """
-      RETURN keys({param}) AS k
+      RETURN keys($param) AS k
       """
     Then the result should be (ignoring element order for lists):
       | k                          |

--- a/tck/features/MatchAcceptance.feature
+++ b/tck/features/MatchAcceptance.feature
@@ -145,7 +145,7 @@ Feature: MatchAcceptance
     When executing query:
       """
       MATCH (a)-[r]->(b)
-      WHERE r.foo = {param}
+      WHERE r.foo = $param
       RETURN b
       """
     Then the result should be:

--- a/tck/features/MatchAcceptance2.feature
+++ b/tck/features/MatchAcceptance2.feature
@@ -790,8 +790,8 @@ Feature: MatchAcceptance2
     When executing query:
       """
       MATCH (advertiser)-[:ADV_HAS_PRODUCT]->(out)-[:AP_HAS_VALUE]->(red)<-[:AA_HAS_VALUE]-(a)
-      WHERE advertiser.id = {1}
-        AND a.id = {2}
+      WHERE advertiser.id = $1
+        AND a.id = $2
         AND red.name = 'red'
         AND out.name = 'product1'
       RETURN out.name

--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -271,7 +271,7 @@ Feature: OrderByAcceptance
       MATCH (p:Person)
       RETURN p.name AS name
       ORDER BY p.name
-      LIMIT {limit}
+      LIMIT $limit
       """
     Then the result should be, in order:
       | name |

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -97,7 +97,7 @@ Feature: ReturnAcceptanceTest
       MATCH (n)
       RETURN n
       ORDER BY n.name ASC
-      SKIP {skipAmount}
+      SKIP $skipAmount
       """
     Then the result should be, in order:
       | n             |
@@ -148,8 +148,8 @@ Feature: ReturnAcceptanceTest
       MATCH (n)
       RETURN n
       ORDER BY n.name ASC
-      SKIP {s}
-      LIMIT {l}
+      SKIP $s
+      LIMIT $l
       """
     Then the result should be, in order:
       | n             |

--- a/tck/features/TernaryLogicAcceptance.feature
+++ b/tck/features/TernaryLogicAcceptance.feature
@@ -76,7 +76,7 @@ Feature: TernaryLogicAcceptanceTest
       | rhs | <rhs> |
     When executing query:
       """
-      RETURN {lhs} AND {rhs} AS result
+      RETURN $lhs AND $rhs AS result
       """
     Then the result should be:
       | result   |
@@ -97,7 +97,7 @@ Feature: TernaryLogicAcceptanceTest
       | rhs | <rhs> |
     When executing query:
       """
-      RETURN {lhs} OR {rhs} AS result
+      RETURN $lhs OR $rhs AS result
       """
     Then the result should be:
       | result   |
@@ -116,10 +116,9 @@ Feature: TernaryLogicAcceptanceTest
     And parameters are:
       | lhs    | <lhs>    |
       | rhs    | <rhs>    |
-      | result | <result> |
     When executing query:
       """
-      RETURN {lhs} XOR {rhs} AS result
+      RETURN $lhs XOR $rhs AS result
       """
     Then the result should be:
       | result   |
@@ -138,10 +137,9 @@ Feature: TernaryLogicAcceptanceTest
     And parameters are:
       | elt    | <elt>    |
       | coll   | <coll>   |
-      | result | <result> |
     When executing query:
       """
-      RETURN {elt} IN {coll} AS result
+      RETURN $elt IN $coll AS result
       """
     Then the result should be:
       | result   |

--- a/tck/features/UnwindAcceptance.feature
+++ b/tck/features/UnwindAcceptance.feature
@@ -107,7 +107,7 @@ Feature: UnwindAcceptance
       | events | [{year: 2016, id: 1}, {year: 2016, id: 2}] |
     When executing query:
       """
-      UNWIND {events} AS event
+      UNWIND $events AS event
       MATCH (y:Year {year: event.year})
       MERGE (e:Event {id: event.id})
       MERGE (y)<-[:IN]-(e)
@@ -251,7 +251,7 @@ Feature: UnwindAcceptance
       | props | [{login: 'login1', name: 'name1'}, {login: 'login2', name: 'name2'}] |
     When executing query:
       """
-      UNWIND {props} AS prop
+      UNWIND $props AS prop
       MERGE (p:Person {login: prop.login})
       SET p.name = prop.name
       RETURN p.name, p.login

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -3,7 +3,7 @@ CREATE( )§
 CREATE (n:Person { name : 'Andres', title : 'Developer' })§
 MATCH (node1:Label1)
 
-WHERE node1.propertyA = {value}
+WHERE node1.propertyA = $value
 
 RETURN node2.propertyA, node2.propertyB§
 MATCH (tom:Person)-[:ACTED_IN]->(tomHanksMovies) RETURN tom§


### PR DESCRIPTION
Replaces `{}` with `$` for parameters.