### PR TITLE
Add Neo4j index extension CIP

### DIFF
--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -28,9 +28,9 @@ Constraints allows us to bound the heterogeneous nature of the property graph in
 
 This CIP includes the following proposed constraints:
 
-* Node property uniqueness constraint
-* Node property existence constraint
-* Relationship property existence constraint
+* <<uniqueness>>
+* <<existence, Node property existence constraint>>
+* <<existence, Relationship property existence constraint>>
 
 Each constraint is detailed in its own below section.
 
@@ -76,6 +76,10 @@ The semantics are defined for each type of constraint, but some characteristics 
 * When a statement tries to drop a constraint referencing a name that does not exist, that statement will raise an error.
 * When an updating statement tries to modify the graph in such a way that it would violate a constraint, that statement will raise an error.
 
+The constraints define a _domain_ within which the constraint applies.
+The domain is defined by the constraint pattern.
+
+[[uniqueness]]
 === Node property uniqueness constraint
 
 This constraint enforces that there can not be duplicate values of a certain property for a certain type of node.
@@ -107,10 +111,10 @@ REQUIRE UNIQUE p.name, p.email, p.address
 
 ==== Semantics
 
-A property uniqueness constraint is applied on nodes with a specific label, for one or more property keys.
-The constraint applies to all nodes where the property exist; its value must be non-null.
-When more than one property key is defined as part of the constraint, the uniqueness applies only to nodes where _all_ of the properties exist (are non-null).
-The uniqueness mandates that two distinct nodes within the domain of the constraint can not have the same combination of values for the defined properties (respectively).
+The domain of a property uniqueness constraint is defined as all the nodes with a specific label where the specified property key(s) exist (are non-null).
+When more than one property key is defined as part of the constraint, only nodes where _all_ of the properties exist are part of the domain.
+
+The uniqueness mandates that two distinct nodes within the domain can not have the same combination of values for the defined properties (respectively).
 
 ===== Example
 
@@ -174,8 +178,10 @@ REQUIRE exists(l.rating)
 
 ==== Semantics
 
-Property existence constraints enforce that the value of the specified property is non-null for all entities in the constraint domain.
+The domain of a node property existence constraint are all nodes with the specified label.
+Similarly, the domain of a relationship property existence constraint are all relationship with the specified type.
 
+Property existence constraints mandates that the value of the specified property exists (is non-null) for all entities in the domain.
 
 ===== Example
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -15,10 +15,6 @@ These are language constructs that impose restrictions on the shape of the data 
 
 toc::[]
 
-== Motivation
-
-Constraints provide the means by which various aspects of the data graph may be controlled.
-
 == Background
 
 Cypher has a loose notion of a schema, in which nodes and relationships may take very heterogeneous forms, both in terms of properties and in graph patterns.

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -232,7 +232,7 @@ REQUIRE p.email <> q.email AND p <> q
 
 == What others do
 
