### PR TITLE
Reserved words

### DIFF
--- a/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
+++ b/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
@@ -1,0 +1,163 @@
+= CIP2016-12-19-Reserved-keywords
+:numbered:
+:toc:
+:toc-placement: macro
+:source-highlighter: codemirror
+
+*Author:* Mats Rydberg <mats@neotechnology.com>
+
+[abstract]
+.Abstract
+--
+Similarly to many programming languages, Cypher has a notion of keywords, which is a word that has special meaning within the language.
+Historically, and in contrast to many other languages, these words have been allowed to be used as symbolic names.
+This is poor practice, as it opens up for users to write hard-to-read and possibly ambiguous statements.
+This CIP defines a set of reserved words and proposes that they be disallowed from being used as symbolic names.
+--
+
+toc::[]
+
+
+== Motivation
+
+Consider the following, syntactically and semantically correct query:
+
+[source, cypher]
+----
+MATCH (null)-[:MERGE]->(true)
+WITH null.delete AS with, `true`.false AS null
+RETURN 2 + with, coalesce(null, 3.1415)
+----
+
+Clearly, this query is poorly authored, and it would not be feasible to expect it to appear in real-world use, except as an example of poor usage of the language.
+However, there is little reason to allow this query to parse successfully in the first place, especially given the observation of its uselessness.
+In fact, most computer languages do limit the space of allowed symbolic names, or identifiers, by reserving a number of words from being used as such.
+
+An additional benefit from this proposal may be understood from a more technical point of view; parsing a language with fewer context-based grammatical rules, and more explicit rules for keywords and their allowed context(s) is generally easier.
+This approach is friendlier towards the increasing size of the Cypher audience.
+
+== Background
+
+Historically, Cypher has been liberally allowing any word as an identifier, relying on context to disambiguate between possible uses of a particular word.
+As Cypher matures towards becoming a standard language, however, a more generic model that aligns with users' expectations from the world of computer languages is preferable, and a grammar with more clear distinctions between identifiers and keywords would be a step in that direction.
+
+== Proposal
+
+The concrete proposal is a listing of _reserved words_ (see f.e. https://en.wikipedia.org/wiki/Reserved_word[Wikipedia's definition]), all of which have a special meaning in Cypher.
+These reserved words would be disallowed from being used as identifiers, in the following contexts:
+
+* Variables
+* Function names
+* Parameters
+
+By _escaping_ any of the reserved words (encapsulating in backticks ```), they would be valid as identifiers in the above contexts.
+
+==== Reserved words
+
+We group the reserved words by the three main classes of words that they draw from: keywords, operators, and literals.
+In addition to this, we list a number of words that are reserved for future use.
+
+===== Keywords
+
+* MATCH
+* WHERE
+* WITH
+* RETURN
+* SKIP
+* LIMIT
+* ORDER
+* BY
+* ASC
+* ASCENDING
+* DESC
+* DESCENDING
+* UNWIND
+* OPTIONAL
+* CREATE
+* DETACH
+* DELETE
+* SET
+* REMOVE
+* MERGE
+* ON
+* EXISTS
+* UNION
+* ALL
+
+===== Operators
+
+* AS
+* DISTINCT
+* AND
+* OR
+* XOR
+* NOT
+* STARTS
+* ENDS
+* CONTAINS
+* IN
+* IS
+
+===== Literals
+
+* null
+* true
+* false
+
+===== Reserved for future use
+
+* DO
+* FOR
+* REQUIRE
+* CONSTRAINT
+* UNIQUE
+
+==== Examples
+
+The query exemplified in <<Motivation>> would no longer be valid, but would have to be escaped:
+
+[source, cypher]
+----
+MATCH (`null`)-[:MERGE]->(`true`)
+WITH `null`.delete AS `with`, `true`.false AS `null`
+RETURN 2 + `with`, coalesce(`null`, 3.1415)
+----
+
+While not recommended, this query is still better than unescaped form, as it is clear to the reader that the literals and keywords used as variables do not represent their special meaning.
+
+The relationship type and the two property keys in this query still carry names that coincide with keywords and/or literals.
+We discuss this further below, in <<Alternatives>>.
+
+=== Interaction with existing features
+
+Provide details on any interactions that need to be considered.
+
+=== Alternatives
+
+This proposal could be extended with disallowing the reserved words also as:
+
+* Relationship types
+* Labels
+* Property keys
+
+However, these usages are only valid in very limited contexts, coupled with a special character (`:` or `.`), so the benefit would be minimal.
+Furthermore, these usages represent _schema_, which is a context in which it is arguably more important to provide higher degrees of freedom, than in a pure statement context.
+
+Another variation that may be taken is to not strictly forbid the future-reserved words, but just issue a strong recommendation to not use them.
+The trade-off in this case is between allowing more freedom for statements now and breaking statements in future language updates.
+
+== What others do
+
+
+
+== Benefits to this proposal
+
+The following benefits are envisioned:
+
+* Grammar would be easier to parse
+* Hard-to-read statements would be more difficult to write
+
+== Caveats to this proposal
+
+Several of the reserved words do represent general-purpose words that one would like to use as informative identifiers.
+This proposal would take away the ability to use these identifiers, meaning that some statements would be slightly more difficult to write.

--- a/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
+++ b/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
@@ -9,8 +9,8 @@
 [abstract]
 .Abstract
 --
-Along with many programming languages, Cypher has a notion of keywords, which is a word that has special meaning within the language.
-Historically, and in contrast to many other languages, these words have been allowed to be used as symbolic names.
+Along with many programming languages, Cypher has a notion of keywords, which are words that have special meaning within the language.
+Historically, and in contrast to many other languages, keywords have been allowed to be used as symbolic names.
 This is poor practice, as it allows users to write hard-to-read and possibly ambiguous statements.
 This CIP defines a set of reserved words and proposes that they be disallowed from being used as symbolic names.
 --
@@ -43,7 +43,7 @@ As Cypher matures towards becoming a standard language, however, a more generic 
 == Proposal
 
 The concrete proposal is a listing of _reserved words_ (see f.e. https://en.wikipedia.org/wiki/Reserved_word[Wikipedia's definition]), all of which have a special meaning in Cypher.
-These reserved words would be disallowed from being used as identifiers, in the following contexts:
+These reserved words would be disallowed from being used as identifiers in the following contexts:
 
 * Variables
 * Function names
@@ -58,57 +58,57 @@ In addition to this, we list a number of words that are reserved for future use.
 
 ===== Keywords
 
-* MATCH
-* WHERE
-* WITH
-* RETURN
-* SKIP
-* LIMIT
-* ORDER
-* BY
+* ALL
 * ASC
 * ASCENDING
+* BY
+* CREATE
+* DELETE
 * DESC
 * DESCENDING
-* UNWIND
-* OPTIONAL
-* CREATE
 * DETACH
-* DELETE
-* SET
-* REMOVE
+* EXISTS
+* LIMIT
+* MATCH
 * MERGE
 * ON
-* EXISTS
+* OPTIONAL
+* ORDER
+* REMOVE
+* RETURN
+* SET
+* SKIP
+* WHERE
+* WITH
 * UNION
-* ALL
+* UNWIND
 
 ===== Operators
 
-* AS
-* DISTINCT
 * AND
-* OR
-* XOR
-* NOT
-* STARTS
-* ENDS
+* AS
 * CONTAINS
+* DISTINCT
+* ENDS
 * IN
 * IS
+* NOT
+* OR
+* STARTS
+* XOR
 
 ===== Literals
 
+* false
 * null
 * true
-* false
 
 ===== Reserved for future use
 
+* CONSTRAINT
 * DO
 * FOR
 * REQUIRE
-* CONSTRAINT
 * UNIQUE
 
 ==== Examples
@@ -142,7 +142,7 @@ An extension to this proposal could disallow using the reserved words as:
 However, these usages are only valid in very limited contexts, coupled with a special character (`:` or `.`), so the benefit would be minimal.
 Furthermore, these usages represent _schema_, which is a context in which it is arguably more important to provide higher degrees of freedom, than in a pure statement context.
 
-Another variation that may be taken is to not strictly forbid the future-reserved words, but instead issue a strong recommendation to not use them.
+Another variation is not to strictly forbid any words earmarked to be reserved in the future, but instead issue a strong recommendation to not use them.
 The trade-off in this case is between allowing more freedom for statements now and breaking statements in future language updates.
 
 == What others do
@@ -165,4 +165,4 @@ The following benefits are envisioned:
 == Caveats to this proposal
 
 Several of the reserved words do represent general-purpose words that one may like to use as informative identifiers.
-This proposal would remove the ability to use these identifiers, meaning that some statements may be slightly more difficult to write.
+This proposal would remove the ability to use these identifiers, which may result in some statements becoming slightly more difficult to write.

--- a/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
+++ b/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
@@ -9,9 +9,9 @@
 [abstract]
 .Abstract
 --
-Similarly to many programming languages, Cypher has a notion of keywords, which is a word that has special meaning within the language.
+Along with many programming languages, Cypher has a notion of keywords, which is a word that has special meaning within the language.
 Historically, and in contrast to many other languages, these words have been allowed to be used as symbolic names.
-This is poor practice, as it opens up for users to write hard-to-read and possibly ambiguous statements.
+This is poor practice, as it allows users to write hard-to-read and possibly ambiguous statements.
 This CIP defines a set of reserved words and proposes that they be disallowed from being used as symbolic names.
 --
 
@@ -20,7 +20,7 @@ toc::[]
 
 == Motivation
 
-Consider the following, syntactically and semantically correct query:
+Consider the following query, which is syntactically and semantically correct:
 
 [source, cypher]
 ----
@@ -29,17 +29,16 @@ WITH null.delete AS with, `true`.false AS null
 RETURN 2 + with, coalesce(null, 3.1415)
 ----
 
-Clearly, this query is poorly authored, and it would not be feasible to expect it to appear in real-world use, except as an example of poor usage of the language.
-However, there is little reason to allow this query to parse successfully in the first place, especially given the observation of its uselessness.
-In fact, most computer languages do limit the space of allowed symbolic names, or identifiers, by reserving a number of words from being used as such.
+Clearly, this query is poorly authored, and is far from being a realistic example other than to exemplify bad practices in writing queries.
+However, there is little reason to allow this query to parse successfully in the first place.
+In fact, most programming languages reserve a set of keywords which are not permitted to be used as symbolic names or identifiers.
 
-An additional benefit from this proposal may be understood from a more technical point of view; parsing a language with fewer context-based grammatical rules, and more explicit rules for keywords and their allowed context(s) is generally easier.
-This approach is friendlier towards the increasing size of the Cypher audience.
+Additionally, a more technically-oriented benefit granted by this proposal is that parsing a language with fewer context-based grammatical rules, and more explicit rules for keywords and their allowed context(s), is generally easier.
 
 == Background
 
-Historically, Cypher has been liberally allowing any word as an identifier, relying on context to disambiguate between possible uses of a particular word.
-As Cypher matures towards becoming a standard language, however, a more generic model that aligns with users' expectations from the world of computer languages is preferable, and a grammar with more clear distinctions between identifiers and keywords would be a step in that direction.
+Historically, Cypher has liberally allowed any word to be used as an identifier, relying on context to disambiguate between possible uses of a particular word.
+As Cypher matures towards becoming a standard language, however, a more generic model that aligns with users' expectations from the world of programming languages is preferable, and a grammar with clearer distinctions between identifiers and keywords is a step in that direction.
 
 == Proposal
 
@@ -54,7 +53,7 @@ By _escaping_ any of the reserved words (encapsulating in backticks ```), they w
 
 ==== Reserved words
 
-We group the reserved words by the three main classes of words that they draw from: keywords, operators, and literals.
+We list the reserved words in the three categories from which they are drawn: keywords, operators, and literals.
 In addition to this, we list a number of words that are reserved for future use.
 
 ===== Keywords
@@ -123,9 +122,9 @@ WITH `null`.delete AS `with`, `true`.false AS `null`
 RETURN 2 + `with`, coalesce(`null`, 3.1415)
 ----
 
-While not recommended, this query is still better than unescaped form, as it is clear to the reader that the literals and keywords used as variables do not represent their special meaning.
+While not recommended, this query is still an improvement over the unescaped form, as it is clear to the reader that the literals and keywords used as variables do not represent their special meaning.
 
-The relationship type and the two property keys in this query still carry names that coincide with keywords and/or literals.
+The relationship type and the two property keys in this query still have names that coincide with keywords and/or literals.
 We discuss this further below, in <<Alternatives>>.
 
 === Interaction with existing features
@@ -134,7 +133,7 @@ Provide details on any interactions that need to be considered.
 
 === Alternatives
 
-This proposal could be extended with disallowing the reserved words also as:
+An extension to this proposal could disallow using the reserved words as:
 
 * Relationship types
 * Labels
@@ -143,12 +142,12 @@ This proposal could be extended with disallowing the reserved words also as:
 However, these usages are only valid in very limited contexts, coupled with a special character (`:` or `.`), so the benefit would be minimal.
 Furthermore, these usages represent _schema_, which is a context in which it is arguably more important to provide higher degrees of freedom, than in a pure statement context.
 
-Another variation that may be taken is to not strictly forbid the future-reserved words, but just issue a strong recommendation to not use them.
+Another variation that may be taken is to not strictly forbid the future-reserved words, but instead issue a strong recommendation to not use them.
 The trade-off in this case is between allowing more freedom for statements now and breaking statements in future language updates.
 
 == What others do
 
-The SQL standard define a set of reserved words and non-reserved keywords which vary across its updates.
+The SQL standard defines a set of reserved words and non-reserved keywords which vary across its revisions.
 SQL implementers interpret the standard in different ways, specifying different sets of reserved words:
 
 * https://www.postgresql.org/docs/9.6/static/sql-keywords-appendix.html[PostgreSQL] lists its ~100 reserved words together with the words and their status in the SQL standards.
@@ -165,5 +164,5 @@ The following benefits are envisioned:
 
 == Caveats to this proposal
 
-Several of the reserved words do represent general-purpose words that one would like to use as informative identifiers.
-This proposal would take away the ability to use these identifiers, meaning that some statements would be slightly more difficult to write.
+Several of the reserved words do represent general-purpose words that one may like to use as informative identifiers.
+This proposal would remove the ability to use these identifiers, meaning that some statements may be slightly more difficult to write.

--- a/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
+++ b/cip/1.accepted/CIP2016-12-19-Reserved-keywords.adoc
@@ -148,7 +148,13 @@ The trade-off in this case is between allowing more freedom for statements now a
 
 == What others do
 
+The SQL standard define a set of reserved words and non-reserved keywords which vary across its updates.
+SQL implementers interpret the standard in different ways, specifying different sets of reserved words:
 
+* https://www.postgresql.org/docs/9.6/static/sql-keywords-appendix.html[PostgreSQL] lists its ~100 reserved words together with the words and their status in the SQL standards.
+* https://dev.mysql.com/doc/refman/5.7/en/keywords.html[MySQL] specifies ~620 reserved words.
+* https://docs.oracle.com/database/121/SQLRF/ap_keywd001.htm#SQLRF55621[Oracle] specifies ~110 reserved words.
+* https://msdn.microsoft.com/en-us/library/ms189822.aspx[Microsoft SQL Server] specifies ~180 reserved words.
 
 == Benefits to this proposal
 


### PR DESCRIPTION
Cypher should specify a set of reserved words that may not be used as variables, parameters, or function names. This would make parsing the language simpler, make it harder to write particularly confusing statements, and is in alignment with how computer languages in general are specified.