### PR TITLE
Clearly define the meaning of TCK side effects

### DIFF
--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -102,6 +102,63 @@ If the side effects step reads `And no side effects`, this implies that all quan
 
 For 'negative' tests, where errors are expected (see <<errors>>), it is implied that the graph suffers no side effects.
 
+==== Observability of side effects
+
+In order for a side effect to be reported, it has to be _observable_ from the point of view of a subsequent Cypher query executed against the same graph.
+This means that side effects that are only temporarily in effect during the execution of a query are not measured in this metric.
+
+For example, the query `CREATE (n) DELETE n`, which creates a node only to immediately delete it, may be correctly implemented as a no-op by a Cypher implementation, and a TCK scenario featuring it should not specify any side effects.
+
+Concretely, observability of each metric is defined by one Cypher query per metric, which will present the metric as the difference in returned records from executing the query before and after the query `Q` under test.
+These defining queries are listed in the following.
+
+===== Nodes
+
+.Observability of the `nodes` metric:
+[source, cypher]
+----
+MATCH (n)
+RETURN n
+----
+
+===== Relationships
+
+.Observability of the `relationships` metric:
+[source, cypher]
+----
+MATCH ()-[r]->()
+RETURN r
+----
+
+===== Properties
+
+.Observability of the `properties` metric:
+[source, cypher]
+----
+MATCH (n)
+UNWIND keys(n) AS key
+WITH properties(n) AS properties, key, n
+RETURN n AS entity, key, properties[key] AS value
+UNION ALL
+MATCH ()-[r]->()
+UNWIND keys(r) AS key
+WITH properties(r) AS properties, key, r
+RETURN r AS entity, key, properties[key] AS value
+----
+
+Note that in the definition above, a property is defined as the triple of containing entity, key, and value.
+Therefore the operation of copying a property between two entities will be noted as one removal and one addition in the side effects.
+
+===== Labels
+
+.Observability of the `labels` metric:
+[source, cypher]
+----
+MATCH (n)
+UNWIND labels(n) AS label
+RETURN DISTINCT label
+----
+
 [[results-format]]
 === Format of the expected results
 

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -66,18 +66,18 @@ Scenario: Indexing a list with a string
 <2> This step is used to specify an initialization query by scenarios that require certain patterns to exist in the graph.
 <3> If `Q` uses parameters, this step will specify a two-column table detailing the required parameter names and values. The parameter values are in the same format as the expected results.
 <4> The actual Cypher query, `Q`.
-<5> This step specifies the expected results of executing `Q`, represented in a table format if not empty. The first row contains the column names, and subsequent rows contain values. However, if `Q` contains an `ORDER BY` clause, then this line should instead be `Then the result should be, in order:`, thus ensuring that the result table will be ordered by the first column appearing after `ORDER BY`.
+<5> This step specifies the expected results of executing `Q`, represented in a table format if not empty. The first row contains the column names, and subsequent rows contain values. However, if `Q` contains a `RETURN` clause with an `ORDER BY` subclause, then this line should instead be `Then the result should be, in order:`, thus ensuring that the result table will be ordered by the first column appearing after `ORDER BY`.
 <6> This step specifies the expected side effects of executing `Q`, with the side effect name and the relevant quantity. Read about the possible side effects in <<side-effects>>.
-<7> This step specifies the expected error should be raised by executing the invalid `Q`. This step is described in detail in <<errors>>.
+<7> This step specifies the expected error that should be raised by executing the invalid `Q`. This step is described in detail in <<errors>>.
 
 [[named-graphs]]
 === Graphs for initial states
 
 The keyword `Given` in the TCK's scenarios specifies the required initial state for the scenario.
 In order to not obfuscate the purpose of the scenario - which is to display the behaviour of the query - the initial state is usually simple.
-Certain queries do require a more complex graph structure in order to yield less obvious behavior, and in these cases a named graph included in the TCK will need to be set up by the implementation before the query is executed.
+Certain queries do require a more complex graph structure in order to yield less obvious behavior, and in these cases a named graph included in the TCK must be set up by the implementation before the query is executed.
 
-The TCK currently supports these named graphs:
+The TCK currently contains these named graphs:
 
 * binary-tree-1
 ** A binary tree of depth 4, with only label `:X` on non-root nodes, and three different relationship types.
@@ -108,9 +108,9 @@ For 'negative' tests, where errors are expected (see <<errors>>), it is implied 
 Values that can be returned from Cypher can be categorized into three groups: primitives (integers, floats, booleans, and strings), containers (lists and maps), and graph elements (nodes, relationships, and paths).
 Please refer to the https://github.com/opencypher/openCypher/blob/master/cip/CIP2015-09-16-public-type-system-type-annotation.adoc[Cypher Type System specification] for more information about types and values in Cypher.
 
