### PR TITLE
Regenerate Anltr parser listener

### DIFF
--- a/tools/grammar/pom.xml
+++ b/tools/grammar/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4</artifactId>
-      <version>4.5.2-1</version>
+      <version>${antlr.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,6 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license.header>${project.baseUri}../ASL-2-header.txt</license.header>
+    <antlr.version>4.5.1</antlr.version>
   </properties>
 
   <licenses>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license.header>${project.baseUri}../ASL-2-header.txt</license.header>
-    <antlr.version>4.5.1</antlr.version>
+    <antlr.version>4.5.3</antlr.version>
   </properties>
 
   <licenses>

--- a/tools/tck/pom.xml
+++ b/tools/tck/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4</artifactId>
-      <version>4.5.1</version>
+      <version>${antlr.version}</version>
     </dependency>
 
     <!-- Test deps -->

--- a/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsBaseListener.java
+++ b/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsBaseListener.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Generated from /Users/mats/gitRoots/openCypher-copy/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.5.1
+// Generated from /Users/mats/gitRoots/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.6
 package org.opencypher.tools.tck.parsing.generated;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsLexer.java
+++ b/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsLexer.java
@@ -14,52 +14,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Generated from /Users/mats/gitRoots/openCypher-copy/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.5.1
+// Generated from /Users/mats/gitRoots/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.6
 package org.opencypher.tools.tck.parsing.generated;
-import org.antlr.v4.runtime.Lexer;
+
 import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.RuntimeMetaData;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.VocabularyImpl;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class FeatureResultsLexer extends Lexer {
-	static { RuntimeMetaData.checkVersion("4.5.1", RuntimeMetaData.VERSION); }
+	static { RuntimeMetaData.checkVersion("4.6", RuntimeMetaData.VERSION); }
 
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
 	public static final int
-		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
-		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, INTEGER_LITERAL=17, 
-		DECIMAL_LITERAL=18, DIGIT=19, NONZERODIGIT=20, INFINITY=21, FLOAT_LITERAL=22, 
-		FLOAT_REPR=23, EXPONENTPART=24, SYMBOLIC_NAME=25, WS=26, IDENTIFIER=27, 
+		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9,
+		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, INTEGER_LITERAL=17,
+		DECIMAL_LITERAL=18, DIGIT=19, NONZERODIGIT=20, INFINITY=21, FLOAT_LITERAL=22,
+		FLOAT_REPR=23, EXPONENTPART=24, SYMBOLIC_NAME=25, WS=26, IDENTIFIER=27,
 		STRING_LITERAL=28, STRING_BODY=29, ESCAPED_APOSTROPHE=30;
 	public static String[] modeNames = {
 		"DEFAULT_MODE"
 	};
 
 	public static final String[] ruleNames = {
-		"T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8", 
-		"T__9", "T__10", "T__11", "T__12", "T__13", "T__14", "T__15", "INTEGER_LITERAL", 
-		"DECIMAL_LITERAL", "DIGIT", "NONZERODIGIT", "INFINITY", "FLOAT_LITERAL", 
-		"FLOAT_REPR", "EXPONENTPART", "SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL", 
+		"T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8",
+		"T__9", "T__10", "T__11", "T__12", "T__13", "T__14", "T__15", "INTEGER_LITERAL",
+		"DECIMAL_LITERAL", "DIGIT", "NONZERODIGIT", "INFINITY", "FLOAT_LITERAL",
+		"FLOAT_REPR", "EXPONENTPART", "SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL",
 		"STRING_BODY", "ESCAPED_APOSTROPHE"
 	};
 
 	private static final String[] _LITERAL_NAMES = {
-		null, "'('", "')'", "'['", "']'", "'<'", "'>'", "'-'", "'->'", "'<-'", 
-		"'true'", "'false'", "'null'", "', '", "'{'", "'}'", "':'", null, null, 
+		null, "'('", "')'", "'['", "']'", "'<'", "'>'", "'-'", "'->'", "'<-'",
+		"'true'", "'false'", "'null'", "', '", "'{'", "'}'", "':'", null, null,
 		null, null, null, null, null, null, null, "' '", null, null, null, "'\\''"
 	};
 	private static final String[] _SYMBOLIC_NAMES = {
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, "INTEGER_LITERAL", "DECIMAL_LITERAL", "DIGIT", 
-		"NONZERODIGIT", "INFINITY", "FLOAT_LITERAL", "FLOAT_REPR", "EXPONENTPART", 
-		"SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL", "STRING_BODY", 
+		null, null, null, null, null, null, null, null, null, null, null, null,
+		null, null, null, null, null, "INTEGER_LITERAL", "DECIMAL_LITERAL", "DIGIT",
+		"NONZERODIGIT", "INFINITY", "FLOAT_LITERAL", "FLOAT_REPR", "EXPONENTPART",
+		"SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL", "STRING_BODY",
 		"ESCAPED_APOSTROPHE"
 	};
 	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);

--- a/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsListener.java
+++ b/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsListener.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Generated from /Users/mats/gitRoots/openCypher-copy/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.5.1
+// Generated from /Users/mats/gitRoots/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.6
 package org.opencypher.tools.tck.parsing.generated;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsParser.java
+++ b/tools/tck/src/main/java/org/opencypher/tools/tck/parsing/generated/FeatureResultsParser.java
@@ -14,58 +14,69 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Generated from /Users/mats/gitRoots/openCypher-copy/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.5.1
+// Generated from /Users/mats/gitRoots/openCypher/tools/tck/src/main/resources/FeatureResults.g4 by ANTLR 4.6
 package org.opencypher.tools.tck.parsing.generated;
-import org.antlr.v4.runtime.atn.*;
-import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.misc.*;
-import org.antlr.v4.runtime.tree.*;
+
 import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
+
+import org.antlr.v4.runtime.NoViableAltException;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.RuntimeMetaData;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.VocabularyImpl;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class FeatureResultsParser extends Parser {
-	static { RuntimeMetaData.checkVersion("4.5.1", RuntimeMetaData.VERSION); }
+	static { RuntimeMetaData.checkVersion("4.6", RuntimeMetaData.VERSION); }
 
 	protected static final DFA[] _decisionToDFA;
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
 	public static final int
-		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
-		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, INTEGER_LITERAL=17, 
-		DECIMAL_LITERAL=18, DIGIT=19, NONZERODIGIT=20, INFINITY=21, FLOAT_LITERAL=22, 
-		FLOAT_REPR=23, EXPONENTPART=24, SYMBOLIC_NAME=25, WS=26, IDENTIFIER=27, 
+		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9,
+		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, INTEGER_LITERAL=17,
+		DECIMAL_LITERAL=18, DIGIT=19, NONZERODIGIT=20, INFINITY=21, FLOAT_LITERAL=22,
+		FLOAT_REPR=23, EXPONENTPART=24, SYMBOLIC_NAME=25, WS=26, IDENTIFIER=27,
 		STRING_LITERAL=28, STRING_BODY=29, ESCAPED_APOSTROPHE=30;
 	public static final int
-		RULE_value = 0, RULE_node = 1, RULE_nodeDesc = 2, RULE_relationship = 3, 
-		RULE_relationshipDesc = 4, RULE_path = 5, RULE_pathBody = 6, RULE_pathLink = 7, 
-		RULE_forwardsRelationship = 8, RULE_backwardsRelationship = 9, RULE_integer = 10, 
-		RULE_floatingPoint = 11, RULE_bool = 12, RULE_nullValue = 13, RULE_list = 14, 
-		RULE_listContents = 15, RULE_listElement = 16, RULE_map = 17, RULE_propertyMap = 18, 
-		RULE_mapContents = 19, RULE_keyValuePair = 20, RULE_propertyKey = 21, 
-		RULE_propertyValue = 22, RULE_relationshipType = 23, RULE_relationshipTypeName = 24, 
+		RULE_value = 0, RULE_node = 1, RULE_nodeDesc = 2, RULE_relationship = 3,
+		RULE_relationshipDesc = 4, RULE_path = 5, RULE_pathBody = 6, RULE_pathLink = 7,
+		RULE_forwardsRelationship = 8, RULE_backwardsRelationship = 9, RULE_integer = 10,
+		RULE_floatingPoint = 11, RULE_bool = 12, RULE_nullValue = 13, RULE_list = 14,
+		RULE_listContents = 15, RULE_listElement = 16, RULE_map = 17, RULE_propertyMap = 18,
+		RULE_mapContents = 19, RULE_keyValuePair = 20, RULE_propertyKey = 21,
+		RULE_propertyValue = 22, RULE_relationshipType = 23, RULE_relationshipTypeName = 24,
 		RULE_label = 25, RULE_labelName = 26, RULE_string = 27;
 	public static final String[] ruleNames = {
-		"value", "node", "nodeDesc", "relationship", "relationshipDesc", "path", 
-		"pathBody", "pathLink", "forwardsRelationship", "backwardsRelationship", 
-		"integer", "floatingPoint", "bool", "nullValue", "list", "listContents", 
-		"listElement", "map", "propertyMap", "mapContents", "keyValuePair", "propertyKey", 
-		"propertyValue", "relationshipType", "relationshipTypeName", "label", 
+		"value", "node", "nodeDesc", "relationship", "relationshipDesc", "path",
+		"pathBody", "pathLink", "forwardsRelationship", "backwardsRelationship",
+		"integer", "floatingPoint", "bool", "nullValue", "list", "listContents",
+		"listElement", "map", "propertyMap", "mapContents", "keyValuePair", "propertyKey",
+		"propertyValue", "relationshipType", "relationshipTypeName", "label",
 		"labelName", "string"
 	};
 
 	private static final String[] _LITERAL_NAMES = {
-		null, "'('", "')'", "'['", "']'", "'<'", "'>'", "'-'", "'->'", "'<-'", 
-		"'true'", "'false'", "'null'", "', '", "'{'", "'}'", "':'", null, null, 
+		null, "'('", "')'", "'['", "']'", "'<'", "'>'", "'-'", "'->'", "'<-'",
+		"'true'", "'false'", "'null'", "', '", "'{'", "'}'", "':'", null, null,
 		null, null, null, null, null, null, null, "' '", null, null, null, "'\\''"
 	};
 	private static final String[] _SYMBOLIC_NAMES = {
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, "INTEGER_LITERAL", "DECIMAL_LITERAL", "DIGIT", 
-		"NONZERODIGIT", "INFINITY", "FLOAT_LITERAL", "FLOAT_REPR", "EXPONENTPART", 
-		"SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL", "STRING_BODY", 
+		null, null, null, null, null, null, null, null, null, null, null, null,
+		null, null, null, null, null, "INTEGER_LITERAL", "DECIMAL_LITERAL", "DIGIT",
+		"NONZERODIGIT", "INFINITY", "FLOAT_LITERAL", "FLOAT_REPR", "EXPONENTPART",
+		"SYMBOLIC_NAME", "WS", "IDENTIFIER", "STRING_LITERAL", "STRING_BODY",
 		"ESCAPED_APOSTROPHE"
 	};
 	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
@@ -167,6 +178,7 @@ public class FeatureResultsParser extends Parser {
 		enterRule(_localctx, 0, RULE_value);
 		try {
 			setState(66);
+			_errHandler.sync(this);
 			switch ( getInterpreter().adaptivePredict(_input,0,_ctx) ) {
 			case 1:
 				enterOuterAlt(_localctx, 1);
@@ -339,6 +351,7 @@ public class FeatureResultsParser extends Parser {
 				_la = _input.LA(1);
 			}
 			setState(78);
+			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==WS) {
 				{
@@ -348,6 +361,7 @@ public class FeatureResultsParser extends Parser {
 			}
 
 			setState(81);
+			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==T__13) {
 				{
@@ -414,15 +428,9 @@ public class FeatureResultsParser extends Parser {
 		public RelationshipTypeContext relationshipType() {
 			return getRuleContext(RelationshipTypeContext.class,0);
 		}
-		public List<TerminalNode> WS() { return getTokens(FeatureResultsParser.WS); }
-		public TerminalNode WS(int i) {
-			return getToken(FeatureResultsParser.WS, i);
-		}
-		public List<PropertyMapContext> propertyMap() {
-			return getRuleContexts(PropertyMapContext.class);
-		}
-		public PropertyMapContext propertyMap(int i) {
-			return getRuleContext(PropertyMapContext.class,i);
+		public TerminalNode WS() { return getToken(FeatureResultsParser.WS, 0); }
+		public PropertyMapContext propertyMap() {
+			return getRuleContext(PropertyMapContext.class,0);
 		}
 		public RelationshipDescContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
@@ -449,23 +457,27 @@ public class FeatureResultsParser extends Parser {
 			match(T__2);
 			setState(88);
 			relationshipType();
-			setState(93);
+			setState(90);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
-			while (_la==WS) {
-				{
+			if (_la==WS) {
 				{
 				setState(89);
 				match(WS);
-				setState(90);
+				}
+			}
+
+			setState(93);
+			_errHandler.sync(this);
+			_la = _input.LA(1);
+			if (_la==T__13) {
+				{
+				setState(92);
 				propertyMap();
 				}
-				}
-				setState(95);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
 			}
-			setState(96);
+
+			setState(95);
 			match(T__3);
 			}
 		}
@@ -504,11 +516,11 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(98);
+			setState(97);
 			match(T__4);
-			setState(99);
+			setState(98);
 			pathBody();
-			setState(100);
+			setState(99);
 			match(T__5);
 			}
 		}
@@ -554,19 +566,19 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(102);
+			setState(101);
 			nodeDesc();
-			setState(106);
+			setState(105);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==T__6 || _la==T__8) {
 				{
 				{
-				setState(103);
+				setState(102);
 				pathLink();
 				}
 				}
-				setState(108);
+				setState(107);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -613,24 +625,25 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(111);
+			setState(110);
+			_errHandler.sync(this);
 			switch (_input.LA(1)) {
 			case T__6:
 				{
-				setState(109);
+				setState(108);
 				forwardsRelationship();
 				}
 				break;
 			case T__8:
 				{
-				setState(110);
+				setState(109);
 				backwardsRelationship();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			setState(113);
+			setState(112);
 			nodeDesc();
 			}
 		}
@@ -669,11 +682,11 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(115);
+			setState(114);
 			match(T__6);
-			setState(116);
+			setState(115);
 			relationshipDesc();
-			setState(117);
+			setState(116);
 			match(T__7);
 			}
 		}
@@ -712,11 +725,11 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(119);
+			setState(118);
 			match(T__8);
-			setState(120);
+			setState(119);
 			relationshipDesc();
-			setState(121);
+			setState(120);
 			match(T__6);
 			}
 		}
@@ -753,7 +766,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(123);
+			setState(122);
 			match(INTEGER_LITERAL);
 			}
 		}
@@ -792,11 +805,14 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(125);
+			setState(124);
 			_la = _input.LA(1);
 			if ( !(_la==INFINITY || _la==FLOAT_LITERAL) ) {
 			_errHandler.recoverInline(this);
-			} else {
+			}
+			else {
+				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
+				_errHandler.reportMatch(this);
 				consume();
 			}
 			}
