### PR TITLE
Existing graph affects labels diff in 'side effect' step:

### DIFF
--- a/tck/features/Create.feature
+++ b/tck/features/Create.feature
@@ -49,7 +49,7 @@ Feature: Create
       | +relationships | 1 |
 
   Scenario: Creating a node with a label
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (:Label)

--- a/tck/features/CreateAcceptance.feature
+++ b/tck/features/CreateAcceptance.feature
@@ -18,7 +18,7 @@
 Feature: CreateAcceptance
 
   Scenario: Create a single node with multiple labels
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (:A:B:C:D)
@@ -131,7 +131,7 @@ Feature: CreateAcceptance
       | +relationships | 1 |
 
   Scenario: Create a self loop
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (root:R)-[:LINK]->(root)
@@ -288,7 +288,7 @@ Feature: CreateAcceptance
       | (:A) | (:B) | (:C) |
 
   Scenario: Create a pattern with multiple hops in the reverse direction
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (:A)<-[:R]-(:B)<-[:R]-(:C)
@@ -308,7 +308,7 @@ Feature: CreateAcceptance
       | (:A) | (:B) | (:C) |
 
   Scenario: Create a pattern with multiple hops in varying directions
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (:A)-[:R]->(:B)<-[:R]-(:C)

--- a/tck/features/LargeCreateQuery.feature
+++ b/tck/features/LargeCreateQuery.feature
@@ -18,7 +18,7 @@
 Feature: LargeCreateQuery
 
   Scenario: Generate the movie graph correctly
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (theMatrix:Movie {title: 'The Matrix', released: 1999, tagline: 'Welcome to the Real World'})
@@ -564,7 +564,7 @@ Feature: LargeCreateQuery
       | +labels        | 2   |
 
   Scenario: Many CREATE clauses
-    Given any graph
+    Given an empty graph
     When executing query:
       """
       CREATE (hf:School {name: 'Hilly Fields Technical College'})


### PR DESCRIPTION
Step 'side effect' takes distinct labels. So, side affects assertion could be affected by existing graph (which could already have the label to be added). To eliminate that 'any graph' step was replaced with 'empty graph' step in scenarios asserting labels diff.