### PR TITLE
Change definition of path equality

### DIFF
--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -140,7 +140,7 @@ We propose that <<comparability-con,comparability>> should be defined between an
   For example, given nodes `n1`, `n2`, `n3`, and relationships `r1` and `r2`, and given that `n1 < n2 < n3` and `r1 < r2`, then the path `p1` from `n1` to `n3` via `r1` would be less than the path `p2` to `n1` from `n2` via `r2`. Expressed in terms of lists:
 
       p1 < p2
-  <=> [n1-r1->n3] < [n1<-r2-n2]
+  <=> [n1, r1, n3] < [n1, r2, n2]
   <=> n1 < n1 || (n1 = n1 && [r1, n3] < [r2, n2])
   <=> false || (true && [r1, n3] < [r2, n2])
   <=> [r1, n3] < [r2, n2]
@@ -148,9 +148,6 @@ We propose that <<comparability-con,comparability>> should be defined between an
   <=> true || (false && false)
   <=> true
 
-  ** Additionally, paths track the direction in which a relationship is traversed.
-  Two paths that traverse the same nodes and relationships in the same order but differ in the direction in which they traverse a single relationship are not equal (this can happen in paths containing loops).
-  The comparison order for paths is expected to align with this.
   ** Paths are <<incomparable>> to any value that is not also a path.
 - Implementation-specific types
   * Implementations may choose to define suitable comparability rules for values of additional, non-canonical types.

--- a/tck/features/PathEquality.feature
+++ b/tck/features/PathEquality.feature
@@ -1,0 +1,35 @@
+#
+# Copyright 2017 "Neo Technology",
+# Network Engine for Objects in Lund AB (http://neotechnology.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Feature: PathEquality
+
+  Scenario: Direction of traversed relationship is not significant for path equality, simple
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (n:A)-[:LOOP]->(n)
+      """
+    When executing query:
+      """
+      MATCH p1 = (:A)-->()
+      MATCH p2 = (:A)<--()
+      RETURN p1 = p2
+      """
+    Then the result should be:
+      | p1 = p2 |
+      | true    |
+    And no side effects


### PR DESCRIPTION
Undirected matching on self-relationships (aka loops) is tricky. #162 makes an effort to try and make explicit the intended semantics. This leaves paths in an ill-defined state, however. Consider the graph with one node and one relationship (to itself), and the following query:

```
MATCH p = ()--()
RETURN p
```

#162 states that only one row is to be returned (there's only one combination of node-rel-node available in the data graph). However, if paths are supposed to capture the direction in which they traverse relationships, then which path should be returned by this query: the one that traverses the relationship outgoing, or the one that does it incoming? It seems ill-defined.

In no other circumstance other than a self-relationship will the traversed direction matter.

Same idea as in #160