### PR TITLE
Eliminate duplicate scenarios names

### DIFF
--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -243,29 +243,6 @@ Feature: DeleteAcceptance
       | -nodes         | 1 |
       | -relationships | 1 |
 
-  Scenario: Delete node from a list
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (u:User)
-      CREATE (u)-[:FRIEND]->()
-      CREATE (u)-[:FRIEND]->()
-      CREATE (u)-[:FRIEND]->()
-      CREATE (u)-[:FRIEND]->()
-      """
-    And parameters are:
-      | friendIndex | 1 |
-    When executing query:
-      """
-      MATCH (:User)-[:FRIEND]->(n)
-      WITH collect(n) AS friends
-      DETACH DELETE friends[$friendIndex]
-      """
-    Then the result should be empty
-    And the side effects should be:
-      | -nodes         | 1 |
-      | -relationships | 1 |
-
   Scenario: Delete relationship from a list
     Given an empty graph
     And having executed:

--- a/tck/features/FunctionsAcceptance.feature
+++ b/tck/features/FunctionsAcceptance.feature
@@ -440,7 +440,7 @@ Feature: FunctionsAcceptance
       | ['Foo', 'Bar'] |
     And no side effects
 
-  Scenario: `labels()` should accept type Any
+  Scenario: `labels()` failing on a path
     Given an empty graph
     And having executed:
       """
@@ -453,7 +453,7 @@ Feature: FunctionsAcceptance
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  Scenario: `labels()` should accept type Any
+  Scenario: `labels()` failing on invalid arguments
     Given an empty graph
     And having executed:
       """

--- a/tck/features/RemoveAcceptance.feature
+++ b/tck/features/RemoveAcceptance.feature
@@ -125,24 +125,6 @@ Feature: RemoveAcceptance
     And the side effects should be:
       | -properties | 1 |
 
-  Scenario: Remove a single relationship property
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a), (b), (a)-[:X {prop: 42}]->(b)
-      """
-    When executing query:
-      """
-      MATCH ()-[r]->()
-      REMOVE r.prop
-      RETURN exists(r.prop) AS still_there
-      """
-    Then the result should be:
-      | still_there |
-      | false       |
-    And the side effects should be:
-      | -properties | 1 |
-
   Scenario: Remove multiple relationship properties
     Given an empty graph
     And having executed:

--- a/tck/features/ReturnAcceptance2.feature
+++ b/tck/features/ReturnAcceptance2.feature
@@ -186,24 +186,6 @@ Feature: ReturnAcceptance2
     And the side effects should be:
       | +properties | 1 |
 
-  Scenario: Setting and returning the size of a list property
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()
-      """
-    When executing query:
-      """
-      MATCH (n)
-      SET n.x = [1, 2, 3]
-      RETURN size(n.x)
-      """
-    Then the result should be:
-      | size(n.x) |
-      | 3         |
-    And the side effects should be:
-      | +properties | 1 |
-
   Scenario: `sqrt()` returning float values
     Given any graph
     When executing query:


### PR DESCRIPTION
I discovered there are duplicate scenario names. There were two reasons for this:
* some scenarios were duplicated
* some scenarios had an incorrect names - their name suggested that they should work, but their `Then` clause specified a compile/runtime error.

This PR eliminates duplicate scenarios and renames failing scenarios appropriately.