### PR TITLE
Introduce notion of abstract vs concrete types

### DIFF
--- a/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
+++ b/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
@@ -68,12 +68,21 @@ Note that `NULL` is not a type but a value that inhabits every nullable type.
 Every nullable type is a supertype of its underlying material type, i.e. `T?` is a supertype of `T`.
 By transitivity of subtyping, if `S` is a supertype of `T`, then `S?` is also a supertype of `T`.
 
+==== Abstract and concrete types
+
+An _abstract_ type is a type that does not have any direct association to a value.
+This is in contrast to a _concrete_ type, which does have such an association.
+In other words, an abstract type may not be instantiated, while a concrete type may.
+
+It is observed that any nullable type is also concrete, because `null` is a value that is directly associated with it.
+
 ==== Any type
 
 The following super types should be supported by any implementation of Cypher:
 
 * `ANY`
 ** The `ANY` type is the parent of all material types.
+** `ANY` is an abstract type.
 * `ANY?`
 ** By definition and as a consequence of subtyping rules for nullable types, `ANY?` is the most generic type available within Cypher and is the supertype of every material and nullable type and the type inhibited by all valid Cypher values.
 
@@ -88,6 +97,7 @@ a nullable variant:
  ** Unicode Strings, i.e. `"Cypher"`, and `‘text’`
  * `NUMBER`
  ** Parent of all numeric types (i.e. `INTEGER` and `FLOAT`)
+ ** `NUMBER` is an abstract type.
  * `INTEGER`
  ** Exact numbers without decimals, i.e. -3, 0, 4
  * `FLOAT`

--- a/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
+++ b/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
@@ -54,16 +54,16 @@ The section below presents presents the new Public Type System (PTS) proposed fo
 
 ==== Material and nullable types
 
-The type system provides a way to track nullability, i.e. a type may express if a given expression may be `NULL` or not.
-Tracking (non-)nullability helps an implementation to detect and warn about possible user errors during compile time and  it also enables optimizations that rely on values not being `NULL`. As an example, an implementation may infer that `MATCH` will never introduce a nullable variable, but `OPTIONAL MATCH` will only introduce nullable variables.
+The type system provides a way to track nullability, i.e. a type may express if a given expression may be `null` or not.
+Tracking (non-)nullability helps an implementation to detect and warn about possible user errors during compile time and  it also enables optimizations that rely on values not being `null`. As an example, an implementation may infer that `MATCH` will never introduce a nullable variable, but `OPTIONAL MATCH` will only introduce nullable variables.
 
-Material types are all types that do not permit `NULL` as a valid result of evaluating the underlying expression.
+Material types are all types that do not permit `null` as a valid result of evaluating the underlying expression.
 In the sections below, generally only the material variants of each type are given.
 
-Nullable types are all types that do permit `NULL` as a valid result of evaluating the underlying expression.
+Nullable types are all types that do permit `null` as a valid result of evaluating the underlying expression.
 Nullable type names are formed by suffixing a material type name with a single question mark (without in-between whitespace).
 Nullable variants of all material types should be supported by any implementation of Cypher.
-Note that `NULL` is not a type but a value that inhabits every nullable type.
+Note that `null` is not a type but a value that inhabits every nullable type.
 
 Every nullable type is a supertype of its underlying material type, i.e. `T?` is a supertype of `T`.
 By transitivity of subtyping, if `S` is a supertype of `T`, then `S?` is also a supertype of `T`.
@@ -92,9 +92,9 @@ The following scalar types should be supported by any implementation of Cypher, 
 a nullable variant:
 
  * `BOOLEAN`
- ** true and false. Note that Cypher uses ternary logic in `WHERE` and hence the type of predicate expressions is generally `BOOLEAN?` with `NULL` indicating lack of information (the unknown state of ternary logic).
+ ** true and false. Note that Cypher uses ternary logic in `WHERE` and hence the type of predicate expressions is generally `BOOLEAN?` with `null` indicating lack of information (the unknown state of ternary logic).
  * `STRING`
