### PR TITLE
Add Eclipse-specific entries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,16 @@
 \#*
 *.bak
 *.html
-.idea
+.idea/
 *.iml
 cip/*.html
 cip/*.pdf
-target
-out
-.DS_Store
+target/
+out/
+.DS_Store/
 # Generated grammar artifacts go here locally, but not to git.
 /grammar/generated
+.cache*
+.classpath
+.project
+.settings/


### PR DESCRIPTION
This is not a terribly important change, but it'd be useful for Eclipse users if the Gitignore file was prepared for Eclipse and the Scala IDE as well.