@@ -834,11 +850,14 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(127);
+			setState(126);
 			_la = _input.LA(1);
 			if ( !(_la==T__9 || _la==T__10) ) {
 			_errHandler.recoverInline(this);
-			} else {
+			}
+			else {
+				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
+				_errHandler.reportMatch(this);
 				consume();
 			}
 			}
@@ -875,7 +894,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(129);
+			setState(128);
 			match(T__11);
 			}
 		}
@@ -915,18 +934,19 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(131);
+			setState(130);
 			match(T__2);
-			setState(133);
+			setState(132);
+			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__0) | (1L << T__2) | (1L << T__4) | (1L << T__9) | (1L << T__10) | (1L << T__11) | (1L << T__13) | (1L << INTEGER_LITERAL) | (1L << INFINITY) | (1L << FLOAT_LITERAL) | (1L << STRING_LITERAL))) != 0)) {
 				{
-				setState(132);
+				setState(131);
 				listContents();
 				}
 			}
 
-			setState(135);
+			setState(134);
 			match(T__3);
 			}
 		}
@@ -969,21 +989,21 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(137);
+			setState(136);
 			listElement();
-			setState(142);
+			setState(141);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==T__12) {
 				{
 				{
-				setState(138);
+				setState(137);
 				match(T__12);
-				setState(139);
+				setState(138);
 				listElement();
 				}
 				}
-				setState(144);
+				setState(143);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1024,7 +1044,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(145);
+			setState(144);
 			value();
 			}
 		}
