### PR TITLE
Making feature files available for external tests

### DIFF
--- a/tools/tck/pom.xml
+++ b/tools/tck/pom.xml
@@ -64,6 +64,7 @@
         <includes>
           <include>**/*.feature</include>
         </includes>
+        <targetPath>features</targetPath>
       </resource>
       <resource>
         <directory>../../tck/graphs</directory>


### PR DESCRIPTION
## Issue

Java Cucumber does not like **default package** referencing features in classpath:
```java
@RunWith(Cucumber.class)
@CucumberOptions(
    // features = {"classpath:."} - doesn't work
    // features = {"classpath:/"} - doesn't work
    // features = {"classpath:"} - doesn't work
    features = {"classpath:features"}
)
public class TestAgainstOpenCypherTck {
    //...
}
```

## Technical details

Cucumber does something like:
```java
import cucumber.runtime.io.ClasspathResourceLoader;
import cucumber.runtime.io.Resource;

@Test
public void temp() throws IOException {
    String features = "classpath:features";
    ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(getClass().getClassLoader());
    for (Resource resource : resourceLoader.resources(features.replace("classpath:", ""), ".feature")) {
        System.out.println(resource.getAbsolutePath());
    }
}
```
finding features in class path:
```
.m2/repository/org/opencypher/tck/1.0-SNAPSHOT/tck-1.0-SNAPSHOT.jar!/features/RemoveAcceptance.feature
.m2/repository/org/opencypher/tck/1.0-SNAPSHOT/tck-1.0-SNAPSHOT.jar!/features/ColumnNameAcceptance.feature
...
```