-In SQL, the following constraints exist (http://www.w3schools.com/sql/sql_constraints.asp):
+In SQL, the following constraints exist (inspired by http://www.w3schools.com/sql/sql_constraints.asp):
 
 * `NOT NULL` - Indicates that a column cannot store a null value.
 * `UNIQUE` - Ensures that each row for a column must have a unique value.

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -44,7 +44,7 @@ drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
 The constraint expression (`constraint-expr` above) is any expression that evaluates to a boolean value.
 This allows for very complex concrete constraint definitions within the specified syntax.
 
-To that set of valid expressions, this CIP further specifies a special prefix operator `UNIQUE`, which is used to assert uniqueness of one or more property expressions.
+To that set of valid expressions, this CIP further specifies a special prefix operator `UNIQUE`, which is used to assert uniqueness of one or more property expressions (see <<uniqueness>> for details).
 
 ==== Constraint names
 
@@ -67,17 +67,27 @@ DROP CONSTRAINT foo
 
 The semantics for constraints follow these general rules:
 
-1. The constraint pattern define the constraint domain, where all entities that would be returned by a `MATCH` clause with the same pattern constitute the domain, with one notable exception (see <<domain-exception, 3.>>).
+1. The constraint pattern define the constraint _domain_, where all entities that would be returned by a `MATCH` clause with the same pattern constitute the domain, with one notable exception (see <<domain-exception, 3.>>).
 
-2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`. Any other result raises an error (see <<Errors>>).
+2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`.
 
 3. [[domain-exception]]Entities for which a constraint expression evaluate to `null` under Cypher's ternary logic are _excluded_ from the constraint domain, even if they fit within the constraint pattern.
+
+==== Errors
+
+The following list describes the situations in which an error will be raised:
+
+* Attempting to create a constraint on a graph where the data does not comply with the constraint criterion.
+* Attempting to create a constraint with a name that already exists.
+* Attempting to drop a constraint referencing a non-existent name.
+* Attempting to modify the graph in such a way that it would violate a constraint.
 
 ==== Mutability
 
 Once a constraint has been created, it may not be amended.
 Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
 
+[[uniqueness]]
 ==== Uniqueness
 
 The new operator `UNIQUE` is only valid as part of a constraint expression.
@@ -93,18 +103,6 @@ CREATE CONSTRAINT unique_person_details
 FOR (p:Person)
 REQUIRE UNIQUE p.name, p.email, p.address
 ----
-
-==== Errors
-
-The following list describes the situations in which an error will be raised:
-
-* Attempting to create a constraint on a graph where the data does not comply with the constraint criterion.
-* Attempting to create a constraint with a name that already exists.
-* Attempting to drop a constraint referencing a non-existent name.
-* Attempting to modify the graph in such a way that it would violate a constraint.
-
-The constraints define a _domain_ within which the constraint applies.
-The domain is defined by the constraint pattern.
 
 ==== Compositionality
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -122,9 +122,9 @@ Consider the graph created by the following statement:
 
 [source, cypher]
 ----
-CREATE (:Color {name: 'white', rgb: 255})
-CREATE (:Color {name: 'black', rgb: 0})
-CREATE (:Color {name: 'very, very dark grey', rgb: 0}) // rounding error!
+CREATE (:Color {name: 'white', rgb: 0xffffff})
+CREATE (:Color {name: 'black', rgb: 0x000000})
+CREATE (:Color {name: 'very, very dark grey', rgb: 0x000000}) // rounding error!
 ----
 
 Due to the duplication of the `rgb` property, the following attempt at creating a constraint will fail:
@@ -184,6 +184,32 @@ Similarly, the domain of a relationship property existence constraint are all re
 Property existence constraints mandates that the value of the specified property exists (is non-null) for all entities in the domain.
 
 ===== Example
+
+Consider the graph containing `:Color` nodes.
+Each color has an integral RGB value representation in a property `rgb`.
+Users may lookup color nodes to extract their RGB values for application processing.
+Users may also add new color nodes to the graph.
+
+Suppose the query that looks up the RGB value of a color with a given name looks like this:
+
+[source, cypher]
+----
+MATCH (c:Color {name: $name})
+WHERE exists(c.rgb)
+RETURN c.rgb
+----
+
+The `WHERE` clause protects the application from receiving `null` values back for user-defined colors where the RGB values have not been specified correctly.
+It may however be eliminated by the introduction of a node property existence constraint:
+
+[source, cypher]
+----
+CREATE CONSTRAINT colors_must_have_rgb
+FOR (c:Color)
+REQUIRE exists(c.rgb)
+----
+
+Any updating statement that would create a `:Color` node without specifying a `rgb` property for it would now fail.
 
 === Interaction with existing features
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -1,0 +1,174 @@
+= CIP2016-12-16 - Constraints syntax
+:numbered:
+:toc:
+:toc-placement: macro
+:source-highlighter: codemirror
+
+*Author:* Mats Rydberg <mats@neotechnology.com>
+
+[abstract]
+.Abstract
+--
+This CIP describes syntax and semantics for Cypher constraints.
+These are language constructs that impose restrictions on the shape of the data graph, and how statements are allowed to change it.
+--
+
+toc::[]
+
+== Motivation
+
+Constraints provide utility for shaping the data graph.
+
+== Background
+
+Cypher has a loose notion of schema, in which nodes and relationships may take very heterogeneous forms, both in terms of properties and in graph patterns.
+Constraints allows us to bound the heterogeneous nature of the property graph into a more regular form.
+
+== Proposal
+
+This CIP includes the following proposed constraints:
+
+* Node property uniqueness constraint
+* Node property existence constraint
+* Relationship property existence constraint
+
+Each constraint is detailed in its own below section.
+
+Once a constraint has been created, it may not be amended.
+Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
+
+==== Constraint names
+
+All constraints require the user to specify a nonempty _name_ at constraint creation time.
+This name is subsequently the handle with which a user may refer to the constraint, e.g. when dropping it.
+
+// TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
+
+=== Syntax overview
+
+The syntax for all constraints follow the same basic outline.
+
+.Grammar definition for constraint syntax.
+[source, ebnf]
+----
+constraint command = create-constraint | drop-constraint ;
+create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", constraint-pattern, "REQUIRE", constraint-expr ;
+constraint-name    = symbolic-name
+constraint-pattern = node-pattern | simple-pattern ;
+constraint-expr    = uniqueness-constraint | existence-constraint ;
+drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
+----
+
+The constraint expressions vary depending on the actual constraint (see the detailed sections).
+
+.Example of dropping a constraint with name foo:
+[source, cypher]
+----
+DROP CONSTRAINT foo
+----
+
+=== Semantics overview
+
+The semantics are defined for each type of constraint, but some characteristics are shared:
+
+* When a statement tries to create a constraint on a graph where the data does not pass the constraint criterion, that statement will raise an error.
+* When a statement tries to create a constraint with a name that already exists, that statement will raise an error.
+* When a statement tries to drop a constraint referencing a name that does not exist, that statement will raise an error.
+* When an updating statement tries to modify the graph in such a way that it would violate a constraint, that statement will raise an error.
+
+=== Node property uniqueness constraint
+
+This constraint enforces that there can not be duplicate values of a certain property for a certain type of node.
+For example, that among nodes labeled with `:Person`, each `email` property must be unique.
+
+==== Syntax
+
+.Grammar definition for node property uniqueness constraint:
+[source, ebnf]
+----
+uniqueness-constraint = "UNIQUE", property-expression, { ",", property-expression } ;
+----
+
+.Example of single-property uniqueness constraint:
+[source, cypher]
+----
+CREATE CONSTRAINT unique_person_email
+FOR (p:Person)
+REQUIRE UNIQUE p.email
+----
+
+.Example of multiple-property uniqueness constraint:
+[source, cypher]
+----
+CREATE CONSTRAINT unique_person_details
+FOR (p:Person)
+REQUIRE UNIQUE p.name, p.email, p.address
+----
+
+==== Semantics
+
+A property uniqueness constraint is applied on nodes with a specific label, for one or more property keys.
+The constraint applies to all nodes where the property exist; its value must be non-null.
+When more than one property key is defined as part of the constraint, the uniqueness applies only to nodes where _all_ of the properties exist (are non-null).
+The uniqueness mandates that two distinct nodes within the domain of the constraint can not have the same combination of values for the defined properties (respectively).
+
+===== Example
+
+Consider the graph created by the following statement:
+
+[source, cypher]
+----
+CREATE (:Color {name: 'white', rgb: 255})
+CREATE (:Color {name: 'black', rgb: 0})
+CREATE (:Color {name: 'very, very dark grey', rgb: 0}) // rounding error!
+----
+
+Due to the duplication of the `rgb` property, the following attempt at creating a constraint will fail:
+
+[source, cypher]
+----
+CREATE CONSTRAINT only_one_color_per_rgb
+FOR (c:Color)
+REQUIRE UNIQUE c.rgb
+----
+
+Suppose that we would rather like to have one color node per name _and_ RGB value (to work around the rounding errors).
+We could then use the following constraint, without modifying our data:
+
+[source, cypher]
+----
+CREATE CONSTRAINT unique_color_nodes
+FOR (c:Color)
+REQUIRE UNIQUE c.rgb, c.name
+----
+
+=== Interaction with existing features
+
+The main interaction between the constraints and the rest of the language happens during updating statements.
+Existing constraints will cause certain updating statements to fail; in fact, that's the main purpose.
+
+=== Alternatives
+
+Plenty of alternative syntaxes have been discussed:
+
+* `GIVEN`, `CONSTRAIN`, `ASSERT` instead of `FOR`
+* `ASSERT`, `ENFORCE`, `IMPLIES` instead of `REQUIRE`
+
+The use of existing expression to express uniqueness, instead of using a new keyword `UNIQUE`, on the form:
+----
+FOR (p:Person), (q:Person)
+REQUIRE p.email <> q.email AND p <> q
+----
+which quickly becomes unwieldy for multiple properties.
+
+== What others do
+
+// TODO: SQL syntax for constraints
+
+== Benefits to this proposal
+
+Constraints make Cypher's notion of schema more well-defined, and allows users to keep graphs in a more regular, easier to manage form.
+
+== Caveats to this proposal
+
+For an implementing system, some constraints may prove challenging to enforce, as they generally require scanning through large parts of the graph to look for conflicting entities.

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -40,7 +40,7 @@ Should a user wish to change its definition, it has to be dropped and recreated 
 ==== Constraint names
 
 All constraints require the user to specify a nonempty _name_ at constraint creation time.
-This name is subsequently the handle with which a user may refer to the constraint, e.g. when dropping it.
+This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
 
 // TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
 
@@ -118,7 +118,11 @@ The uniqueness constraint mandates that two distinct nodes within the domain can
 
 ===== Example
 
-Consider the graph created by the following statement:
+Consider the graph created by the statement below.
+The graph contains nodes labeled with `:Color`.
+Each color is represented as an integer-type RGB value in a property `rgb`.
+Users may look up nodes labeled with `:Color` to extract their RGB values for application processing.
+Users may also add new `:Color`-labeled nodes to the graph.
 
 [source, cypher]
 ----
@@ -136,7 +140,7 @@ FOR (c:Color)
 REQUIRE UNIQUE c.rgb
 ----
 
-Suppose that we would rather like to have one color node per name _and_ RGB value (to work around the rounding errors).
+Suppose that we would rather like to have one color node per `name` _and_ `rgb` value (to work around the rounding errors).
 We could then use the following constraint, without modifying our data:
 
 [source, cypher]
@@ -185,10 +189,7 @@ The property existence constraint mandates that the value of the specified prope
 
 ===== Example
 
-Consider the graph containing `:Color` nodes.
-Each color is represented as an integer-type RGB value in a property `rgb`.
-Users may look up nodes labeled with `:Color` to extract their RGB values for application processing.
-Users may also add new `:Color`-labeled nodes to the graph.
+Consider once again the graph containing `:Color` nodes.
 
 The following query retrieves the RGB value of a color with a given `name`:
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -33,9 +33,8 @@ The constraint syntax is defined as follows:
 [source, ebnf]
 ----
 constraint command = create-constraint | drop-constraint ;
-create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", constraint-pattern, "REQUIRE", constraint-expr, { "REQUIRE", constraint-expr } ;
+create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", pattern, "REQUIRE", constraint-expr, { "REQUIRE", constraint-expr } ;
 constraint-name    = symbolic-name
-constraint-pattern = node-pattern | simple-pattern ;
 constraint-expr    = uniqueness-expr | expression ;
 uniquness-expr     = "UNIQUE", property-expression, { ",", property-expression }
 drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
@@ -50,8 +49,6 @@ To that set of valid expressions, this CIP further specifies a special prefix op
 
 All constraints require the user to specify a nonempty _name_ at constraint creation time.
 This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
-
-// TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
 
 ==== Removing constraints
 
@@ -184,6 +181,22 @@ REQUIRE exists(c.rgb)
 This composite constraint will make sure that all `:Color` nodes has a value for their `rgb` property, and that its value is unique for each `name`.
 
 More complex constraint definitions are considered below:
+
+.Multiple property existence using conjunction
+[source, cypher]
+----
+CREATE CONSTRAINT person_properties
+FOR (p:Person)
+REQUIRE exists(p.name) AND exists(p.email)
+----
+
+.Using larger pattern
+[source, cypher]
+----
+CREATE CONSTRAINT not_rating_own_posts
+FOR (u1:User)-[:RATED]->(:Post)<-[:POSTED_BY]-(u2:User)
+REQUIRE u.name <> u2.name
+----
 
 .Property value limitations
 [source, cypher]

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -232,7 +232,49 @@ which quickly becomes unwieldy for multiple properties.
 
 == What others do
 
-// TODO: SQL syntax for constraints
+In SQL, the following constraints exist (http://www.w3schools.com/sql/sql_constraints.asp):
+
+* `NOT NULL` - Indicates that a column cannot store NULL value
+* `UNIQUE` - Ensures that each row for a column must have a unique value
+* `PRIMARY KEY` - A combination of a `NOT NULL` and `UNIQUE`. Ensures that a column (or combination of two or more columns) have a unique identity which helps to find a particular record in a table more easily and quickly
+* `FOREIGN KEY` - Ensure the referential integrity of the data in one table to match values in another table
+* `CHECK` - Ensures that the value in a column meets a specific condition
+* `DEFAULT` - Specifies a default value for a column
+The next chapters will describe each constraint in detail.
+
+The property existence constraints represent the same functionality as the `NOT NULL` SQL constraint.
+The node property uniqueness constraint represents the `PRIMARY KEY` SQL constraint.
+
+SQL constraints may be introduced at table creation time (in a `CREATE TABLE` statement), or in an `ALTER TABLE` statement:
+
+.Creating a persons table in SQL Server / Oracle / MS Access:
+[source, sql]
+----
+CREATE TABLE Persons
+(
+   P_Id int NOT NULL UNIQUE,
+   LastName varchar(255) NOT NULL,
+   FirstName varchar(255))
+----
+
+.Creating a persons table in MySQL:
+[source, sql]
+----
+CREATE TABLE Persons
+(
+  P_Id int NOT NULL,
+  LastName varchar(255) NOT NULL,
+  FirstName varchar(255)
+  UNIQUE (P_Id)
+)
+----
+
+.Adding a named composite `UNIQUE` constraint in MySQL / SQL Server / Oracle / MS Access:
+[source, sql]
+----
+ALTER TABLE Persons
+ADD CONSTRAINT uc_PersonID UNIQUE (P_Id,LastName)
+----
 
 == Benefits to this proposal
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -1,4 +1,4 @@
-= CIP2016-12-16 - Constraints syntax
+= CIP2016-12-16 Constraints syntax
 :numbered:
 :toc:
 :toc-placement: macro

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -70,7 +70,7 @@ The semantics for constraints follow these general rules:
 
 1. The constraint pattern define the constraint _domain_, where all entities that would be returned by a `MATCH` clause with the same pattern constitute the domain, with one notable exception (see <<domain-exception, 3.>>).
 
-2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`.
+2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`, at all times.
 
 3. [[domain-exception]]Entities for which a constraint expression evaluate to `null` under Cypher's ternary logic are _excluded_ from the constraint domain, even if they fit within the constraint pattern.
 
@@ -78,7 +78,7 @@ The semantics for constraints follow these general rules:
 
 The following list describes the situations in which an error will be raised:
 
-* Attempting to add a constraint on a graph where the data does not comply with the constraint criterion.
+* Attempting to add a constraint on a graph where the data does not comply with a constraint predicate.
 * Attempting to add a constraint with a name that already exists.
 * Attempting to add a constraint that the underlying engine does not support enforcing.
 * Attempting to drop a constraint referencing a non-existent name.
@@ -87,7 +87,7 @@ The following list describes the situations in which an error will be raised:
 ==== Mutability
 
 Once a constraint has been added, it may not be amended.
-Should a user wish to change its definition, it has to be dropped and added anew with an updated structure.
+Should a user wish to change a constraint definition, the constraint has to be dropped and added anew with an updated structure.
 
 [[uniqueness]]
 ==== Uniqueness
@@ -158,7 +158,7 @@ This field contains the constraint definition, which is the contents of the cons
 
 The contents of this field are left unspecified, to be used for implementation-specific messages and/or details.
 
-Consider the following constraint:
+.Example: consider the following constraint:
 [source, Cypher]
 ----
 CREATE CONSTRAINT myConstraint
@@ -300,7 +300,7 @@ REQUIRE acyclic(p)
 === Interaction with existing features
 
 The main interaction between the constraints and the rest of the language occurs during updating statements.
-Existing constraints will cause any updating statements to fail, thereby fulfilling the main purpose of this feature.
+Existing constraints will cause some updating statements to fail, thereby fulfilling the main purpose of this feature.
 
 === Alternatives
 
@@ -368,7 +368,7 @@ ADD CONSTRAINT uc_PersonID UNIQUE (P_Id,LastName)
 Constraints make Cypher's notion of schema more well-defined, allowing users to maintain graphs in a more regular, easier-to-manage form.
 
 Additionally, this specification is deliberately defining a constraint _language_ within which a great deal of possible concrete constraints are made possible.
-This allows different implementers of Cypher to independently choose how to limit the scope of supported constraint expressions that fit their model and targeted use cases.
+This allows different implementers of Cypher to independently choose how to limit the scope of supported constraint expressions that fit their model and targeted use cases, while retaining a common and consistent semantic and syntactic model.
 
 == Caveats to this proposal
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -34,8 +34,8 @@ The constraint syntax is defined as follows:
 .Grammar definition for constraint syntax.
 [source, ebnf]
 ----
-constraint command    = add-constraint | drop-constraint ;
-add-constraint        = "ADD", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
+constraint command    = create-constraint | drop-constraint ;
+add-constraint        = "CREATE", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
 constraint-name       = symbolic-name
 constraint-predicate  = expression | unique | node-key ;
 unique                = "UNIQUE", property-expression
@@ -99,7 +99,7 @@ Following on rule <<domain-exception,3.>> above, entities for which the property
 .Example of a constraint definition using `UNIQUE`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
-ADD CONSTRAINT only_one_person_per_name
+CREATE CONSTRAINT only_one_person_per_name
 FOR (p:Person)
 REQUIRE UNIQUE p.name
 ----
@@ -115,7 +115,7 @@ The domain of a node key constraint is thus exactly defined as all entities whic
 .Example of a constraint definition using `NODE KEY`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
-ADD CONSTRAINT person_details
+CREATE CONSTRAINT person_details
 FOR (p:Person)
 REQUIRE NODE KEY p.name, p.email, p.address
 ----
@@ -125,7 +125,7 @@ In the context of a single property, a semantically equivalent constraint is ach
 .Example of a constraint definition equivalent to a `NODE KEY` on a single property `name`:
 [source, cypher]
 ----
-ADD CONSTRAINT person_details
+CREATE CONSTRAINT person_details
 FOR (p:Person)
 REQUIRE UNIQUE p.name
 REQUIRE exists(p.name)
@@ -161,7 +161,7 @@ The contents of this field are left unspecified, to be used for implementation-s
 Consider the following constraint:
 [source, Cypher]
 ----
-ADD CONSTRAINT myConstraint
+CREATE CONSTRAINT myConstraint
 FOR (n:Node)
 REQUIRE NODE KEY n.prop1, n.prop2
 ----
@@ -199,7 +199,7 @@ Owing to the duplication of the `rgb` property, the following attempt at adding 
 
 [source, cypher]
 ----
-ADD CONSTRAINT only_one_color_per_rgb
+CREATE CONSTRAINT only_one_color_per_rgb
 FOR (c:Color)
 REQUIRE UNIQUE c.rgb
 ----
@@ -218,7 +218,7 @@ It may, however, be eliminated by the introduction of a constraint asserting the
 
 [source, cypher]
 ----
-ADD CONSTRAINT colors_must_have_rgb
+CREATE CONSTRAINT colors_must_have_rgb
 FOR (c:Color)
 REQUIRE exists(c.rgb)
 ----
@@ -229,7 +229,7 @@ If we instead want to make the _combination_ of the properties `name` and `rgb` 
 
 [source, cypher]
 ----
-ADD CONSTRAINT color_schema
+CREATE CONSTRAINT color_schema
 FOR (c:Color)
 REQUIRE NODE KEY c.rgb, c.name
 ----
@@ -242,7 +242,7 @@ More complex constraint definitions are considered below:
 .Multiple property existence using conjunction
 [source, cypher]
 ----
-ADD CONSTRAINT person_properties
+CREATE CONSTRAINT person_properties
 FOR (p:Person)
 REQUIRE exists(p.name) AND exists(p.email)
 ----
@@ -250,7 +250,7 @@ REQUIRE exists(p.name) AND exists(p.email)
 .Using larger pattern
 [source, cypher]
 ----
-ADD CONSTRAINT not_rating_own_posts
+CREATE CONSTRAINT not_rating_own_posts
 FOR (u1:User)-[:RATED]->(:Post)<-[:POSTED_BY]-(u2:User)
 REQUIRE u.name <> u2.name
 ----
@@ -258,7 +258,7 @@ REQUIRE u.name <> u2.name
 .Property value limitations
 [source, cypher]
 ----
-ADD CONSTRAINT road_width
+CREATE CONSTRAINT road_width
 FOR ()-[r:ROAD]-()
 REQUIRE 5 < r.width < 50
 ----
@@ -266,7 +266,7 @@ REQUIRE 5 < r.width < 50
 .Cardinality
 [source, cypher]
 ----
-ADD CONSTRAINT spread_the_love
+CREATE CONSTRAINT spread_the_love
 FOR (p:Person)
 REQUIRE size((p)-[:LOVES]->()) > 3
 ----
@@ -274,7 +274,7 @@ REQUIRE size((p)-[:LOVES]->()) > 3
 .Endpoint requirements
 [source, cypher]
 ----
-ADD CONSTRAINT can_only_own_things
+CREATE CONSTRAINT can_only_own_things
 FOR ()-[:OWNS]->(t)
 REQUIRE (t:Vehicle) OR (t:Building) OR (t:Object)
 ----
@@ -282,7 +282,7 @@ REQUIRE (t:Vehicle) OR (t:Building) OR (t:Object)
 .Label coexistence
 [source, cypher]
 ----
-ADD CONSTRAINT programmers_are_people_too
+CREATE CONSTRAINT programmers_are_people_too
 FOR (p:Programmer)
 REQUIRE p:Person
 ----
@@ -292,7 +292,7 @@ Assuming a function `acyclic()` that takes a path as argument and returns `true`
 .Constraint example from CIR-2017-172
 [source, cypher]
 ----
-ADD CONSTRAINT enforce_dag_acyclic_for_R_links
+CREATE CONSTRAINT enforce_dag_acyclic_for_R_links
 FOR p = ()-[:R*]-()
 REQUIRE acyclic(p)
 ----
@@ -308,6 +308,8 @@ Alternative syntaxes have been discussed:
 
 * `GIVEN`, `CONSTRAIN`, `ASSERT` instead of `FOR`
 * `ASSERT`, `ENFORCE`, `IMPLIES` instead of `REQUIRE`
+* `ADD` instead of `CREATE`
+** It is desirable for verb pairs for modifying operations to be consistent in the language, and recent discussions are (so far informally) suggesting `INSERT`/`DELETE` to be used for data modification, thus making `CREATE` and `DROP` available for schema modification such as constraints.
 
 The use of an existing expression to express uniqueness -- instead of using the operator `UNIQUE` -- becomes unwieldy for multiple properties, as exemplified by the following:
 ----

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -35,16 +35,16 @@ The constraint syntax is defined as follows:
 constraint command    = create-constraint | drop-constraint ;
 create-constraint     = "CREATE", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
 constraint-name       = symbolic-name
-constraint-predicate  = expression | unique | primary-key ;
+constraint-predicate  = expression | unique | node-key ;
 unique                = "UNIQUE", property-expression
-primary-key           = "PRIMARY KEY", property-expression, { ",", property-expression }
+node-key              = "NODE KEY", property-expression, { ",", property-expression }
 drop-constraint       = "DROP", "CONSTRAINT", constraint-name ;
 ----
 
-The `REQUIRE` clause works exactly like the `WHERE` clause in a standard Cypher query, with the addition of also supporting the special constraint operators `UNIQUE` and `PRIMARY KEY`.
+The `REQUIRE` clause works exactly like the `WHERE` clause in a standard Cypher query, with the addition of also supporting the special constraint operators `UNIQUE` and `NODE KEY`.
 This allows for very complex concrete constraint definitions (using custom predicates) within the specified syntax.
 
-For details on `UNIQUE` and `PRIMARY KEY`, see the dedicated sections below: <<uniqueness>>, <<primary-key>>.
+For details on `UNIQUE` and `NODE KEY`, see the dedicated sections below: <<uniqueness>>, <<node-key>>.
 
 ==== Constraint names
 
@@ -101,32 +101,31 @@ FOR (p:Person)
 REQUIRE UNIQUE p.name
 ----
 
-[[primary-key]]
-==== Primary key
+[[node-key]]
+==== Node key
 
-The new operator `PRIMARY KEY` is only valid as part of a constraint predicate.
+The new operator `NODE KEY` is only valid as part of a constraint predicate.
 It takes as argument one or more property expressions, and asserts that the combination of the evaluated values of the expressions (forming a tuple) is unique across the constraint domain.
-It further asserts that the property expressions all exist on the entities of the domain, and thus avoids applicability of rule <<domain-exception, 3.>> above. The domain of a primary key constraint is thus exactly defined as all entities which fit the constraint pattern.
+It further asserts that the property expressions all exist on the entities of the domain, and thus avoids applicability of rule <<domain-exception, 3.>> above.
+The domain of a node key constraint is thus exactly defined as all entities which fit the constraint pattern.
 
-.Example of a constraint definition using `PRIMARY KEY`, over the domain of nodes labeled with `:Person`:
+.Example of a constraint definition using `NODE KEY`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
 CREATE CONSTRAINT person_details
 FOR (p:Person)
-REQUIRE PRIMARY KEY p.name, p.email, p.address
+REQUIRE NODE KEY p.name, p.email, p.address
 ----
 
-A semantically equivalent constraint is achieved by composing the use of the `UNIQUE` operator with `exists()` predicates, as exemplified by:
+In the context of a single property, a semantically equivalent constraint is achieved by composing the use of the `UNIQUE` operator with `exists()` predicates, as exemplified by:
 
-.Example of a constraint definition equivalent to the above `PRIMARY KEY` example:
+.Example of a constraint definition equivalent to a `NODE KEY` on a single property `name`:
 [source, cypher]
 ----
 CREATE CONSTRAINT person_details
 FOR (p:Person)
 REQUIRE UNIQUE p.name
-REQUIRE UNIQUE p.email
-REQUIRE UNIQUE p.address
-REQUIRE exists(p.name) AND exists(p.email) AND exists(p.address)
+REQUIRE exists(p.name)
 ----
 
 ==== Compositionality
@@ -163,17 +162,6 @@ FOR (c:Color)
 REQUIRE UNIQUE c.rgb
 ----
 
-Suppose that we would rather like to have one color node per `name` _and_ `rgb` value (to work around the rounding errors).
-We could then use the following constraint, without modifying our data:
-
-[source, cypher]
-----
-CREATE CONSTRAINT unique_color_nodes
-FOR (c:Color)
-REQUIRE UNIQUE c.rgb
-REQUIRE UNIQUE c.name
-----
-
 Now, consider the following query which retrieves the RGB value of a color with a given `name`:
 
 [source, cypher]
@@ -195,16 +183,17 @@ REQUIRE exists(c.rgb)
 
 Any updating statement that would create a `:Color` node without specifying an `rgb` property for it would now fail.
 
-If we also want to mandate the existence of the `name` property, we could use a `PRIMARY KEY` operator to capture all these requirements in a single constraint:
+If we instead want to make the _combination_ of the properties `name` and `rgb` unique, while simultaneously mandating their existence, we could use a `NODE KEY` operator to capture all these requirements in a single constraint:
 
 [source, cypher]
 ----
 CREATE CONSTRAINT color_schema
 FOR (c:Color)
-REQUIRE PRIMARY KEY c.rgb, c.name
+REQUIRE NODE KEY c.rgb, c.name
 ----
 
 This constraint will make sure that all `:Color` nodes has a value for their `rgb` and `name` properties, and that the combination is unique across all the nodes.
+This would allow several `:Color` nodes named `'grey'`, as long as their `rgb` values are distinct.
 
 More complex constraint definitions are considered below:
 
@@ -297,7 +286,7 @@ In SQL, the following constraints exist (inspired by http://www.w3schools.com/sq
 
 The `NOT NULL` SQL constraint is expressible using an `exists()` constraint predicate.
 The `UNIQUE` SQL constraint is exactly as Cypher's `UNIQUE` constraint predicate.
-The `PRIMARY KEY` SQL constraint is exactly as Cypher's `PRIMARY KEY` constraint predicate.
+The `PRIMARY KEY` SQL constraint is exactly as Cypher's `NODE KEY` constraint predicate.
 
 SQL constraints may be introduced at table creation time in a `CREATE TABLE` statement, or in an `ALTER TABLE` statement:
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -17,12 +17,12 @@ toc::[]
 
 == Motivation
 
-Constraints provide utility for shaping the data graph.
+Constraints provide the means by which various aspects of the data graph may be controlled.
 
 == Background
 
-Cypher has a loose notion of schema, in which nodes and relationships may take very heterogeneous forms, both in terms of properties and in graph patterns.
-Constraints allows us to bound the heterogeneous nature of the property graph into a more regular form.
+Cypher has a loose notion of a schema, in which nodes and relationships may take very heterogeneous forms, both in terms of properties and in graph patterns.
+Constraints allow us to mould the heterogeneous nature of the property graph into a more regular form.
 
 == Proposal
 
@@ -32,7 +32,7 @@ This CIP includes the following proposed constraints:
 * <<existence, Node property existence constraint>>
 * <<existence, Relationship property existence constraint>>
 
-Each constraint is detailed in its own below section.
+Each constraint is detailed in the sections below.
 
 Once a constraint has been created, it may not be amended.
 Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
@@ -61,7 +61,7 @@ drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
 
 The constraint expressions vary depending on the actual constraint (see the detailed sections).
 
-.Example of dropping a constraint with name foo:
+.Example of dropping a constraint with name `foo`:
 [source, cypher]
 ----
 DROP CONSTRAINT foo
@@ -69,12 +69,12 @@ DROP CONSTRAINT foo
 
 === Semantics overview
 
-The semantics are defined for each type of constraint, but some characteristics are shared:
+The following list describes the situations in which an error will be raised:
 
-* When a statement tries to create a constraint on a graph where the data does not pass the constraint criterion, that statement will raise an error.
-* When a statement tries to create a constraint with a name that already exists, that statement will raise an error.
-* When a statement tries to drop a constraint referencing a name that does not exist, that statement will raise an error.
-* When an updating statement tries to modify the graph in such a way that it would violate a constraint, that statement will raise an error.
+* Attempting to create a constraint on a graph where the data does not comply with the constraint criterion.
+* Attempting to create a constraint with a name that already exists.
+* Attempting to drop a constraint referencing a non-existent name.
+* Attempting to modify the graph in such a way that it would violate a constraint.
 
 The constraints define a _domain_ within which the constraint applies.
 The domain is defined by the constraint pattern.
@@ -82,18 +82,18 @@ The domain is defined by the constraint pattern.
 [[uniqueness]]
 === Node property uniqueness constraint
 
-This constraint enforces that there can not be duplicate values of a certain property for a certain type of node.
-For example, that among nodes labeled with `:Person`, each `email` property must be unique.
+This constraint enforces that there cannot be duplicate values of some property `p` for any node labeled with some label `l`.
+For example, this constraint can specify that the `email` property must be unique for all nodes labeled with `:Person`.
 
 ==== Syntax
 
-.Grammar definition for node property uniqueness constraint:
+.Grammar definition for the node property uniqueness constraint:
 [source, ebnf]
 ----
 uniqueness-constraint = "UNIQUE", property-expression, { ",", property-expression } ;
 ----
 
-.Example of single-property uniqueness constraint:
+.Example of a single-property uniqueness constraint:
 [source, cypher]
 ----
 CREATE CONSTRAINT unique_person_email
@@ -101,7 +101,7 @@ FOR (p:Person)
 REQUIRE UNIQUE p.email
 ----
 
-.Example of multiple-property uniqueness constraint:
+.Example of a multiple-property uniqueness constraint:
 [source, cypher]
 ----
 CREATE CONSTRAINT unique_person_details
@@ -111,10 +111,10 @@ REQUIRE UNIQUE p.name, p.email, p.address
 
 ==== Semantics
 
-The domain of a property uniqueness constraint is defined as all the nodes with a specific label where the specified property key(s) exist (are non-null).
+The domain of a property uniqueness constraint is defined as all the nodes with a specific label where the specified property key(s) exist (i.e. are not null).
 When more than one property key is defined as part of the constraint, only nodes where _all_ of the properties exist are part of the domain.
 
-The uniqueness mandates that two distinct nodes within the domain can not have the same combination of values for the defined properties (respectively).
+The uniqueness constraint mandates that two distinct nodes within the domain cannot have the same combination of values for the defined properties.
 
 ===== Example
 
@@ -127,7 +127,7 @@ CREATE (:Color {name: 'black', rgb: 0x000000})
 CREATE (:Color {name: 'very, very dark grey', rgb: 0x000000}) // rounding error!
 ----
 
-Due to the duplication of the `rgb` property, the following attempt at creating a constraint will fail:
+Owing to the duplication of the `rgb` property, the following attempt at creating a constraint will fail:
 
 [source, cypher]
 ----
@@ -149,18 +149,18 @@ REQUIRE UNIQUE c.rgb, c.name
 [[existence]]
 === Property existence constraints
 
-Property existence constraints are defined for both nodes and relationships, but the semantics are the same.
-For this reason we will go over both constraints in the same section.
+Property existence constraints are defined for both nodes and relationships; these have the same semantics.
+We now describe both of these.
 
 ==== Syntax
 
-.Grammar definition for property existence constraint:
+.Grammar definition for the property existence constraint:
 [source, ebnf]
 ----
 existence-constraint = "exists", "(", property-expression, ")" ;
 ----
 
-.Example of node property existence constraint:
+.Example of a node property existence constraint:
 [source, cypher]
 ----
 CREATE CONSTRAINT colors_must_have_rgb
@@ -168,7 +168,7 @@ FOR (c:Color)
 REQUIRE exists(c.rgb)
 ----
 
-.Example of relationship property existence constraint:
+.Example of a relationship property existence constraint:
 [source, cypher]
 ----
 CREATE CONSTRAINT rates_have_quality
@@ -181,16 +181,16 @@ REQUIRE exists(l.rating)
 The domain of a node property existence constraint are all nodes with the specified label.
 Similarly, the domain of a relationship property existence constraint are all relationship with the specified type.
 
-Property existence constraints mandates that the value of the specified property exists (is non-null) for all entities in the domain.
+The property existence constraint mandates that the value of the specified property exists (i.e. is not null) for all entities in the domain.
 
 ===== Example
 
 Consider the graph containing `:Color` nodes.
-Each color has an integral RGB value representation in a property `rgb`.
-Users may lookup color nodes to extract their RGB values for application processing.
-Users may also add new color nodes to the graph.
+Each color is represented as an integer-type RGB value in a property `rgb`.
+Users may look up nodes labeled with `:Color` to extract their RGB values for application processing.
+Users may also add new `:Color`-labeled nodes to the graph.
 
-Suppose the query that looks up the RGB value of a color with a given name looks like this:
+The following query retrieves the RGB value of a color with a given `name`:
 
 [source, cypher]
 ----
@@ -199,8 +199,8 @@ WHERE exists(c.rgb)
 RETURN c.rgb
 ----
 
-The `WHERE` clause protects the application from receiving `null` values back for user-defined colors where the RGB values have not been specified correctly.
-It may however be eliminated by the introduction of a node property existence constraint:
+The `WHERE` clause may be used to prevent an application from retrieving `null` values for user-defined colors where the RGB values have not been specified correctly.
+It may, however, be eliminated by the introduction of a node property existence constraint:
 
 [source, cypher]
 ----
@@ -213,54 +213,52 @@ Any updating statement that would create a `:Color` node without specifying a `r
 
 === Interaction with existing features
 
-The main interaction between the constraints and the rest of the language happens during updating statements.
-Existing constraints will cause certain updating statements to fail; in fact, that's the main purpose.
+The main interaction between the constraints and the rest of the language occurs during updating statements.
+Existing constraints will cause any updating statements to fail, thereby fulfilling the main purpose of this feature.
 
 === Alternatives
 
-Plenty of alternative syntaxes have been discussed:
+Alternative syntaxes have been discussed:
 
 * `GIVEN`, `CONSTRAIN`, `ASSERT` instead of `FOR`
 * `ASSERT`, `ENFORCE`, `IMPLIES` instead of `REQUIRE`
 
-The use of existing expression to express uniqueness, instead of using a new keyword `UNIQUE`, on the form:
+The use of an existing expression to express uniqueness -- instead of using a new keyword `UNIQUE` -- becomes unwieldy for multiple properties, as exemplified by the following:
 ----
 FOR (p:Person), (q:Person)
 REQUIRE p.email <> q.email AND p <> q
 ----
-which quickly becomes unwieldy for multiple properties.
 
 == What others do
 
 In SQL, the following constraints exist (http://www.w3schools.com/sql/sql_constraints.asp):
 
-* `NOT NULL` - Indicates that a column cannot store NULL value
-* `UNIQUE` - Ensures that each row for a column must have a unique value
-* `PRIMARY KEY` - A combination of a `NOT NULL` and `UNIQUE`. Ensures that a column (or combination of two or more columns) have a unique identity which helps to find a particular record in a table more easily and quickly
-* `FOREIGN KEY` - Ensure the referential integrity of the data in one table to match values in another table
+* `NOT NULL` - Indicates that a column cannot store a null value.
+* `UNIQUE` - Ensures that each row for a column must have a unique value.
+* `PRIMARY KEY` - A combination of a `NOT NULL` and `UNIQUE`. Ensures that a column (or a combination of two or more columns) has a unique identity, reducing the resources required to locate a specific record in a table.
+* `FOREIGN KEY` - Ensures the referential integrity of the data in one table matches values in another table.
 * `CHECK` - Ensures that the value in a column meets a specific condition
-* `DEFAULT` - Specifies a default value for a column
-The next chapters will describe each constraint in detail.
+* `DEFAULT` - Specifies a default value for a column.
 
-The property existence constraints represent the same functionality as the `NOT NULL` SQL constraint.
-The node property uniqueness constraint represents the `PRIMARY KEY` SQL constraint.
+The property existence constraints correspond to the `NOT NULL` SQL constraint.
+The node property uniqueness constraint corresponds to the `PRIMARY KEY` SQL constraint.
 
-SQL constraints may be introduced at table creation time (in a `CREATE TABLE` statement), or in an `ALTER TABLE` statement:
+SQL constraints may be introduced at table creation time in a `CREATE TABLE` statement, or in an `ALTER TABLE` statement:
 
-.Creating a persons table in SQL Server / Oracle / MS Access:
+.Creating a `Person` table in SQL Server / Oracle / MS Access:
 [source, sql]
 ----
-CREATE TABLE Persons
+CREATE TABLE Person
 (
    P_Id int NOT NULL UNIQUE,
    LastName varchar(255) NOT NULL,
    FirstName varchar(255))
 ----
 
-.Creating a persons table in MySQL:
+.Creating a `Person` table in MySQL:
 [source, sql]
 ----
-CREATE TABLE Persons
+CREATE TABLE Person
 (
   P_Id int NOT NULL,
   LastName varchar(255) NOT NULL,
@@ -272,14 +270,14 @@ CREATE TABLE Persons
 .Adding a named composite `UNIQUE` constraint in MySQL / SQL Server / Oracle / MS Access:
 [source, sql]
 ----
-ALTER TABLE Persons
+ALTER TABLE Person
 ADD CONSTRAINT uc_PersonID UNIQUE (P_Id,LastName)
 ----
 
 == Benefits to this proposal
 
-Constraints make Cypher's notion of schema more well-defined, and allows users to keep graphs in a more regular, easier to manage form.
+Constraints make Cypher's notion of schema more well-defined, allowing users to maintain graphs in a more regular, easier-to-manage form.
 
 == Caveats to this proposal
 
-For an implementing system, some constraints may prove challenging to enforce, as they generally require scanning through large parts of the graph to look for conflicting entities.
+Some constraints may prove challenging to enforce in a system seeking to implement the contents of this CIP, as these generally require scanning through large parts of the graph to locate conflicting entities.

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -26,40 +26,45 @@ Constraints allow us to mould the heterogeneous nature of the property graph int
 
 == Proposal
 
-This CIP includes the following proposed constraints:
+This CIP specifies the general syntax for constraint definition (and constraint removal), and provides several examples of possible use cases for constraints.
+However, the specification does not otherwise specify or limit the space of expressible constraints that the syntax and semantics allow.
 
-* <<uniqueness>>
-* <<existence, Node property existence constraint>>
-* <<existence, Relationship property existence constraint>>
-
-Each constraint is detailed in the sections below.
+===== Mutability
 
 Once a constraint has been created, it may not be amended.
 Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
 
-==== Constraint names
+===== Constraint names
 
 All constraints require the user to specify a nonempty _name_ at constraint creation time.
 This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
 
 // TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
 
-=== Syntax overview
+=== Syntax
 
-The syntax for all constraints follow the same basic outline.
+The constraint syntax is defined as follows:
 
 .Grammar definition for constraint syntax.
 [source, ebnf]
 ----
 constraint command = create-constraint | drop-constraint ;
-create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", constraint-pattern, "REQUIRE", constraint-expr ;
+create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", constraint-pattern, "REQUIRE", constraint-expr, { "REQUIRE", constraint-expr } ;
 constraint-name    = symbolic-name
 constraint-pattern = node-pattern | simple-pattern ;
-constraint-expr    = uniqueness-constraint | existence-constraint ;
+constraint-expr    = uniqueness-expr | expression ;
+uniquness-expr     = "UNIQUE", property-expression, { ",", property-expression }
 drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
 ----
 
-The constraint expressions vary depending on the actual constraint (see the detailed sections).
+The constraint expression (`constraint-expr` above) is any expression that evaluates to a boolean value.
+This allows for very complex concrete constraint definitions within the specified syntax.
+
+To that set of valid expressions, this CIP further specifies a special prefix operator `UNIQUE`, which is used to assert uniqueness of one or more property expressions.
+
+==== Removing constraints
+
+A constraint is removed by referring to its name.
 
 .Example of dropping a constraint with name `foo`:
 [source, cypher]
@@ -67,7 +72,33 @@ The constraint expressions vary depending on the actual constraint (see the deta
 DROP CONSTRAINT foo
 ----
 
-=== Semantics overview
+=== Semantics
+
+The semantics for constraints follow these general rules:
+
+1. The constraint pattern define the constraint domain, where all entities that would be returned by a `MATCH` clause with the same pattern constitute the domain, with one notable exception (see <<domain-exception, 3.>>).
+
+2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`. Any other result raises an error (see <<Errors>>).
+
+3. [[domain-exception]]Entities for which a constraint expression evaluate to `null` under Cypher's ternary logic are _excluded_ from the constraint domain, even if they fit within the constraint pattern.
+
+==== Uniqueness
+
+The new operator `UNIQUE` is only valid as part of a constraint expression.
+It takes as argument one or more property expressions, and asserts that the combination of the evaluated values of the expressions (forming a tuple) is unique across the constraint domain.
+
+The domain of the uniqueness expression is limited to entities for which _all_ properties defined as arguments to the `UNIQUE` operator exist.
+In other words, property expressions which evaluate to `null` are not considered for uniqueness (see <<domain-exception,3.>>) above.
+
+.Example of a constraint definition using `UNIQUE`, over the domain of nodes labeled with `:Person`:
+[source, cypher]
+----
+CREATE CONSTRAINT unique_person_details
+FOR (p:Person)
+REQUIRE UNIQUE p.name, p.email, p.address
+----
+
+==== Errors
 
 The following list describes the situations in which an error will be raised:
 
@@ -79,44 +110,19 @@ The following list describes the situations in which an error will be raised:
 The constraints define a _domain_ within which the constraint applies.
 The domain is defined by the constraint pattern.
 
-[[uniqueness]]
-=== Node property uniqueness constraint
+==== Compositionality
 
-This constraint enforces that there cannot be duplicate values of some property `p` for any node labeled with some label `l`.
-For example, this constraint can specify that the `email` property must be unique for all nodes labeled with `:Person`.
+It is possible to define multiple `REQUIRE` clauses within the scope of the same constraint.
+The semantics between these is that of a conjunction between the constraint expressions of the clauses, such that the constraint is upheld if and only if for all `REQUIRE` clauses, the expression evaluates to `true`.
 
-==== Syntax
+This is useful not only for readability and logical separation of different aspects of the same constraint, but also for combining the use of the `UNIQUE` operator with other constraint expressions.
 
-.Grammar definition for the node property uniqueness constraint:
-[source, ebnf]
-----
-uniqueness-constraint = "UNIQUE", property-expression, { ",", property-expression } ;
-----
+=== Examples
 
-.Example of a single-property uniqueness constraint:
-[source, cypher]
-----
-CREATE CONSTRAINT unique_person_email
-FOR (p:Person)
-REQUIRE UNIQUE p.email
-----
+In this section we provide several examples of constraints that are possible to express in the specified syntax.
 
-.Example of a multiple-property uniqueness constraint:
-[source, cypher]
-----
-CREATE CONSTRAINT unique_person_details
-FOR (p:Person)
-REQUIRE UNIQUE p.name, p.email, p.address
-----
-
-==== Semantics
-
-The domain of a property uniqueness constraint is defined as all the nodes with a specific label where the specified property key(s) exist (i.e. are not null).
-When more than one property key is defined as part of the constraint, only nodes where _all_ of the properties exist are part of the domain.
-
-The uniqueness constraint mandates that two distinct nodes within the domain cannot have the same combination of values for the defined properties.
-
-===== Example
+[NOTE]
+The specification in this CIP is limited to the general syntax of constraints, and the following are simply examples of possible uses of the language defined by that syntax. None of the examples provided are to be viewed as mandatory for any Cypher implementation.
 
 Consider the graph created by the statement below.
 The graph contains nodes labeled with `:Color`.
@@ -150,48 +156,7 @@ FOR (c:Color)
 REQUIRE UNIQUE c.rgb, c.name
 ----
 
-[[existence]]
-=== Property existence constraints
-
-Property existence constraints are defined for both nodes and relationships; these have the same semantics.
-We now describe both of these.
-
-==== Syntax
-
-.Grammar definition for the property existence constraint:
-[source, ebnf]
-----
-existence-constraint = "exists", "(", property-expression, ")" ;
-----
-
-.Example of a node property existence constraint:
-[source, cypher]
-----
-CREATE CONSTRAINT colors_must_have_rgb
-FOR (c:Color)
-REQUIRE exists(c.rgb)
-----
-
-.Example of a relationship property existence constraint:
-[source, cypher]
-----
-CREATE CONSTRAINT rates_have_quality
-FOR ()-[l:RATED]-()
-REQUIRE exists(l.rating)
-----
-
-==== Semantics
-
-The domain of a node property existence constraint are all nodes with the specified label.
-Similarly, the domain of a relationship property existence constraint are all relationship with the specified type.
-
-The property existence constraint mandates that the value of the specified property exists (i.e. is not null) for all entities in the domain.
-
-===== Example
-
-Consider once again the graph containing `:Color` nodes.
-
-The following query retrieves the RGB value of a color with a given `name`:
+Now, consider the following query which retrieves the RGB value of a color with a given `name`:
 
 [source, cypher]
 ----
@@ -200,8 +165,8 @@ WHERE exists(c.rgb)
 RETURN c.rgb
 ----
 
-The `WHERE` clause may be used to prevent an application from retrieving `null` values for user-defined colors where the RGB values have not been specified correctly.
-It may, however, be eliminated by the introduction of a node property existence constraint:
+The `WHERE` clause is here used to prevent an application from retrieving `null` values for user-defined colors where the RGB values have not been specified correctly.
+It may, however, be eliminated by the introduction of a constraint asserting the existence of that property:
 
 [source, cypher]
 ----
@@ -210,7 +175,53 @@ FOR (c:Color)
 REQUIRE exists(c.rgb)
 ----
 
-Any updating statement that would create a `:Color` node without specifying a `rgb` property for it would now fail.
+Any updating statement that would create a `:Color` node without specifying an `rgb` property for it would now fail.
+
+Alternatively, we could extend our previous constraint definition with this new requirement:
+
+[source, cypher]
+----
+CREATE CONSTRAINT color_schema
+FOR (c:Color)
+REQUIRE UNIQUE c.rgb, c.name
+REQUIRE exists(c.rgb)
+----
+
+This composite constraint will make sure that all `:Color` nodes has a value for their `rgb` property, and that its value is unique for each `name`.
+
+More complex constraint definitions are considered below:
+
+.Property value limitations
+[source, cypher]
+----
+CREATE CONSTRAINT road_width
+FOR ()-[r:ROAD]-()
+REQUIRE 5 < r.width < 50
+----
+
+.Cardinality
+[source, cypher]
+----
+CREATE CONSTRAINT spread_the_love
+FOR (p:Person)
+REQUIRE size((p)-[:LOVES]->()) > 3
+----
+
+.Endpoint requirements
+[source, cypher]
+----
+CREATE CONSTRAINT can_only_own_things
+FOR ()-[:OWNS]->(t)
+REQUIRE (t:Vehicle) OR (t:Building) OR (t:Object)
+----
+
+.Label coexistence
+[source, cypher]
+----
+CREATE CONSTRAINT programmers_are_people_too
+FOR (p:Programmer)
+REQUIRE p:Person
+----
 
 === Interaction with existing features
 
@@ -224,7 +235,7 @@ Alternative syntaxes have been discussed:
 * `GIVEN`, `CONSTRAIN`, `ASSERT` instead of `FOR`
 * `ASSERT`, `ENFORCE`, `IMPLIES` instead of `REQUIRE`
 
-The use of an existing expression to express uniqueness -- instead of using a new keyword `UNIQUE` -- becomes unwieldy for multiple properties, as exemplified by the following:
+The use of an existing expression to express uniqueness -- instead of using the operator `UNIQUE` -- becomes unwieldy for multiple properties, as exemplified by the following:
 ----
 FOR (p:Person), (q:Person)
 REQUIRE p.email <> q.email AND p <> q
@@ -278,6 +289,9 @@ ADD CONSTRAINT uc_PersonID UNIQUE (P_Id,LastName)
 == Benefits to this proposal
 
 Constraints make Cypher's notion of schema more well-defined, allowing users to maintain graphs in a more regular, easier-to-manage form.
+
+Additionally, this specification is deliberately defining a constraint _language_ within which a great deal of possible concrete constraints are made possible.
+This allows different implementers of Cypher to independently choose how to limit the scope of supported constraint expressions that fit their model and targeted use cases.
 
 == Caveats to this proposal
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -25,18 +25,6 @@ Constraints allow us to mould the heterogeneous nature of the property graph int
 This CIP specifies the general syntax for constraint definition (and constraint removal), and provides several examples of possible use cases for constraints.
 However, the specification does not otherwise specify or limit the space of expressible constraints that the syntax and semantics allow.
 
-===== Mutability
-
-Once a constraint has been created, it may not be amended.
-Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
-
-===== Constraint names
-
-All constraints require the user to specify a nonempty _name_ at constraint creation time.
-This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
-
-// TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
-
 === Syntax
 
 The constraint syntax is defined as follows:
@@ -58,6 +46,13 @@ This allows for very complex concrete constraint definitions within the specifie
 
 To that set of valid expressions, this CIP further specifies a special prefix operator `UNIQUE`, which is used to assert uniqueness of one or more property expressions.
 
+==== Constraint names
+
+All constraints require the user to specify a nonempty _name_ at constraint creation time.
+This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
+
+// TODO: Should we impose restrictions on the domain of constraint names, or are all Unicode characters allowed?
+
 ==== Removing constraints
 
 A constraint is removed by referring to its name.
@@ -77,6 +72,11 @@ The semantics for constraints follow these general rules:
 2. The constraint expressions defined in the `REQUIRE` clauses of the constraint definition must all evaluate to `true`. Any other result raises an error (see <<Errors>>).
 
 3. [[domain-exception]]Entities for which a constraint expression evaluate to `null` under Cypher's ternary logic are _excluded_ from the constraint domain, even if they fit within the constraint pattern.
+
+==== Mutability
+
+Once a constraint has been created, it may not be amended.
+Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
 
 ==== Uniqueness
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -32,8 +32,8 @@ The constraint syntax is defined as follows:
 .Grammar definition for constraint syntax.
 [source, ebnf]
 ----
-constraint command    = create-constraint | drop-constraint ;
-create-constraint     = "CREATE", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
+constraint command    = add-constraint | drop-constraint ;
+add-constraint        = "ADD", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
 constraint-name       = symbolic-name
 constraint-predicate  = expression | unique | node-key ;
 unique                = "UNIQUE", property-expression
@@ -76,15 +76,16 @@ The semantics for constraints follow these general rules:
 
 The following list describes the situations in which an error will be raised:
 
-* Attempting to create a constraint on a graph where the data does not comply with the constraint criterion.
-* Attempting to create a constraint with a name that already exists.
+* Attempting to add a constraint on a graph where the data does not comply with the constraint criterion.
+* Attempting to add a constraint with a name that already exists.
+* Attempting to add a constraint that the underlying engine does not support enforcing.
 * Attempting to drop a constraint referencing a non-existent name.
 * Attempting to modify the graph in such a way that it would violate a constraint.
 
 ==== Mutability
 
-Once a constraint has been created, it may not be amended.
-Should a user wish to change its definition, it has to be dropped and recreated with an updated structure.
+Once a constraint has been added, it may not be amended.
+Should a user wish to change its definition, it has to be dropped and added anew with an updated structure.
 
 [[uniqueness]]
 ==== Uniqueness
@@ -96,7 +97,7 @@ Following on rule <<domain-exception,3.>> above, entities for which the property
 .Example of a constraint definition using `UNIQUE`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
-CREATE CONSTRAINT only_one_person_per_name
+ADD CONSTRAINT only_one_person_per_name
 FOR (p:Person)
 REQUIRE UNIQUE p.name
 ----
@@ -112,7 +113,7 @@ The domain of a node key constraint is thus exactly defined as all entities whic
 .Example of a constraint definition using `NODE KEY`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
-CREATE CONSTRAINT person_details
+ADD CONSTRAINT person_details
 FOR (p:Person)
 REQUIRE NODE KEY p.name, p.email, p.address
 ----
@@ -122,7 +123,7 @@ In the context of a single property, a semantically equivalent constraint is ach
 .Example of a constraint definition equivalent to a `NODE KEY` on a single property `name`:
 [source, cypher]
 ----
-CREATE CONSTRAINT person_details
+ADD CONSTRAINT person_details
 FOR (p:Person)
 REQUIRE UNIQUE p.name
 REQUIRE exists(p.name)
@@ -140,7 +141,7 @@ In this section we provide several examples of constraints that are possible to 
 [NOTE]
 The specification in this CIP is limited to the general syntax of constraints, and the following are simply examples of possible uses of the language defined by that syntax. None of the examples provided are to be viewed as mandatory for any Cypher implementation.
 
-Consider the graph created by the statement below.
+Consider the graph added by the statement below.
 The graph contains nodes labeled with `:Color`.
 Each color is represented as an integer-type RGB value in a property `rgb`.
 Users may look up nodes labeled with `:Color` to extract their RGB values for application processing.
@@ -153,11 +154,11 @@ CREATE (:Color {name: 'black', rgb: 0x000000})
 CREATE (:Color {name: 'very, very dark grey', rgb: 0x000000}) // rounding error!
 ----
 
-Owing to the duplication of the `rgb` property, the following attempt at creating a constraint will fail:
+Owing to the duplication of the `rgb` property, the following attempt at adding a constraint will fail:
 
 [source, cypher]
 ----
-CREATE CONSTRAINT only_one_color_per_rgb
+ADD CONSTRAINT only_one_color_per_rgb
 FOR (c:Color)
 REQUIRE UNIQUE c.rgb
 ----
@@ -176,7 +177,7 @@ It may, however, be eliminated by the introduction of a constraint asserting the
 
 [source, cypher]
 ----
-CREATE CONSTRAINT colors_must_have_rgb
+ADD CONSTRAINT colors_must_have_rgb
 FOR (c:Color)
 REQUIRE exists(c.rgb)
 ----
@@ -187,7 +188,7 @@ If we instead want to make the _combination_ of the properties `name` and `rgb` 
 
 [source, cypher]
 ----
-CREATE CONSTRAINT color_schema
+ADD CONSTRAINT color_schema
 FOR (c:Color)
 REQUIRE NODE KEY c.rgb, c.name
 ----
@@ -200,7 +201,7 @@ More complex constraint definitions are considered below:
 .Multiple property existence using conjunction
 [source, cypher]
 ----
-CREATE CONSTRAINT person_properties
+ADD CONSTRAINT person_properties
 FOR (p:Person)
 REQUIRE exists(p.name) AND exists(p.email)
 ----
@@ -208,7 +209,7 @@ REQUIRE exists(p.name) AND exists(p.email)
 .Using larger pattern
 [source, cypher]
 ----
-CREATE CONSTRAINT not_rating_own_posts
+ADD CONSTRAINT not_rating_own_posts
 FOR (u1:User)-[:RATED]->(:Post)<-[:POSTED_BY]-(u2:User)
 REQUIRE u.name <> u2.name
 ----
@@ -216,7 +217,7 @@ REQUIRE u.name <> u2.name
 .Property value limitations
 [source, cypher]
 ----
-CREATE CONSTRAINT road_width
+ADD CONSTRAINT road_width
 FOR ()-[r:ROAD]-()
 REQUIRE 5 < r.width < 50
 ----
@@ -224,7 +225,7 @@ REQUIRE 5 < r.width < 50
 .Cardinality
 [source, cypher]
 ----
-CREATE CONSTRAINT spread_the_love
+ADD CONSTRAINT spread_the_love
 FOR (p:Person)
 REQUIRE size((p)-[:LOVES]->()) > 3
 ----
@@ -232,7 +233,7 @@ REQUIRE size((p)-[:LOVES]->()) > 3
 .Endpoint requirements
 [source, cypher]
 ----
-CREATE CONSTRAINT can_only_own_things
+ADD CONSTRAINT can_only_own_things
 FOR ()-[:OWNS]->(t)
 REQUIRE (t:Vehicle) OR (t:Building) OR (t:Object)
 ----
@@ -240,7 +241,7 @@ REQUIRE (t:Vehicle) OR (t:Building) OR (t:Object)
 .Label coexistence
 [source, cypher]
 ----
-CREATE CONSTRAINT programmers_are_people_too
+ADD CONSTRAINT programmers_are_people_too
 FOR (p:Programmer)
 REQUIRE p:Person
 ----
@@ -250,7 +251,7 @@ Assuming a function `acyclic()` that takes a path as argument and returns `true`
 .Constraint example from CIR-2017-172
 [source, cypher]
 ----
-CREATE CONSTRAINT enforce_dag_acyclic_for_R_links
+ADD CONSTRAINT enforce_dag_acyclic_for_R_links
 FOR p = ()-[:R*]-()
 REQUIRE acyclic(p)
 ----

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -32,23 +32,25 @@ The constraint syntax is defined as follows:
 .Grammar definition for constraint syntax.
 [source, ebnf]
 ----
-constraint command = create-constraint | drop-constraint ;
-create-constraint  = "CREATE", "CONSTRAINT", constraint-name, "FOR", pattern, "REQUIRE", constraint-expr, { "REQUIRE", constraint-expr } ;
-constraint-name    = symbolic-name
-constraint-expr    = uniqueness-expr | expression ;
-uniquness-expr     = "UNIQUE", property-expression, { ",", property-expression }
-drop-constraint    = "DROP", "CONSTRAINT", constraint-name ;
+constraint command    = create-constraint | drop-constraint ;
+create-constraint     = "CREATE", "CONSTRAINT", [ constraint-name ], "FOR", pattern, "REQUIRE", constraint-predicate, { "REQUIRE", constraint-predicate } ;
+constraint-name       = symbolic-name
+constraint-predicate  = expression | unique | primary-key ;
+unique                = "UNIQUE", property-expression
+primary-key           = "PRIMARY KEY", property-expression, { ",", property-expression }
+drop-constraint       = "DROP", "CONSTRAINT", constraint-name ;
 ----
 
-The constraint expression (`constraint-expr` above) is any expression that evaluates to a boolean value.
-This allows for very complex concrete constraint definitions within the specified syntax.
+The `REQUIRE` clause works exactly like the `WHERE` clause in a standard Cypher query, with the addition of also supporting the special constraint operators `UNIQUE` and `PRIMARY KEY`.
+This allows for very complex concrete constraint definitions (using custom predicates) within the specified syntax.
 
-To that set of valid expressions, this CIP further specifies a special prefix operator `UNIQUE`, which is used to assert uniqueness of one or more property expressions (see <<uniqueness>> for details).
+For details on `UNIQUE` and `PRIMARY KEY`, see the dedicated sections below: <<uniqueness>>, <<primary-key>>.
 
 ==== Constraint names
 
-All constraints require the user to specify a nonempty _name_ at constraint creation time.
+All constraints provide the user the option to specify a nonempty _name_ at constraint creation time.
 This name is subsequently the handle with which a user may refer to the constraint, for example when dropping it.
+In the case where a name is not provided, the system will generate a unique name.
 
 ==== Removing constraints
 
@@ -87,26 +89,50 @@ Should a user wish to change its definition, it has to be dropped and recreated 
 [[uniqueness]]
 ==== Uniqueness
 
-The new operator `UNIQUE` is only valid as part of a constraint expression.
-It takes as argument one or more property expressions, and asserts that the combination of the evaluated values of the expressions (forming a tuple) is unique across the constraint domain.
-
-The domain of the uniqueness expression is limited to entities for which _all_ properties defined as arguments to the `UNIQUE` operator exist.
-In other words, property expressions which evaluate to `null` are not considered for uniqueness (see <<domain-exception,3.>>) above.
+The new operator `UNIQUE` is only valid as part of a constraint predicate.
+It takes as argument a single property expression, and asserts that this property is unique across the domain of the constraint.
+Following on rule <<domain-exception,3.>> above, entities for which the property is not defined (is `null`) are not part of the constraint domain.
 
 .Example of a constraint definition using `UNIQUE`, over the domain of nodes labeled with `:Person`:
 [source, cypher]
 ----
-CREATE CONSTRAINT unique_person_details
+CREATE CONSTRAINT only_one_person_per_name
 FOR (p:Person)
-REQUIRE UNIQUE p.name, p.email, p.address
+REQUIRE UNIQUE p.name
+----
+
+[[primary-key]]
+==== Primary key
+
+The new operator `PRIMARY KEY` is only valid as part of a constraint predicate.
+It takes as argument one or more property expressions, and asserts that the combination of the evaluated values of the expressions (forming a tuple) is unique across the constraint domain.
+It further asserts that the property expressions all exist on the entities of the domain, and thus avoids applicability of rule <<domain-exception, 3.>> above. The domain of a primary key constraint is thus exactly defined as all entities which fit the constraint pattern.
+
+.Example of a constraint definition using `PRIMARY KEY`, over the domain of nodes labeled with `:Person`:
+[source, cypher]
+----
+CREATE CONSTRAINT person_details
+FOR (p:Person)
+REQUIRE PRIMARY KEY p.name, p.email, p.address
+----
+
+A semantically equivalent constraint is achieved by composing the use of the `UNIQUE` operator with `exists()` predicates, as exemplified by:
+
+.Example of a constraint definition equivalent to the above `PRIMARY KEY` example:
+[source, cypher]
+----
+CREATE CONSTRAINT person_details
+FOR (p:Person)
+REQUIRE UNIQUE p.name
+REQUIRE UNIQUE p.email
+REQUIRE UNIQUE p.address
+REQUIRE exists(p.name) AND exists(p.email) AND exists(p.address)
 ----
 
 ==== Compositionality
 
 It is possible to define multiple `REQUIRE` clauses within the scope of the same constraint.
-The semantics between these is that of a conjunction between the constraint expressions of the clauses, such that the constraint is upheld if and only if for all `REQUIRE` clauses, the expression evaluates to `true`.
-
-This is useful not only for readability and logical separation of different aspects of the same constraint, but also for combining the use of the `UNIQUE` operator with other constraint expressions.
+The semantics between these is that of a conjunction (under standard 2-valued boolean logic) between the constraint predicates of the clauses, such that the constraint is upheld if and only if for all `REQUIRE` clauses, the joint predicate evaluates to `true`.
 
 === Examples
 
@@ -144,7 +170,8 @@ We could then use the following constraint, without modifying our data:
 ----
 CREATE CONSTRAINT unique_color_nodes
 FOR (c:Color)
-REQUIRE UNIQUE c.rgb, c.name
+REQUIRE UNIQUE c.rgb
+REQUIRE UNIQUE c.name
 ----
 
 Now, consider the following query which retrieves the RGB value of a color with a given `name`:
@@ -168,17 +195,16 @@ REQUIRE exists(c.rgb)
 
 Any updating statement that would create a `:Color` node without specifying an `rgb` property for it would now fail.
 
-Alternatively, we could extend our previous constraint definition with this new requirement:
+If we also want to mandate the existence of the `name` property, we could use a `PRIMARY KEY` operator to capture all these requirements in a single constraint:
 
 [source, cypher]
 ----
 CREATE CONSTRAINT color_schema
 FOR (c:Color)
-REQUIRE UNIQUE c.rgb, c.name
-REQUIRE exists(c.rgb)
+REQUIRE PRIMARY KEY c.rgb, c.name
 ----
 
-This composite constraint will make sure that all `:Color` nodes has a value for their `rgb` property, and that its value is unique for each `name`.
+This constraint will make sure that all `:Color` nodes has a value for their `rgb` and `name` properties, and that the combination is unique across all the nodes.
 
 More complex constraint definitions are considered below:
 
@@ -269,8 +295,9 @@ In SQL, the following constraints exist (inspired by http://www.w3schools.com/sq
 * `CHECK` - Ensures that the value in a column meets a specific condition
 * `DEFAULT` - Specifies a default value for a column.
 
-The property existence constraints correspond to the `NOT NULL` SQL constraint.
-The node property uniqueness constraint corresponds to the `PRIMARY KEY` SQL constraint.
+The `NOT NULL` SQL constraint is expressible using an `exists()` constraint predicate.
+The `UNIQUE` SQL constraint is exactly as Cypher's `UNIQUE` constraint predicate.
+The `PRIMARY KEY` SQL constraint is exactly as Cypher's `PRIMARY KEY` constraint predicate.
 
 SQL constraints may be introduced at table creation time in a `CREATE TABLE` statement, or in an `ALTER TABLE` statement:
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -25,6 +25,8 @@ Constraints allow us to mould the heterogeneous nature of the property graph int
 This CIP specifies the general syntax for constraint definition (and constraint removal), and provides several examples of possible use cases for constraints.
 However, the specification does not otherwise specify or limit the space of expressible constraints that the syntax and semantics allow.
 
+This specification also covers the return structure of constraint commands, see <<return-record>>.
+
 === Syntax
 
 The constraint syntax is defined as follows:
@@ -133,6 +135,45 @@ REQUIRE exists(p.name)
 
 It is possible to define multiple `REQUIRE` clauses within the scope of the same constraint.
 The semantics between these is that of a conjunction (under standard 2-valued boolean logic) between the constraint predicates of the clauses, such that the constraint is upheld if and only if for all `REQUIRE` clauses, the joint predicate evaluates to `true`.
+
+[[return-record]]
+==== Return record
+
+Since constraints always are named, but user-defined names are optional, the system must sometimes generate a constraint name.
+In order for a user to be able to drop such a constraint, the system-generated name is therefore returned in a standard Cypher result record.
+The result record has a fixed structure, with three string fields: `name`, `definition`, and `details`.
+
+A constraint command will always return exactly one record, if successful.
+Note that also `DROP CONSTRAINT` will return a record.
+
+===== Name
+
+This field contains the name of the constraint, either user- or system-defined.
+
+===== Definition
+
+This field contains the constraint definition, which is the contents of the constraint creation command following (and including) the `FOR` clause.
+
+===== Details
+
+The contents of this field are left unspecified, to be used for implementation-specific messages and/or details.
+
+Consider the following constraint:
+[source, Cypher]
+----
+ADD CONSTRAINT myConstraint
+FOR (n:Node)
+REQUIRE NODE KEY n.prop1, n.prop2
+----
+
+A correct result record for it could be:
+
+----
+name         | definition                                     | details
+-----------------------------------------------------------------------
+myConstraint | FOR (n:NODE)                                   | n/a
+             | REQUIRE NODE KEY n.prop1, n.prop2              |
+----
 
 === Examples
 

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -142,6 +142,43 @@ FOR (c:Color)
 REQUIRE UNIQUE c.rgb, c.name
 ----
 
+[[existence]]
+=== Property existence constraints
+
+Property existence constraints are defined for both nodes and relationships, but the semantics are the same.
+For this reason we will go over both constraints in the same section.
+
+==== Syntax
+
+.Grammar definition for property existence constraint:
+[source, ebnf]
+----
+existence-constraint = "exists", "(", property-expression, ")" ;
+----
+
+.Example of node property existence constraint:
+[source, cypher]
+----
+CREATE CONSTRAINT colors_must_have_rgb
+FOR (c:Color)
+REQUIRE exists(c.rgb)
+----
+
+.Example of relationship property existence constraint:
+[source, cypher]
+----
+CREATE CONSTRAINT rates_have_quality
+FOR ()-[l:RATED]-()
+REQUIRE exists(l.rating)
+----
+
+==== Semantics
+
+Property existence constraints enforce that the value of the specified property is non-null for all entities in the constraint domain.
+
+
+===== Example
+
 === Interaction with existing features
 
 The main interaction between the constraints and the rest of the language happens during updating statements.

--- a/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
+++ b/cip/1.accepted/CIP2016-12-14-Constraint-syntax.adoc
@@ -217,6 +217,16 @@ FOR (p:Programmer)
 REQUIRE p:Person
 ----
 
+Assuming a function `acyclic()` that takes a path as argument and returns `true` if and only if the same node does not appear twice in the path, otherwise `false`, we may express:
+
+.Constraint example from CIR-2017-172
+[source, cypher]
+----
+CREATE CONSTRAINT enforce_dag_acyclic_for_R_links
+FOR p = ()-[:R*]-()
+REQUIRE acyclic(p)
+----
+
 === Interaction with existing features
 
 The main interaction between the constraints and the rest of the language occurs during updating statements.

--- a/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
+++ b/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
@@ -1,4 +1,4 @@
-= CIP2016-12-16 - Neo4j Indexes
+= CIP2016-12-16 Neo4j Indexes
 :numbered:
 :toc:
 :toc-placement: macro

--- a/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
+++ b/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
@@ -26,7 +26,7 @@ These nodes are kept in a separate, persisted data structure which allows lookup
 
 === Syntax
 
-The index syntax is based on the constraint syntax, and is detailed below:
+The index syntax is based on the constraint syntax (see the Constraint Syntax CIP), and is detailed below:
 
 .Grammar definition for Neo4j index syntax.
 [source, ebnf]
@@ -44,7 +44,7 @@ The `index-key` expression defines the key for the index, and consist of one or 
 ==== Index names
 
 Just like constraints, indexes have names.
-Neo4j does not support user-defined names, but the index will be assigned a system-generated name.
+If the user does not provide a name, a system-generated name will be generated.
 
 ==== Removing indexes
 
@@ -60,21 +60,31 @@ DROP INDEX index-1
 
 Indexes do not impose any semantics on the graph, or on queries.
 They exist solely for performance reasons.
-
-Any query that is matching for nodes using a label and property/ies that match an index is viable to be planned using the matching index.
-The _query key_ is formed by combining the referenced properties, and using this to scan the index for matching entities.
-Predicates in which
+In other words, any query on any graph should behave exactly identical in the presence of indexes as they would otherwise.
 
 ==== Domain
 
-Only nodes with the specified label, and values for _all_ the properties are considered part of the index domain.
-This means that only queries that specify _all_ the properties will be able to be planned with index lookups.
-Queries that only reference a subset of properties of an index will need the creation of another, smaller index that is defined using those properties only.
+For a node to be considered part of an index domain, it is required that it
+
+A. has the label referenced in the index pattern
+B. [[B]]has a value different from `null` for all properties referenced in the index key
+
+A consequence of <<B, B.>> is that an index will only partially support queries that project the indexed properties.
+However, queries that pose predicates on the indexed properties will still enjoy full support in many cases.
+See <<domain-example>> for more details on this difference.
+
+==== Errors
+
+The following list describes the situations in which an error will be raised:
+
+* Attempting to create an index with a name that already exists.
+* Attempting to create an index that the underlying engine does not support enforcing.
+* Attempting to drop an index referencing a non-existent name.
 
 ==== Mutability
 
 Once an index has been created, its definition may not be amended.
-Should a user wish to change its definition, the index will have to be dropped and recreated with an updated structure.
+Should a user wish to change the definition of an index, the index will have to be dropped and recreated with the amended definition.
 
 === Examples
 
@@ -83,29 +93,81 @@ Creating indexes is straight-forward following the specified syntax.
 .An index with multiple properties
 [source, cypher]
 ----
-CREATE INDEX
+CREATE INDEX addresses
 FOR (a:Address)
 ON a.street, a.city, a.country
 ----
 
-.An index with a single properties
+.An index with a single property
 [source, cypher]
 ----
-CREATE INDEX
+CREATE INDEX person_names
 FOR (p:Person)
 ON p.name
 ----
 
+[[domain-example]]
+==== Domain example
+
+Consider a graph of `:Person` nodes with `name`, `email`, and `age` properties.
+Not all nodes in this graph has all properties.
+On this graph we declare the following index on all the properties:
+
+[source, cypher]
+----
+CREATE INDEX person_properties
+FOR (p:Person)
+ON p.name, p.email, p.age
+----
+
+Queries that _project_ these properties will be unable to find all nodes for its result in the index domain.
+The projection query is required to return all nodes regardless of whether the projected properties contain non-null values or not, and nodes with `null` for any of the referenced properties will not be found in the index domain.
+
+.Projection query:
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN p.name, p.age, p.email
+----
+
+Queries that pose _conjunctive predicates_ on the properties will however be able to find all required nodes in the index domain.
+The predicate query is only required to return all nodes that passes the predicate, and predicates on non-existing properties will discard the tuple.
+This applies even when the predicate does not reference all indexed properties.
+
+.Conjunctive predicate query:
+[source, cypher]
+----
+MATCH (p:Person)
+WHERE p.email ENDS WITH '@opencypher.org'
+  AND p.age > 25
+RETURN p.name, p.age, p.email
+----
+
+[NOTE]
+While this example is generally applicable, some predicate constructs behave differently for `null` values and need to taken into special consideration.
+
+.Predicate with special `null` semantics:
+[source, cypher]
+----
+MATCH (p:Person)
+WHERE p.email IS NULL
+  AND p.age > 25
+RETURN p.name, p.age, p.email
+----
+
+In this query the index domain does not contain all nodes required for the result.
+Similar reasoning must be applied to disjunctive predicates which reference expressions other than indexed properties (e.g. `WHERE p.age > 25 OR p.country = 'SWE'` ).
+
 ==== Combination with Neo4j constraints
 
-In Neo4j, constraints are upheld through the use of indexes.
-Neo4j supports three types of constraints: property uniqueness, property existence, and primary key.
+In Neo4j, constraints are generally upheld through the use of indexes.
+Neo4j supports three types of constraints: property uniqueness, property existence, and node key.
 These are expressed as exemplified below.
 
 .A Neo4j property uniqueness constraint
 [source, cypher]
 ----
-CREATE CONSTRAINT
+CREATE CONSTRAINT one_address_per_street
 FOR (a:Address)
 REQUIRE UNIQUE a.street
 ----
@@ -113,26 +175,28 @@ REQUIRE UNIQUE a.street
 .A Neo4j node property existence constraint
 [source, cypher]
 ----
-CREATE CONSTRAINT
+CREATE CONSTRAINT streets_on_all_addresses
 FOR (a:Address)
 REQUIRE exists(a.street)
 ----
 
-.A Neo4j relationship property existence constraint
+.A Neo4j node key constraint
 [source, cypher]
 ----
-CREATE CONSTRAINT
-FOR ()-[o:OWNS]->()
-REQUIRE exists(o.since)
-----
-
-.A Neo4j primary key constraint
-[source, cypher]
-----
-CREATE CONSTRAINT
+CREATE CONSTRAINT address_key
 FOR (a:Address)
-REQUIRE PRIMARY KEY a.street, a.city, a.country
+REQUIRE NODE KEY a.street, a.city, a.country
 ----
 
 Creating a constraint as outlined above will also create a matching index.
 It will not be possible to drop that index without also dropping the constraint.
+
+An exception to this rule is the relationship existence constraint, which is not upheld by the use of an index.
+
+.A Neo4j relationship property existence constraint
+[source, cypher]
+----
+CREATE CONSTRAINT owning_must_have_start_time
+FOR ()-[o:OWNS]->()
+REQUIRE exists(o.since)
+----

--- a/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
+++ b/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
@@ -1,0 +1,138 @@
+= CIP2016-12-16 - Neo4j Indexes
+:numbered:
+:toc:
+:toc-placement: macro
+:source-highlighter: codemirror
+
+*Author:* Mats Rydberg <mats@neotechnology.com>
+
+[abstract]
+.Abstract
+--
+This CIP details Neo4j's indexing extension to Cypher, which is based on the standardised constraints syntax.
+--
+
+toc::[]
+
+== Background
+
+In Neo4j, indexes are formed using label and property combinations.
+This enables queries that reference these label/property combinations to use the index for faster lookup with reduced cardinality overhead.
+
+== Proposal
+
+Indexes in Neo4j are able to index _labeled nodes_ only.
+These nodes are kept in a separate, persisted data structure which allows lookups based on providing values for the specified indexed properties.
+
+=== Syntax
+
+The index syntax is based on the constraint syntax, and is detailed below:
+
+.Grammar definition for Neo4j index syntax.
+[source, ebnf]
+----
+index command = create-index | drop-index ;
+create-index  = "CREATE", "INDEX", [ index-name ], "FOR", index-pattern, "ON", index-key ;
+index-pattern = node-pattern
+index-name    = symbolic-name
+index-key     = property-expression { ",", property-expression } ;
+drop-index    = "DROP", "INDEX", index-name ;
+----
+
+The `index-key` expression defines the key for the index, and consist of one or more property expressions, which refer to the entity defined in the pattern.
+
+==== Index names
+
+Just like constraints, indexes have names.
+Neo4j does not support user-defined names, but the index will be assigned a system-generated name.
+
+==== Removing indexes
+
+An index is removed by referring to its name.
+
+.Example of dropping an index with name `index-1`:
+[source, cypher]
+----
+DROP INDEX index-1
+----
+
+=== Semantics
+
+Indexes do not impose any semantics on the graph, or on queries.
+They exist solely for performance reasons.
+
+Any query that is matching for nodes using a label and property/ies that match an index is viable to be planned using the matching index.
+The _query key_ is formed by combining the referenced properties, and using this to scan the index for matching entities.
+Predicates in which
+
+==== Domain
+
+Only nodes with the specified label, and values for _all_ the properties are considered part of the index domain.
+This means that only queries that specify _all_ the properties will be able to be planned with index lookups.
+Queries that only reference a subset of properties of an index will need the creation of another, smaller index that is defined using those properties only.
+
+==== Mutability
+
+Once an index has been created, its definition may not be amended.
+Should a user wish to change its definition, the index will have to be dropped and recreated with an updated structure.
+
+=== Examples
+
+Creating indexes is straight-forward following the specified syntax.
+
+.An index with multiple properties
+[source, cypher]
+----
+CREATE INDEX
+FOR (a:Address)
+ON a.street, a.city, a.country
+----
+
+.An index with a single properties
+[source, cypher]
+----
+CREATE INDEX
+FOR (p:Person)
+ON p.name
+----
+
+==== Combination with Neo4j constraints
+
+In Neo4j, constraints are upheld through the use of indexes.
+Neo4j supports three types of constraints: property uniqueness, property existence, and primary key.
+These are expressed as exemplified below.
+
+.A Neo4j property uniqueness constraint
+[source, cypher]
+----
+CREATE CONSTRAINT
+FOR (a:Address)
+REQUIRE UNIQUE a.street
+----
+
+.A Neo4j node property existence constraint
+[source, cypher]
+----
+CREATE CONSTRAINT
+FOR (a:Address)
+REQUIRE exists(a.street)
+----
+
+.A Neo4j relationship property existence constraint
+[source, cypher]
+----
+CREATE CONSTRAINT
+FOR ()-[o:OWNS]->()
+REQUIRE exists(o.since)
+----
+
+.A Neo4j primary key constraint
+[source, cypher]
+----
+CREATE CONSTRAINT
+FOR (a:Address)
+REQUIRE PRIMARY KEY a.street, a.city, a.country
+----
+
+Creating a constraint as outlined above will also create a matching index.
+It will not be possible to drop that index without also dropping the constraint.

--- a/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
+++ b/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
@@ -24,6 +24,8 @@ This enables queries that reference these label/property combinations to use the
 Indexes in Neo4j are able to index _labeled nodes_ only.
 These nodes are kept in a separate, persisted data structure which allows lookups based on providing values for the specified indexed properties.
 
+While not going into exact detail on every aspect, this proposal is intended to comply with all rules stated in the Constraint Syntax CIP, where applicable.
+
 === Syntax
 
 The index syntax is based on the constraint syntax (see the Constraint Syntax CIP), and is detailed below:

--- a/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
+++ b/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc
@@ -33,7 +33,7 @@ The index syntax is based on the constraint syntax (see the Constraint Syntax CI
 .Grammar definition for Neo4j index syntax.
 [source, ebnf]
 ----
-index command = create-index | drop-index ;
+index-command = create-index | drop-index ;
 create-index  = "CREATE", "INDEX", [ index-name ], "FOR", index-pattern, "ON", index-key ;
 index-pattern = node-pattern
 index-name    = symbolic-name
@@ -87,6 +87,44 @@ The following list describes the situations in which an error will be raised:
 
 Once an index has been created, its definition may not be amended.
 Should a user wish to change the definition of an index, the index will have to be dropped and recreated with the amended definition.
+
+[[return-record]]
+==== Return record
+
+Similar to the Constraint Syntax CIP, index commands will yield a single return record.
+The result record has a fixed structure, with three string fields: `name`, `definition`, and `details`.
+
+An index command will always return exactly one record, if successful.
+Note that also `DROP INDEX` will return a record.
+
+===== Name
+
+This field contains the name of the index, either user- or system-defined.
+
+===== Definition
+
+This field contains the index definition, which is the contents of the index creation command following (and including) the `FOR` clause.
+
+===== Details
+
+The contents of this field are left unspecified, to be used for implementation-specific messages and/or details.
+
+.Example: consider the following index:
+[source, cypher]
+----
+CREATE INDEX myIndex
+FOR (n:Node)
+ON n.prop1, n.prop2
+----
+
+A correct result record for it could be:
+
+----
+name    | definition          | details
+---------------------------------------
+myIndex | FOR (n:NODE)        | n/a
+        | ON n.prop1, n.prop2 |
+----
 
 === Examples
 

--- a/docs/standardisation-scope.adoc
+++ b/docs/standardisation-scope.adoc
@@ -44,6 +44,10 @@ It is the goal of this project to create a good and feature-rich standard langua
 * `allShortestPaths()`
 * `shortestPath()`
 
+=== Commands
+
+* `CREATE CONSTRAINT`
+
 === Operators
 
 ==== General
@@ -210,7 +214,6 @@ It is the goal of this project to create a good and feature-rich standard langua
 
 === Commands
 
-* `CREATE CONSTRAINT`
 * `CREATE INDEX`
 
 === Operators

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -146,7 +146,7 @@
     </alt>
   </production>
 
-  <production name="RelType" rr:inline="true" oc:legacy="true">
+  <production name="RelType" rr:inline="true">
     : &WS; <non-terminal ref="RelTypeName"/>
   </production>
 

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -716,6 +716,8 @@
       ANY
       NONE
       SINGLE
+      NODE
+      KEY
     </alt>
   </production>
 

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -66,7 +66,7 @@
   <!-- / NEW CONSTRAINT SYNTAX \ -->
 
   <production name="CreateConstraint">
-    ADD &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/> &SP;
+    CREATE &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/> &SP;
     FOR &SP; <non-terminal ref="ConstraintPattern"/> &SP;
     REQUIRE &SP; <non-terminal ref="ConstraintExpression"/>
   </production>

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -66,7 +66,7 @@
   <!-- / NEW CONSTRAINT SYNTAX \ -->
 
   <production name="CreateConstraint">
-    CREATE &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/> &SP;
+    ADD &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/> &SP;
     FOR &SP; <non-terminal ref="ConstraintPattern"/> &SP;
     REQUIRE &SP; <non-terminal ref="ConstraintExpression"/>
   </production>
@@ -88,17 +88,18 @@
 
   <production name="ConstraintExpression">
     <alt>
-      <non-terminal ref="NodePropertyUniquenessConstraint"/>
-      <non-terminal ref="PropertyExistenceConstraint"/>
+      <non-terminal ref="Uniqueness"/>
+      <non-terminal ref="NodeKey"/>
+      <non-terminal ref="Expression"/>
     </alt>
   </production>
 
-  <production name="NodePropertyUniquenessConstraint">
-    UNIQUE &SP; <non-terminal ref="PropertyExpression"/> <repeat>&WS; , &WS; <non-terminal ref="PropertyExpression"/></repeat>
+  <production name="Uniqueness">
+    UNIQUE &SP; <non-terminal ref="PropertyExpression"/>
   </production>
 
-  <production name="PropertyExistenceConstraint">
-    exists ( <non-terminal ref="PropertyExpression"/> )
+  <production name="NodeKey">
+    NODE &SP; KEY &SP; <non-terminal ref="PropertyExpression"/> <repeat>&WS; , &WS; <non-terminal ref="PropertyExpression"/></repeat>
   </production>
 
   <!-- / LEGACY COMMANDS \ -->

--- a/grammar/commands.xml
+++ b/grammar/commands.xml
@@ -44,7 +44,7 @@
   xmlns:rr="http://opencypher.org/railroad"
   xmlns:oc="http://opencypher.org/opencypher">
 
-  <production name="Command" rr:inline="true" oc:legacy="true">
+  <production name="Command" rr:inline="true">
     <alt>
       <non-terminal ref="CreateIndex"/>
       <non-terminal ref="DropIndex"/>
@@ -57,10 +57,51 @@
 
       <non-terminal ref="CreateRelationshipPropertyExistenceConstraint"/>
       <non-terminal ref="DropRelationshipPropertyExistenceConstraint"/>
+
+      <non-terminal ref="CreateConstraint"/>
+      <non-terminal ref="DropConstraint"/>
     </alt>
   </production>
 
-  <!-- / COMMANDS \ -->
+  <!-- / NEW CONSTRAINT SYNTAX \ -->
+
+  <production name="CreateConstraint">
+    CREATE &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/> &SP;
+    FOR &SP; <non-terminal ref="ConstraintPattern"/> &SP;
+    REQUIRE &SP; <non-terminal ref="ConstraintExpression"/>
+  </production>
+
+  <production name="DropConstraint">
+    DROP &SP; CONSTRAINT &SP; <non-terminal ref="ConstraintName"/>
+  </production>
+
+  <production name="ConstraintName">
+    <non-terminal ref="SymbolicName"/>
+  </production>
+
+  <production name="ConstraintPattern">
+    <alt>
+      <seq>( &var; &label; ) </seq>
+      <seq>( ) - [ &var; <non-terminal ref='RelType'/> ] - ( ) </seq>
+    </alt>
+  </production>
+
+  <production name="ConstraintExpression">
+    <alt>
+      <non-terminal ref="NodePropertyUniquenessConstraint"/>
+      <non-terminal ref="PropertyExistenceConstraint"/>
+    </alt>
+  </production>
+
+  <production name="NodePropertyUniquenessConstraint">
+    UNIQUE &SP; <non-terminal ref="PropertyExpression"/> <repeat>&WS; , &WS; <non-terminal ref="PropertyExpression"/></repeat>
+  </production>
+
+  <production name="PropertyExistenceConstraint">
+    exists ( <non-terminal ref="PropertyExpression"/> )
+  </production>
+
+  <!-- / LEGACY COMMANDS \ -->
 
   <production name="CreateUniqueConstraint" rr:inline="true" oc:legacy="true">
     CREATE &SP; <non-terminal ref="UniqueConstraint"/>

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -312,22 +312,23 @@ CALL db.labels() YIELD *
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
 CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§
-ADD CONSTRAINT foo
+CREATE CONSTRAINT foo
 FOR (p:Person)
 REQUIRE UNIQUE p.name§
-ADD CONSTRAINT baz
+CREATE CONSTRAINT baz
 FOR (p:Person)
 REQUIRE exists(p.name)§
-ADD CONSTRAINT cru
+CREATE CONSTRAINT cru
 FOR ()-[r:REL]-()
 REQUIRE exists(r.property)§
 DROP CONSTRAINT foo_bar_baz§
-ADD CONSTRAINT nodeKey
+CREATE CONSTRAINT nodeKey
 FOR (n:Node)
 REQUIRE NODE KEY n.prop§
-ADD CONSTRAINT nodeKey
+CREATE CONSTRAINT nodeKey
 FOR (n:Node)
 REQUIRE NODE KEY n.p1, n.p2, n.p3§
-ADD CONSTRAINT nodeKey
+CREATE CONSTRAINT nodeKey
 FOR (n:Node)
 REQUIRE NODE KEY n.p1   ,n.p2,    n.p3§
+DROP CONSTRAINT foo§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -312,3 +312,16 @@ CALL db.labels() YIELD *
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
 CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§
+CREATE CONSTRAINT foo
+FOR (p:Person)
+REQUIRE UNIQUE p.name§
+CREATE CONSTRAINT bar
+FOR (p:Person)
+REQUIRE UNIQUE p.name, p.email§
+CREATE CONSTRAINT baz
+FOR (p:Person)
+REQUIRE exists(p.name)§
+CREATE CONSTRAINT cru
+FOR ()-[r:REL]-()
+REQUIRE exists(r.property)§
+DROP CONSTRAINT foo_bar_baz§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -312,16 +312,22 @@ CALL db.labels() YIELD *
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
 CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§
-CREATE CONSTRAINT foo
+ADD CONSTRAINT foo
 FOR (p:Person)
 REQUIRE UNIQUE p.name§
-CREATE CONSTRAINT bar
-FOR (p:Person)
-REQUIRE UNIQUE p.name, p.email§
-CREATE CONSTRAINT baz
+ADD CONSTRAINT baz
 FOR (p:Person)
 REQUIRE exists(p.name)§
-CREATE CONSTRAINT cru
+ADD CONSTRAINT cru
 FOR ()-[r:REL]-()
 REQUIRE exists(r.property)§
 DROP CONSTRAINT foo_bar_baz§
+ADD CONSTRAINT nodeKey
+FOR (n:Node)
+REQUIRE NODE KEY n.prop§
+ADD CONSTRAINT nodeKey
+FOR (n:Node)
+REQUIRE NODE KEY n.p1, n.p2, n.p3§
+ADD CONSTRAINT nodeKey
+FOR (n:Node)
+REQUIRE NODE KEY n.p1   ,n.p2,    n.p3§


### PR DESCRIPTION
This reflects a Neo4j extension of the constraints syntax suggested in #166 to support index creation/deletion.

[Direct link to CIP](https://github.com/Mats-SX/openCypher/blob/neo4j-indexes/cip/vendor-extensions/neo4j/CIP2016-12-14-Neo4j-indexes.adoc)