-Unless there is an `ORDER BY` present in the Cypher query, Cypher provides no guarantees as to the order in which the values are returned.
-In theory, this means that executing the same query twice could yield the same values returned in different orders.
-For this reason, the rows of the expected results table are to be considered a set, rather than a list, unless there is an `ORDER BY` clause in the query.
+Unless there is an `ORDER BY` present in the `RETURN` clause of the Cypher query, Cypher provides no guarantees as to the order in which the records are returned.
+In theory, this means that executing the same query twice could yield the same records returned in different orders.
+For this reason, the rows of the expected results table are to be considered a set, rather than a list, unless the above condition on the `RETURN` clause is met.
 
 * Primitives:
 ** An integer will be written as a simple string of decimal digits.
@@ -132,11 +132,12 @@ For this reason, the rows of the expected results table are to be considered a s
 ** A path will be written as `<n~0~, r~1~, n~1~, r~2~, ..., r~k~, n~k~>`, where `n~i~` and `r~i~` are the nodes and relationships, respectively, that make up the path.
 *** Note that the smallest possible path, with length zero, consists of one node and zero relationships.
 
-=== How to implement the TCK
+=== Downloading the TCK
 
-In order to implement the Cypher TCK, you will have to retrieve the full suite of TCK feature files, hosted at this GitHub repository, https://github.com/opencypher/openCypher/tree/master/tck/features[in this subdirectory].
+In order to implement the Cypher TCK, you will have to retrieve the full suite of TCK feature files, which are best found at the http://www.opencypher.org/#resources[openCypher website] (stable and snapshot) or in this GitHub repository under `features`.
 
-// TODO: Mention Cucumber ?
+The TCK feature files are also included in the `resources` path of a Maven JAR archive that is periodically released as part of the openCypher release process.
+Find the latest version via https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.opencypher%22%20AND%20a%3A%22tck%22[Maven Central].
 
 [[errors]]
 === Cypher errors

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -147,7 +147,7 @@ RETURN r AS entity, key, properties[key] AS value
 ----
 
 Note that in the definition above, a property is defined as the triple of containing entity, key, and value.
-Therefore the operation of copying a property between two entities will be noted as one removal and one addition in the side effects.
+Therefore the operation of moving a property from one entity to another will be noted as one removal and one addition in the side effects.
 
 ===== Labels
 

--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -170,9 +170,7 @@ Feature: DeleteAcceptance
       DELETE n
       """
     Then the result should be empty
-    And the side effects should be:
-      | +nodes | 1 |
-      | -nodes | 1 |
+    And no side effects
 
   Scenario: Delete optionally matched relationship
     Given an empty graph

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -468,7 +468,6 @@ Feature: MergeNodeAcceptance
     And the side effects should be:
       | +nodes  | 1 |
       | -nodes  | 2 |
-      | +labels | 1 |
 
   Scenario: ON CREATE on created nodes
     Given an empty graph

--- a/tck/features/MergeRelationshipAcceptance.feature
+++ b/tck/features/MergeRelationshipAcceptance.feature
@@ -484,8 +484,8 @@ Feature: MergeRelationshipAcceptance
       | -nodes         | 4 |
       | +relationships | 2 |
       | -relationships | 4 |
-      | +labels        | 2 |
       | +properties    | 1 |
+      | -properties    | 2 |
 
   Scenario: Do not match on deleted relationships
     Given an empty graph
@@ -510,6 +510,7 @@ Feature: MergeRelationshipAcceptance
       | +relationships | 1 |
       | -relationships | 2 |
       | +properties    | 1 |
+      | -properties    | 2 |
 
   Scenario: Aliasing of existing nodes 1
     Given an empty graph

--- a/tck/features/SetAcceptance.feature
+++ b/tck/features/SetAcceptance.feature
@@ -267,7 +267,7 @@ Feature: SetAcceptance
       | -properties | 1 |
 
   Scenario: Non-existent values in a property map are removed with SET =
-    Given any graph
+    Given an empty graph
     And having executed:
       """
       CREATE (:X {foo: 'A', bar: 'B'})


### PR DESCRIPTION
At the 2nd oCIM, @szarnyasg presented the problem of unclearly defined side effects in the TCK, which is also discussed in #221. @szarnyasg also proposed a solution, which is largely implemented in this PR, with one notable amendment: properties are defined not only by their key and value, but also by the containing entity.

This PR aims to solve #221.