@@ -1063,7 +1083,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(147);
+			setState(146);
 			propertyMap();
 			}
 		}
@@ -1103,18 +1123,19 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(149);
+			setState(148);
 			match(T__13);
-			setState(151);
+			setState(150);
+			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==SYMBOLIC_NAME) {
 				{
-				setState(150);
+				setState(149);
 				mapContents();
 				}
 			}
 
-			setState(153);
+			setState(152);
 			match(T__14);
 			}
 		}
@@ -1157,21 +1178,21 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(155);
+			setState(154);
 			keyValuePair();
-			setState(160);
+			setState(159);
 			_errHandler.sync(this);
 			_la = _input.LA(1);
 			while (_la==T__12) {
 				{
 				{
-				setState(156);
+				setState(155);
 				match(T__12);
-				setState(157);
+				setState(156);
 				keyValuePair();
 				}
 				}
-				setState(162);
+				setState(161);
 				_errHandler.sync(this);
 				_la = _input.LA(1);
 			}
@@ -1217,20 +1238,21 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(163);
+			setState(162);
 			propertyKey();
-			setState(164);
+			setState(163);
 			match(T__15);
-			setState(166);
+			setState(165);
+			_errHandler.sync(this);
 			_la = _input.LA(1);
 			if (_la==WS) {
 				{
-				setState(165);
+				setState(164);
 				match(WS);
 				}
 			}
 