- ** Unicode Strings, i.e. `"Cypher"`, and `‘text’`
+ ** Unicode Strings, i.e. `'Cypher'`, and `‘text’`
  * `NUMBER`
  ** Parent of all numeric types (i.e. `INTEGER` and `FLOAT`)
  ** `NUMBER` is an abstract type.
@@ -126,10 +126,10 @@ The following container types should be supported by any implementation of Cyphe
 a nullable variant:
 
 * `LIST OF T`
-** Lists (ordered sequences with random access) of elements of a given material or nullable type `T`. The syntax for a nullable lists of elements of type `T` is `LIST? OF T`. Note that accessing a list by index always yields a value of type `T?` since indexing out of bounds is defined to return `NULL`.
+** Lists (ordered sequences with random access) of elements of a given material or nullable type `T`. The syntax for a nullable lists of elements of type `T` is `LIST? OF T`. Note that accessing a list by index always yields a value of type `T?` since indexing out of bounds is defined to return `null`.
 ** `LIST OF T2` is a subtype of `LIST OF T1` if `T2` is a subtype of `T1`. This is a valid subtyping rule since values in Cypher are immutable. Adding an element of type `T` to a `LIST OF S` would produce a new list of type `LIST OF R`, where `R` is the nearest common supertype of `T` and `S`
 * `MAP`
-** Maps from string keys to values of any type, i.e. `{ name: "Svensson" }`. The type of map values is `ANY?` since it is unknown to the type system if a given map contains a certain key or not. Note also that maps do not distinguish between missing keys and keys that map to a `NULL` value. `MAP` is a parent to all property containers, like `NODE` and `RELATIONSHIP`.
+** Maps from string keys to values of any type, i.e. `{ name: 'Svensson' }`. The type of map values is `ANY?` since it is unknown to the type system if a given map contains a certain key or not. Note also that maps do not distinguish between missing keys and keys that map to a `null` value. `MAP` is a parent to all property containers, like `NODE` and `RELATIONSHIP`.
 
 ==== Graph Types
 
@@ -145,7 +145,7 @@ a nullable variant:
 
 ==== Void type
 
-This CIP also introduces an additional nullable type called `VOID`. `VOID` is intended to be used as the return type of user defined procedures that execute without producing a result value, i.e. the return type of procedures with side effects. `VOID` is a subtype of `ANY?`. In an expression context, `NULL` is the only value that inhibits the `VOID` type, indicating a missing "real" return value (Note though that Cypher currently does not have any expressions of type `VOID` and this is merely defined here for completeness).
+This CIP also introduces an additional nullable type called `VOID`. `VOID` is intended to be used as the return type of user defined procedures that execute without producing a result value, i.e. the return type of procedures with side effects. `VOID` is a subtype of `ANY?`. In an expression context, `null` is the only value that inhibits the `VOID` type, indicating a missing "real" return value (Note though that Cypher currently does not have any expressions of type `VOID` and this is merely defined here for completeness).
 
 === Type Annotation
 
@@ -404,4 +404,4 @@ This is why they have not been included in this proposal.
 They could be added instead at a later stage.
 
 *Example*
-`RETURN [1, "Yo"] :: LIST OF (STRING | NUMBER)`
+`RETURN [1, 'Yo'] :: LIST OF (STRING | NUMBER)`

--- a/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
+++ b/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
@@ -70,11 +70,10 @@ By transitivity of subtyping, if `S` is a supertype of `T`, then `S?` is also a 
 
 ==== Abstract and concrete types
 
-An _abstract_ type is a type that does not have any direct association to a value.
-This is in contrast to a _concrete_ type, which does have such an association.
-In other words, an abstract type may not be instantiated, while a concrete type may.
+An _abstract_ type is a type that is not directly associated with a value, and thus may not be instantiated.
+This is in contrast to a _concrete_ type.
 
-It is observed that any nullable type is also concrete, because `null` is a value that is directly associated with it.
+We observe that any nullable type is also concrete as `null` is a value that is directly associated with it.
 
 ==== Any type
 


### PR DESCRIPTION
In the drafting of the Property Graph Model I found I wanted to define property values as being of the _scalar, concrete_ Cypher types, at which point I saw we lacked specifying the notion of abstractness for our types. This PR suggests adding them.