### PR TITLE
Grammar prohibits using whitespace in count(*) atom

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -255,7 +255,7 @@
       FALSE
       NULL
       <non-terminal ref="CaseExpression"/>
-      <seq>COUNT ( * )</seq>
+      <seq>COUNT &WS; ( &WS; * &WS; )</seq>
       <non-terminal ref="MapLiteral"/>
       <non-terminal ref="ListComprehension"/>
       <seq> [ &WS; &expr; &WS; <repeat> , &WS; &expr; &WS; </repeat> ] </seq>

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -64,3 +64,12 @@ RETURN toInteger ()§
 RETURN toInteger ( )§
 RETURN toInteger   ()§
 RETURN toInteger   (  )§
+MATCH (n) RETURN cOuNt(*)§
+MATCH (n) RETURN cOuNt( * )§
+MATCH (n) RETURN cOuNt( *)§
+MATCH (n) RETURN cOuNt(* )§
+MATCH (n) RETURN cOuNt (*)§
+MATCH (n) RETURN cOuNt ( * )§
+MATCH (n) RETURN cOuNt ( *)§
+MATCH (n) RETURN cOuNt (* )§
+MATCH (n) RETURN cOuNt  (*)§


### PR DESCRIPTION
See opencypher/openCypher#137