### PR TITLE
gitignore: grammar/generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 target
 out
 .DS_Store
+# Generated grammar artifacts go here locally, but not to git.
+/grammar/generated


### PR DESCRIPTION
Just to make sure generated grammar artifacts don't show up in the "git status", nor in the repository.