### PR TITLE
Align side effects with standard definitions

### DIFF
--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -148,6 +148,7 @@ RETURN r AS entity, key, properties[key] AS value
 
 Note that in the definition above, a property is defined as the triple of containing entity, key, and value.
 Therefore the operation of moving a property from one entity to another will be noted as one removal and one addition in the side effects.
+Likewise, the operation of changing the value of a property is noted as one removal and one addition in the side effects.
 
 ===== Labels
 
@@ -158,6 +159,8 @@ MATCH (n)
 UNWIND labels(n) AS label
 RETURN DISTINCT label
 ----
+
+Note that this definition measures the amount of distinct labels present in the graph, and not the amount of nodes that are assigned these labels.
 
 [[results-format]]
 === Format of the expected results

--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -97,6 +97,7 @@ Feature: DeleteAcceptance
     And the side effects should be:
       | -nodes         | 1 |
       | -relationships | 3 |
+      | -labels        | 1 |
 
   Scenario: Detach deleting paths
     Given an empty graph
@@ -116,6 +117,7 @@ Feature: DeleteAcceptance
     And the side effects should be:
       | -nodes         | 4 |
       | -relationships | 3 |
+      | -labels        | 1 |
 
   Scenario: Undirected expand followed by delete and count
     Given an empty graph
@@ -277,7 +279,8 @@ Feature: DeleteAcceptance
       """
     Then the result should be empty
     And the side effects should be:
-      | -nodes | 2 |
+      | -nodes  | 2 |
+      | -labels | 1 |
 
   Scenario: Delete relationships from a map
     Given an empty graph
@@ -352,6 +355,7 @@ Feature: DeleteAcceptance
     And the side effects should be:
       | -nodes         | 2 |
       | -relationships | 2 |
+      | -labels        | 1 |
 
   Scenario: Delete relationship with bidirectional matching
     Given an empty graph
@@ -368,3 +372,4 @@ Feature: DeleteAcceptance
     Then the result should be empty
     And the side effects should be:
       | -relationships | 1 |
+      | -properties    | 1 |

--- a/tck/features/LargeCreateQuery.feature
+++ b/tck/features/LargeCreateQuery.feature
@@ -561,7 +561,7 @@ Feature: LargeCreateQuery
       | +nodes         | 171 |
       | +relationships | 253 |
       | +properties    | 564 |
-      | +labels        | 171 |
+      | +labels        | 2   |
 
   Scenario: Many CREATE clauses
     Given any graph
@@ -1357,5 +1357,5 @@ Feature: LargeCreateQuery
     And the side effects should be:
       | +nodes         | 731  |
       | +relationships | 1247 |
-      | +labels        | 730  |
+      | +labels        | 6    |
       | +properties    | 230  |

--- a/tck/features/MergeIntoAcceptance.feature
+++ b/tck/features/MergeIntoAcceptance.feature
@@ -143,6 +143,7 @@ Feature: MergeIntoAcceptance
     Then the result should be empty
     And the side effects should be:
       | +properties    | 2 |
+      | -properties    | 1 |
     When executing control query:
       """
       MATCH ()-[r:TYPE]->()

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -125,7 +125,6 @@ Feature: MergeNodeAcceptance
       | 43     |
     And the side effects should be:
       | +nodes      | 1 |
-      | +labels     | 1 |
       | +properties | 1 |
 
   Scenario: Merge node with prop and label
@@ -208,7 +207,7 @@ Feature: MergeNodeAcceptance
     Then the result should be empty
     And the side effects should be:
       | +nodes  | 2 |
-      | +labels | 2 |
+      | +labels | 1 |
 
   Scenario: Should handle argument properly
     Given an empty graph
@@ -259,7 +258,7 @@ Feature: MergeNodeAcceptance
     Then the result should be empty
     And the side effects should be:
       | +nodes      | 3 |
-      | +labels     | 3 |
+      | +labels     | 1 |
       | +properties | 3 |
 
   Scenario: Should be able to use properties from match in ON CREATE
@@ -330,7 +329,7 @@ Feature: MergeNodeAcceptance
     And the side effects should be:
       | +nodes      | 1 |
       | +labels     | 1 |
-      | +properties | 2 |
+      | +properties | 1 |
 
   Scenario: Should be able to set labels on match
     Given an empty graph
@@ -395,7 +394,7 @@ Feature: MergeNodeAcceptance
       | 2 | 2 |
     And the side effects should be:
       | +nodes      | 15 |
-      | +labels     | 15 |
+      | +labels     | 1  |
       | +properties | 30 |
 
   Scenario: Merge must properly handle multiple labels
@@ -414,7 +413,7 @@ Feature: MergeNodeAcceptance
       | ['L', 'B'] |
     And the side effects should be:
       | +nodes      | 1 |
-      | +labels     | 2 |
+      | +labels     | 1 |
       | +properties | 1 |
 
   Scenario: Merge followed by multiple creates
@@ -466,8 +465,9 @@ Feature: MergeNodeAcceptance
       | null     |
       | null     |
     And the side effects should be:
-      | +nodes  | 1 |
-      | -nodes  | 2 |
+      | +nodes      | 1 |
+      | -nodes      | 2 |
+      | -properties | 2 |
 
   Scenario: ON CREATE on created nodes
     Given an empty graph

--- a/tck/features/MergeRelationshipAcceptance.feature
+++ b/tck/features/MergeRelationshipAcceptance.feature
@@ -454,7 +454,7 @@ Feature: MergeRelationshipAcceptance
     And the side effects should be:
       | +nodes         | 5 |
       | +relationships | 4 |
-      | +labels        | 5 |
+      | +labels        | 2 |
       | +properties    | 5 |
 
   Scenario: Do not match on deleted entities

--- a/tck/features/ProcedureCallAcceptance.feature
+++ b/tck/features/ProcedureCallAcceptance.feature
@@ -189,6 +189,7 @@ Feature: ProcedureCallAcceptance
     Then the result should be, in order:
       | city     | country_code |
       | 'Berlin' | 49           |
+    And no side effects
 
   Scenario: In-query call to procedure with explicit arguments that drops all result fields
     And there exists a procedure test.my.proc(name :: STRING?, id :: INTEGER?) :: (city :: STRING?, country_code :: INTEGER?):
@@ -208,6 +209,7 @@ Feature: ProcedureCallAcceptance
     Then the result should be, in order:
       | name     | id | count |
       | 'Stefan' | 1  | 1     |
+    And no side effects
 
   Scenario: Standalone call to procedure with explicit arguments
     And there exists a procedure test.my.proc(name :: STRING?, id :: INTEGER?) :: (city :: STRING?, country_code :: INTEGER?):
@@ -225,6 +227,7 @@ Feature: ProcedureCallAcceptance
     Then the result should be, in order:
       | city     | country_code |
       | 'Berlin' | 49           |
+    And no side effects
 
   Scenario: Standalone call to procedure with implicit arguments
     And there exists a procedure test.my.proc(name :: STRING?, id :: INTEGER?) :: (city :: STRING?, country_code :: INTEGER?):

--- a/tck/features/SetAcceptance.feature
+++ b/tck/features/SetAcceptance.feature
@@ -71,6 +71,7 @@ Feature: SetAcceptance
       | (:A {name: 'Michael'}) |
     And the side effects should be:
       | +properties | 1 |
+      | -properties | 1 |
 
   Scenario: Set a property to an expression
     Given an empty graph
@@ -90,6 +91,7 @@ Feature: SetAcceptance
       | (:A {name: 'Andres was here'}) |
     And the side effects should be:
       | +properties | 1 |
+      | -properties | 1 |
 
   Scenario: Set a property by selecting the node using a simple expression
     Given an empty graph
@@ -195,7 +197,7 @@ Feature: SetAcceptance
       | [1, 2, 3, 4, 5] |
     And the side effects should be:
       | +nodes      | 1 |
-      | +properties | 2 |
+      | +properties | 1 |
 
   Scenario: Concatenate elements in reverse onto a list property
     Given any graph
@@ -210,7 +212,7 @@ Feature: SetAcceptance
       | [1, 2, 3, 4, 5] |
     And the side effects should be:
       | +nodes      | 1 |
-      | +properties | 2 |
+      | +properties | 1 |
 
   Scenario: Overwrite values when using +=
     Given an empty graph
@@ -229,6 +231,7 @@ Feature: SetAcceptance
       | (:X {foo: 'A', bar: 'C'}) |
     And the side effects should be:
       | +properties | 1 |
+      | -properties | 1 |
 
   Scenario: Retain old values when using +=
     Given an empty graph
@@ -283,4 +286,4 @@ Feature: SetAcceptance
       | (:X {foo: 'B', baz: 'C'}) |
     And the side effects should be:
       | +properties | 2 |
-      | -properties | 1 |
+      | -properties | 2 |

--- a/tck/features/UnwindAcceptance.feature
+++ b/tck/features/UnwindAcceptance.feature
@@ -121,7 +121,7 @@ Feature: UnwindAcceptance
     And the side effects should be:
       | +nodes         | 2 |
       | +relationships | 2 |
-      | +labels        | 2 |
+      | +labels        | 1 |
       | +properties    | 2 |
 
   Scenario: Double unwinding a list of lists
@@ -264,5 +264,5 @@ Feature: UnwindAcceptance
       | 'name2' | 'login2' |
     And the side effects should be:
       | +nodes      | 2 |
-      | +labels     | 2 |
+      | +labels     | 1 |
       | +properties | 4 |


### PR DESCRIPTION
This updates the side effects specification of many TCK scenarios, following the definitions from #236.

It is worth to note that the standard definition of the `labels` side effect metric measures the amount of distinct labels in the graph, and not the amount of nodes carrying these labels. This has the consequence that some queries that set or remove labels from nodes will not report any side effects at all, under certain circumstances. For example, this is a valid scenario:

```
Scenario: Setting an already existing label does not constitute a side effect
  Given any graph
  And having executed:
    """
    CREATE (:A), (:B)
    """
  When executing query:
    """
    MATCH (b:B)
    SET b:A
    """
  Then the result should be empty
  And no side effects
```

It is beyond the scope of this PR to change this, but it could be a topic for the oCIG to consider.