### PR TITLE
Only allow a zero or one propertyMaps for relationshipDesc

### DIFF
--- a/tools/tck/src/main/resources/FeatureResults.g4
+++ b/tools/tck/src/main/resources/FeatureResults.g4
@@ -34,7 +34,7 @@ nodeDesc : '(' (label)* WS? (propertyMap)? ')' ;
 
 relationship : relationshipDesc ;
 
-relationshipDesc : '[' relationshipType (WS propertyMap)* ']' ;
+relationshipDesc : '[' relationshipType WS? (propertyMap)? ']' ;
 
 path : '<' pathBody '>' ;
 


### PR DESCRIPTION
I think `relationshipDesc` should handle `propertyMap`s similarly to the `nodeDesc` rule, i.e. it can have 0 or 1 `propertyMap`s, multiple (2+) `propertyMap`s are not allowed.