### PR TITLE
Rework whitespace handling in grammar not to include unnecessary ws nodes

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<non-terminal ref='WS'/>">
+  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY expr "<non-terminal ref='Expression'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
@@ -569,7 +569,7 @@
   </production>
 
   <production name="WS" rr:skip="true">
-    <repeat><non-terminal ref='whitespace'/></repeat>
+    <repeat min="1"><non-terminal ref='whitespace'/></repeat>
   </production>
 
   <production name="SP" rr:skip="true">

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
+  <!ENTITY WS "<opt><non-terminal ref='SP'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY expr "<non-terminal ref='Expression'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
@@ -566,10 +566,6 @@
     <repeat min="1">
       ` <repeat><character><except literal="`"/></character></repeat> `
     </repeat>
-  </production>
-
-  <production name="WS" rr:skip="true">
-    <repeat min="1"><non-terminal ref='whitespace'/></repeat>
   </production>
 
   <production name="SP" rr:skip="true">

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<non-terminal ref='WS'/>">
+  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
   <!ENTITY node "(&WS;)">

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
+  <!ENTITY WS "<opt><non-terminal ref='SP'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
   <!ENTITY node "(&WS;)">

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<non-terminal ref='WS'/>">
+  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY expr "<non-terminal ref='Expression'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
+  <!ENTITY WS "<opt><non-terminal ref='SP'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY expr "<non-terminal ref='Expression'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">

--- a/grammar/pre-parser.xml
+++ b/grammar/pre-parser.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<non-terminal ref='WS'/>">
+  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
 ]>
 <grammar language="Cypher Pre-Parser"

--- a/grammar/pre-parser.xml
+++ b/grammar/pre-parser.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
+  <!ENTITY WS "<opt><non-terminal ref='SP'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
 ]>
 <grammar language="Cypher Pre-Parser"

--- a/grammar/start.xml
+++ b/grammar/start.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
+  <!ENTITY WS "<opt><non-terminal ref='SP'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
 ]>

--- a/grammar/start.xml
+++ b/grammar/start.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <!DOCTYPE grammar [
-  <!ENTITY WS "<non-terminal ref='WS'/>">
+  <!ENTITY WS "<opt><non-terminal ref='WS'/></opt>">
   <!ENTITY SP "<non-terminal ref='SP'/>">
   <!ENTITY var "<non-terminal ref='Variable'/>">
 ]>


### PR DESCRIPTION
Fixes opencypher/openCypher#140

Should be merged after opencypher/openCypher#138.

known bug: this creates weird thing in the railroad diagram (see image attached) as SP has rr:skip="true", but its optional routes are shown.

![railroad-diagram-issue](https://cloud.githubusercontent.com/assets/10688599/18321026/9422cf86-752c-11e6-9e25-5d4bd05464e5.png)
