### PR TITLE
Add header for empty result sets. Fixes #214

### DIFF
--- a/tck/features/AggregationAcceptance.feature
+++ b/tck/features/AggregationAcceptance.feature
@@ -74,7 +74,8 @@ Feature: AggregationAcceptance
       MATCH (a {name: 'Andres'})<-[:FATHER]-(child)
       RETURN {foo: a.name='Andres', kids: collect(child.name)}
       """
-    Then the result should be empty
+    Then the result should be:
+      | {foo: a.name='Andres', kids: collect(child.name)} |
     And no side effects
 
   Scenario: Count nodes

--- a/tck/features/ComparisonOperatorAcceptance.feature
+++ b/tck/features/ComparisonOperatorAcceptance.feature
@@ -181,7 +181,8 @@ Feature: ComparisonOperatorAcceptance
       WHERE 10 < n.value <= 3
       RETURN n.value
       """
-    Then the result should be empty
+    Then the result should be:
+      | n.value |
     And no side effects
 
   Scenario: Handling long chains of operators

--- a/tck/features/MatchAcceptance.feature
+++ b/tck/features/MatchAcceptance.feature
@@ -384,7 +384,8 @@ Feature: MatchAcceptance
       WHERE length(p) = 10
       RETURN x
       """
-    Then the result should be empty
+    Then the result should be:
+      | x |
     And no side effects
 
   Scenario: Pass the path length test
@@ -546,5 +547,6 @@ Feature: MatchAcceptance
       WHERE 1 = 0
       RETURN n SKIP 0
       """
-    Then the result should be empty
+    Then the result should be:
+      | n |
     And no side effects

--- a/tck/features/UnwindAcceptance.feature
+++ b/tck/features/UnwindAcceptance.feature
@@ -150,7 +150,8 @@ Feature: UnwindAcceptance
       UNWIND [] AS empty
       RETURN empty
       """
-    Then the result should be empty
+    Then the result should be:
+      | empty |
     And no side effects
 
   Scenario: Unwinding null
@@ -160,7 +161,8 @@ Feature: UnwindAcceptance
       UNWIND null AS nil
       RETURN nil
       """
-    Then the result should be empty
+    Then the result should be:
+      | nil |
     And no side effects
 
   Scenario: Unwinding list with duplicates


### PR DESCRIPTION
Some of the test scenarios were a bit inconsistent. When there's a `RETURN` but no records are produced,  assertion should still be made on the headers. 

Example:
```
Scenario: Handle aggregates inside non-aggregate expressions
    Given an empty graph
    When executing query:
      """
      MATCH (a {name: 'Andres'})<-[:FATHER]-(child)
      RETURN {foo: a.name='Andres', kids: collect(child.name)}
      """
    Then the result should be empty
    And no side effects
```
Now:
```
  Scenario: Handle aggregates inside non-aggregate expressions
    Given an empty graph
    When executing query:
      """
      MATCH (a {name: 'Andres'})<-[:FATHER]-(child)
      RETURN {foo: a.name='Andres', kids: collect(child.name)}
      """
    Then the result should be:
      | {foo: a.name='Andres', kids: collect(child.name)} |
    And no side effects
```