-			setState(168);
+			setState(167);
 			propertyValue();
 			}
 		}
@@ -1267,7 +1289,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(170);
+			setState(169);
 			match(SYMBOLIC_NAME);
 			}
 		}
@@ -1306,7 +1328,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(172);
+			setState(171);
 			value();
 			}
 		}
@@ -1345,9 +1367,9 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(174);
+			setState(173);
 			match(T__15);
-			setState(175);
+			setState(174);
 			relationshipTypeName();
 			}
 		}
@@ -1384,7 +1406,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(177);
+			setState(176);
 			match(SYMBOLIC_NAME);
 			}
 		}
@@ -1423,9 +1445,9 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(179);
+			setState(178);
 			match(T__15);
-			setState(180);
+			setState(179);
 			labelName();
 			}
 		}
@@ -1462,7 +1484,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(182);
+			setState(181);
 			match(SYMBOLIC_NAME);
 			}
 		}
@@ -1499,7 +1521,7 @@ public class FeatureResultsParser extends Parser {
 		try {
 			enterOuterAlt(_localctx, 1);
 			{
-			setState(184);
+			setState(183);
 			match(STRING_LITERAL);
 			}
 		}
@@ -1515,59 +1537,58 @@ public class FeatureResultsParser extends Parser {
 	}
 
 	public static final String _serializedATN =
-		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3 \u00bd\4\2\t\2\4"+
+		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3 \u00bc\4\2\t\2\4"+
 		"\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
 		"\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
 		"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
 		"\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\3\2\3\2\3\2\3\2\3\2\3\2\3\2\3"+
 		"\2\3\2\3\2\5\2E\n\2\3\3\3\3\3\4\3\4\7\4K\n\4\f\4\16\4N\13\4\3\4\5\4Q\n"+
-		"\4\3\4\5\4T\n\4\3\4\3\4\3\5\3\5\3\6\3\6\3\6\3\6\7\6^\n\6\f\6\16\6a\13"+
-		"\6\3\6\3\6\3\7\3\7\3\7\3\7\3\b\3\b\7\bk\n\b\f\b\16\bn\13\b\3\t\3\t\5\t"+
-		"r\n\t\3\t\3\t\3\n\3\n\3\n\3\n\3\13\3\13\3\13\3\13\3\f\3\f\3\r\3\r\3\16"+
-		"\3\16\3\17\3\17\3\20\3\20\5\20\u0088\n\20\3\20\3\20\3\21\3\21\3\21\7\21"+
-		"\u008f\n\21\f\21\16\21\u0092\13\21\3\22\3\22\3\23\3\23\3\24\3\24\5\24"+
-		"\u009a\n\24\3\24\3\24\3\25\3\25\3\25\7\25\u00a1\n\25\f\25\16\25\u00a4"+
-		"\13\25\3\26\3\26\3\26\5\26\u00a9\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3"+
-		"\31\3\31\3\31\3\32\3\32\3\33\3\33\3\33\3\34\3\34\3\35\3\35\3\35\2\2\36"+
-		"\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668\2\4\3\2"+
-		"\27\30\3\2\f\r\u00b4\2D\3\2\2\2\4F\3\2\2\2\6H\3\2\2\2\bW\3\2\2\2\nY\3"+
-		"\2\2\2\fd\3\2\2\2\16h\3\2\2\2\20q\3\2\2\2\22u\3\2\2\2\24y\3\2\2\2\26}"+
-		"\3\2\2\2\30\177\3\2\2\2\32\u0081\3\2\2\2\34\u0083\3\2\2\2\36\u0085\3\2"+
-		"\2\2 \u008b\3\2\2\2\"\u0093\3\2\2\2$\u0095\3\2\2\2&\u0097\3\2\2\2(\u009d"+
-		"\3\2\2\2*\u00a5\3\2\2\2,\u00ac\3\2\2\2.\u00ae\3\2\2\2\60\u00b0\3\2\2\2"+
-		"\62\u00b3\3\2\2\2\64\u00b5\3\2\2\2\66\u00b8\3\2\2\28\u00ba\3\2\2\2:E\5"+
-		"\4\3\2;E\5\b\5\2<E\5\f\7\2=E\5\26\f\2>E\5\30\r\2?E\58\35\2@E\5\32\16\2"+
-		"AE\5\34\17\2BE\5\36\20\2CE\5$\23\2D:\3\2\2\2D;\3\2\2\2D<\3\2\2\2D=\3\2"+
-		"\2\2D>\3\2\2\2D?\3\2\2\2D@\3\2\2\2DA\3\2\2\2DB\3\2\2\2DC\3\2\2\2E\3\3"+
-		"\2\2\2FG\5\6\4\2G\5\3\2\2\2HL\7\3\2\2IK\5\64\33\2JI\3\2\2\2KN\3\2\2\2"+
-		"LJ\3\2\2\2LM\3\2\2\2MP\3\2\2\2NL\3\2\2\2OQ\7\34\2\2PO\3\2\2\2PQ\3\2\2"+
-		"\2QS\3\2\2\2RT\5&\24\2SR\3\2\2\2ST\3\2\2\2TU\3\2\2\2UV\7\4\2\2V\7\3\2"+
-		"\2\2WX\5\n\6\2X\t\3\2\2\2YZ\7\5\2\2Z_\5\60\31\2[\\\7\34\2\2\\^\5&\24\2"+
-		"][\3\2\2\2^a\3\2\2\2_]\3\2\2\2_`\3\2\2\2`b\3\2\2\2a_\3\2\2\2bc\7\6\2\2"+
-		"c\13\3\2\2\2de\7\7\2\2ef\5\16\b\2fg\7\b\2\2g\r\3\2\2\2hl\5\6\4\2ik\5\20"+
-		"\t\2ji\3\2\2\2kn\3\2\2\2lj\3\2\2\2lm\3\2\2\2m\17\3\2\2\2nl\3\2\2\2or\5"+
-		"\22\n\2pr\5\24\13\2qo\3\2\2\2qp\3\2\2\2rs\3\2\2\2st\5\6\4\2t\21\3\2\2"+
-		"\2uv\7\t\2\2vw\5\n\6\2wx\7\n\2\2x\23\3\2\2\2yz\7\13\2\2z{\5\n\6\2{|\7"+
-		"\t\2\2|\25\3\2\2\2}~\7\23\2\2~\27\3\2\2\2\177\u0080\t\2\2\2\u0080\31\3"+
-		"\2\2\2\u0081\u0082\t\3\2\2\u0082\33\3\2\2\2\u0083\u0084\7\16\2\2\u0084"+
-		"\35\3\2\2\2\u0085\u0087\7\5\2\2\u0086\u0088\5 \21\2\u0087\u0086\3\2\2"+
-		"\2\u0087\u0088\3\2\2\2\u0088\u0089\3\2\2\2\u0089\u008a\7\6\2\2\u008a\37"+
-		"\3\2\2\2\u008b\u0090\5\"\22\2\u008c\u008d\7\17\2\2\u008d\u008f\5\"\22"+
-		"\2\u008e\u008c\3\2\2\2\u008f\u0092\3\2\2\2\u0090\u008e\3\2\2\2\u0090\u0091"+
-		"\3\2\2\2\u0091!\3\2\2\2\u0092\u0090\3\2\2\2\u0093\u0094\5\2\2\2\u0094"+
-		"#\3\2\2\2\u0095\u0096\5&\24\2\u0096%\3\2\2\2\u0097\u0099\7\20\2\2\u0098"+
-		"\u009a\5(\25\2\u0099\u0098\3\2\2\2\u0099\u009a\3\2\2\2\u009a\u009b\3\2"+
-		"\2\2\u009b\u009c\7\21\2\2\u009c\'\3\2\2\2\u009d\u00a2\5*\26\2\u009e\u009f"+
-		"\7\17\2\2\u009f\u00a1\5*\26\2\u00a0\u009e\3\2\2\2\u00a1\u00a4\3\2\2\2"+
-		"\u00a2\u00a0\3\2\2\2\u00a2\u00a3\3\2\2\2\u00a3)\3\2\2\2\u00a4\u00a2\3"+
-		"\2\2\2\u00a5\u00a6\5,\27\2\u00a6\u00a8\7\22\2\2\u00a7\u00a9\7\34\2\2\u00a8"+
-		"\u00a7\3\2\2\2\u00a8\u00a9\3\2\2\2\u00a9\u00aa\3\2\2\2\u00aa\u00ab\5."+
-		"\30\2\u00ab+\3\2\2\2\u00ac\u00ad\7\33\2\2\u00ad-\3\2\2\2\u00ae\u00af\5"+
-		"\2\2\2\u00af/\3\2\2\2\u00b0\u00b1\7\22\2\2\u00b1\u00b2\5\62\32\2\u00b2"+
-		"\61\3\2\2\2\u00b3\u00b4\7\33\2\2\u00b4\63\3\2\2\2\u00b5\u00b6\7\22\2\2"+
-		"\u00b6\u00b7\5\66\34\2\u00b7\65\3\2\2\2\u00b8\u00b9\7\33\2\2\u00b9\67"+
-		"\3\2\2\2\u00ba\u00bb\7\36\2\2\u00bb9\3\2\2\2\16DLPS_lq\u0087\u0090\u0099"+
-		"\u00a2\u00a8";
+		"\4\3\4\5\4T\n\4\3\4\3\4\3\5\3\5\3\6\3\6\3\6\5\6]\n\6\3\6\5\6`\n\6\3\6"+
+		"\3\6\3\7\3\7\3\7\3\7\3\b\3\b\7\bj\n\b\f\b\16\bm\13\b\3\t\3\t\5\tq\n\t"+
+		"\3\t\3\t\3\n\3\n\3\n\3\n\3\13\3\13\3\13\3\13\3\f\3\f\3\r\3\r\3\16\3\16"+
+		"\3\17\3\17\3\20\3\20\5\20\u0087\n\20\3\20\3\20\3\21\3\21\3\21\7\21\u008e"+
+		"\n\21\f\21\16\21\u0091\13\21\3\22\3\22\3\23\3\23\3\24\3\24\5\24\u0099"+
+		"\n\24\3\24\3\24\3\25\3\25\3\25\7\25\u00a0\n\25\f\25\16\25\u00a3\13\25"+
+		"\3\26\3\26\3\26\5\26\u00a8\n\26\3\26\3\26\3\27\3\27\3\30\3\30\3\31\3\31"+
+		"\3\31\3\32\3\32\3\33\3\33\3\33\3\34\3\34\3\35\3\35\3\35\2\2\36\2\4\6\b"+
+		"\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668\2\4\3\2\27\30\3"+
+		"\2\f\r\u00b4\2D\3\2\2\2\4F\3\2\2\2\6H\3\2\2\2\bW\3\2\2\2\nY\3\2\2\2\f"+
+		"c\3\2\2\2\16g\3\2\2\2\20p\3\2\2\2\22t\3\2\2\2\24x\3\2\2\2\26|\3\2\2\2"+
+		"\30~\3\2\2\2\32\u0080\3\2\2\2\34\u0082\3\2\2\2\36\u0084\3\2\2\2 \u008a"+
+		"\3\2\2\2\"\u0092\3\2\2\2$\u0094\3\2\2\2&\u0096\3\2\2\2(\u009c\3\2\2\2"+
+		"*\u00a4\3\2\2\2,\u00ab\3\2\2\2.\u00ad\3\2\2\2\60\u00af\3\2\2\2\62\u00b2"+
+		"\3\2\2\2\64\u00b4\3\2\2\2\66\u00b7\3\2\2\28\u00b9\3\2\2\2:E\5\4\3\2;E"+
+		"\5\b\5\2<E\5\f\7\2=E\5\26\f\2>E\5\30\r\2?E\58\35\2@E\5\32\16\2AE\5\34"+
+		"\17\2BE\5\36\20\2CE\5$\23\2D:\3\2\2\2D;\3\2\2\2D<\3\2\2\2D=\3\2\2\2D>"+
+		"\3\2\2\2D?\3\2\2\2D@\3\2\2\2DA\3\2\2\2DB\3\2\2\2DC\3\2\2\2E\3\3\2\2\2"+
+		"FG\5\6\4\2G\5\3\2\2\2HL\7\3\2\2IK\5\64\33\2JI\3\2\2\2KN\3\2\2\2LJ\3\2"+
+		"\2\2LM\3\2\2\2MP\3\2\2\2NL\3\2\2\2OQ\7\34\2\2PO\3\2\2\2PQ\3\2\2\2QS\3"+
+		"\2\2\2RT\5&\24\2SR\3\2\2\2ST\3\2\2\2TU\3\2\2\2UV\7\4\2\2V\7\3\2\2\2WX"+
+		"\5\n\6\2X\t\3\2\2\2YZ\7\5\2\2Z\\\5\60\31\2[]\7\34\2\2\\[\3\2\2\2\\]\3"+
+		"\2\2\2]_\3\2\2\2^`\5&\24\2_^\3\2\2\2_`\3\2\2\2`a\3\2\2\2ab\7\6\2\2b\13"+
+		"\3\2\2\2cd\7\7\2\2de\5\16\b\2ef\7\b\2\2f\r\3\2\2\2gk\5\6\4\2hj\5\20\t"+
+		"\2ih\3\2\2\2jm\3\2\2\2ki\3\2\2\2kl\3\2\2\2l\17\3\2\2\2mk\3\2\2\2nq\5\22"+
+		"\n\2oq\5\24\13\2pn\3\2\2\2po\3\2\2\2qr\3\2\2\2rs\5\6\4\2s\21\3\2\2\2t"+
+		"u\7\t\2\2uv\5\n\6\2vw\7\n\2\2w\23\3\2\2\2xy\7\13\2\2yz\5\n\6\2z{\7\t\2"+
+		"\2{\25\3\2\2\2|}\7\23\2\2}\27\3\2\2\2~\177\t\2\2\2\177\31\3\2\2\2\u0080"+
+		"\u0081\t\3\2\2\u0081\33\3\2\2\2\u0082\u0083\7\16\2\2\u0083\35\3\2\2\2"+
+		"\u0084\u0086\7\5\2\2\u0085\u0087\5 \21\2\u0086\u0085\3\2\2\2\u0086\u0087"+
+		"\3\2\2\2\u0087\u0088\3\2\2\2\u0088\u0089\7\6\2\2\u0089\37\3\2\2\2\u008a"+
+		"\u008f\5\"\22\2\u008b\u008c\7\17\2\2\u008c\u008e\5\"\22\2\u008d\u008b"+
+		"\3\2\2\2\u008e\u0091\3\2\2\2\u008f\u008d\3\2\2\2\u008f\u0090\3\2\2\2\u0090"+
+		"!\3\2\2\2\u0091\u008f\3\2\2\2\u0092\u0093\5\2\2\2\u0093#\3\2\2\2\u0094"+
+		"\u0095\5&\24\2\u0095%\3\2\2\2\u0096\u0098\7\20\2\2\u0097\u0099\5(\25\2"+
+		"\u0098\u0097\3\2\2\2\u0098\u0099\3\2\2\2\u0099\u009a\3\2\2\2\u009a\u009b"+
+		"\7\21\2\2\u009b\'\3\2\2\2\u009c\u00a1\5*\26\2\u009d\u009e\7\17\2\2\u009e"+
+		"\u00a0\5*\26\2\u009f\u009d\3\2\2\2\u00a0\u00a3\3\2\2\2\u00a1\u009f\3\2"+
+		"\2\2\u00a1\u00a2\3\2\2\2\u00a2)\3\2\2\2\u00a3\u00a1\3\2\2\2\u00a4\u00a5"+
+		"\5,\27\2\u00a5\u00a7\7\22\2\2\u00a6\u00a8\7\34\2\2\u00a7\u00a6\3\2\2\2"+
+		"\u00a7\u00a8\3\2\2\2\u00a8\u00a9\3\2\2\2\u00a9\u00aa\5.\30\2\u00aa+\3"+
+		"\2\2\2\u00ab\u00ac\7\33\2\2\u00ac-\3\2\2\2\u00ad\u00ae\5\2\2\2\u00ae/"+
+		"\3\2\2\2\u00af\u00b0\7\22\2\2\u00b0\u00b1\5\62\32\2\u00b1\61\3\2\2\2\u00b2"+
+		"\u00b3\7\33\2\2\u00b3\63\3\2\2\2\u00b4\u00b5\7\22\2\2\u00b5\u00b6\5\66"+
+		"\34\2\u00b6\65\3\2\2\2\u00b7\u00b8\7\33\2\2\u00b8\67\3\2\2\2\u00b9\u00ba"+
+		"\7\36\2\2\u00ba9\3\2\2\2\17DLPS\\_kp\u0086\u008f\u0098\u00a1\u00a7";
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {


### PR DESCRIPTION
This is in response to the grammar change made by #207.

Upgrade to Antlr 4.5.3.

NOTE: Latest Antlr version is 4.6, which adds target language support for C++, Go and Swift. Upgrading to it was not drop-and-go, but I've put it on the todo list.