### PR TITLE
Align `CONTAINS` et al with comparability

### DIFF
--- a/cip/2.testable/CIP2015-09-15-STARTS-WITH-and-ENDS-WITH.adoc
+++ b/cip/2.testable/CIP2015-09-15-STARTS-WITH-and-ENDS-WITH.adoc
@@ -82,6 +82,12 @@ contains      = expression, “CONTAINS” expression ;
 
 === Semantics
 
+All three proposed operators are defined as _comparison operators_ on string operands.
+As such, behavioural semantics need to be in line with what is detailed by the link:https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc[Comparability CIP].
+This has the following consequence:
+
+- If any argument to `STARTS WITH`, `ENDS WITH`, or `CONTAINS` is `null` or not a string, then the result of evaluating the whole predicate is `null`.
+
 ==== STARTS WITH
 Using `lhs STARTS WITH rhs` requires both `lhs` and `rhs` to be strings. This new expression evaluates to true if `lhs` textually starts with `rhs`. Otherwise, it is false.
 
@@ -90,10 +96,6 @@ Using `lhs ENDS WITH rhs` requires both `lhs` and `rhs` to be strings. This new 
 
 ==== CONTAINS
 Using `lhs CONTAINS rhs` requires both `lhs` and `rhs` to be strings. This new expression evaluates to true if `lhs` textually contains `rhs`. Otherwise, it is false.
-
-If any argument to `STARTS WITH`, `ENDS WITH`, or `CONTAINS` is `NULL`, then the result of evaluating the whole predicate is `NULL`.
-
-It is a type error to use `STARTS WITH`, `ENDS WITH`, or `CONTAINS` with a value that is not a string.
 
 === Alternatives
 

--- a/cip/2.testable/CIP2015-09-15-STARTS-WITH-and-ENDS-WITH.adoc
+++ b/cip/2.testable/CIP2015-09-15-STARTS-WITH-and-ENDS-WITH.adoc
@@ -33,30 +33,34 @@ This CIP follows a more focused approach by adding explicit operators for common
 === Examples
 
 [source, cypher]
-.Find all persons whose name starts with `"And"`
+.Find all persons whose name starts with `'And'`
 ----
-MATCH (a:Person) WHERE a.name STARTS WITH "And"
+MATCH (a:Person)
+WHERE a.name STARTS WITH 'And'
 RETURN a
 ----
 
 [source, cypher]
 .Find all persons whose name starts with the parameter `prefix`
 ----
-MATCH (a:Person) WHERE a.name STARTS WITH {prefix}
+MATCH (a:Person)
+WHERE a.name STARTS WITH $prefix
 RETURN a
 ----
 
 [source, cypher]
-.Find all persons whose name ends with `"fan"`
+.Find all persons whose name ends with `'fan'`
 ----
-MATCH (a:Person) WHERE a.name ENDS WITH “fan”
+MATCH (a:Person)
+WHERE a.name ENDS WITH 'fan'
 RETURN a
 ----
 
 [source, cypher]
-.Find all books whose isbn in string form contains `"007"`
+.Find all books whose isbn in string form contains `'007'`
 ----
-MATCH (b:Book) WHERE toString(b.isbn) CONTAINS “007”
+MATCH (b:Book)
+WHERE toString(b.isbn) CONTAINS '007'
 RETURN a
 ----
 
@@ -93,7 +97,7 @@ It is a type error to use `STARTS WITH`, `ENDS WITH`, or `CONTAINS` with a value
 
 === Alternatives
 
-* link:https://docs.google.com/document/d/1eXhnAS2KmpiAhFTeWssf3s5LrLzUM59B39WJbXa1z_0/edit?usp=sharing[LIKE] with link:https://docs.google.com/document/d/1hq-Pu7igb1aFdFZtVCnG59D1_QuqnzsBLPYm7dqpKwg/edit?usp=sharing[String interpolation] (rejected as described in the <<motivation-and-background>> section.
+* link:https://docs.google.com/document/d/1eXhnAS2KmpiAhFTeWssf3s5LrLzUM59B39WJbXa1z_0/edit?usp=sharing[LIKE] with link:https://docs.google.com/document/d/1hq-Pu7igb1aFdFZtVCnG59D1_QuqnzsBLPYm7dqpKwg/edit?usp=sharing[String interpolation] (rejected as described in the <<motivation-and-background>> section).
 * Rely on regular expressions only (difficult for the same reasons as LIKE).
 
 == What others do

--- a/tck/features/StartsWithAcceptance.feature
+++ b/tck/features/StartsWithAcceptance.feature
@@ -316,3 +316,45 @@ Feature: StartsWithAcceptance
       | (:Label {name: 'AB'})     |
       | (:Label {name: ''})       |
     And no side effects
+
+  Scenario: Handling non-string operands for STARTS WITH
+    When executing query:
+      """
+      WITH [1, 3.14, true, [], {}, null] AS operands
+      UNWIND operands AS op1
+      UNWIND operands AS op2
+      WITH op1 STARTS WITH op2 AS v
+      RETURN v, count(*)
+      """
+    Then the result should be:
+      | v    | count(*) |
+      | null | 36       |
+    And no side effects
+
+  Scenario: Handling non-string operands for CONTAINS
+    When executing query:
+      """
+      WITH [1, 3.14, true, [], {}, null] AS operands
+      UNWIND operands AS op1
+      UNWIND operands AS op2
+      WITH op1 STARTS WITH op2 AS v
+      RETURN v, count(*)
+      """
+    Then the result should be:
+      | v    | count(*) |
+      | null | 36       |
+    And no side effects
+
+  Scenario: Handling non-string operands for ENDS WITH
+    When executing query:
+      """
+      WITH [1, 3.14, true, [], {}, null] AS operands
+      UNWIND operands AS op1
+      UNWIND operands AS op2
+      WITH op1 STARTS WITH op2 AS v
+      RETURN v, count(*)
+      """
+    Then the result should be:
+      | v    | count(*) |
+      | null | 36       |
+    And no side effects


### PR DESCRIPTION
With the introduction of the thorough definition of comparability, we need to sort these operators in line to achieve consistency.