### PR TITLE
Clarification about null in lists in CIP2016-06-14

### DIFF
--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -71,6 +71,53 @@ For the following discussion, it is helpful to clarify the meaning of `null`. In
 [[unknown-null,unknown `null`]]*Unknown*:: An "unknown" `null` is taken to be a placeholder for an arbitrary but unknown value. When evaluating predicates, an "unknown" `null` is the `maybe` truth value of ternary logic. For node and relationship properties, an "unknown" `null` is a value that is definite in the real world but has not been stored in the graph. Since in these cases, two "unknown" `null` values stand for arbitrary but definite values in the real world, two "unknown" `null` values should never be treated as certainly being the same value.
 [[missing-null,missing `null`]]*Missing*:: A "missing" `null` is taken to be a marker for the absence of a value. In the context of updating node properties from a map, a "missing" `null` is used to mark properties that are to be removed. In the context of `DISTINCT` and grouping, a "missing" `null` value is used as grouping key for all records that miss a more specific value. Since in these cases, two "missing" `null` values represent the same concept, they should always be treated as the same value.
 
+===== Ternary logic truth tables
+
+Allowing null for an unknown boolean value requires defining ternary logic for boolean operators.
+The truth tables for the boolean operators `NOT`, `AND` and `OR` are given below.
+The `XOR` in Cypher is defined by these basic operators as `a XOR b = (a AND NOT(b)) OR (NOT(a) AND b)`.
+
+*Negation*
+[width="50%",options="header"]
+|===========
+|a    |NOT a
+|true |false
+|null |null
+|false|true
+|===========
+
+
+*Conjunction*
+[width="50%",options="header"]
+|===================
+|a    |b    |a AND B
+|true |true |true
+|true |null |null
+|true |false|false
+|null |true |null
+|null |null |null
+|null |false|false
+|false|true |false
+|false|null |false
+|false|false|false
+|===================
+
+
+*Disjunction*
+[width="50%",options="header"]
+|==================
+|a    |b    |a OR B
+|true |true |true
+|true |null |true
+|true |false|true
+|null |true |true
+|null |null |null
+|null |false|null
+|false|true |true
+|false|null |null
+|false|false|false
+|==================
+
 [[regular-map]]
 ==== Regular maps
 

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -120,7 +120,7 @@ We propose that <<comparability-con,comparability>> should be defined between an
   * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including `null` values).
   For example, `[1] < [1, 0]` but also `[1] < [1, null]`.
   * If comparing two lists requires comparing at least a single `null` value to some other value, these lists are <<incomparable>>.
-  For example, `[1, 2] >= [1, null]` evaluates to `null` (ncomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
+  For example, `[1, 2] >= [1, null]` evaluates to `null` (incomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
   * Lists are <<incomparable>> to any value that is not also a list.
 - Maps
   * [[regular-maps,regular maps]]Regular maps

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -130,8 +130,8 @@ Cypher today has one supertype `MAP` for all map values. This includes nodes (of
 We propose that comparability and equality should be aligned with each other, i.e.
 
 
-`expr1 = expr2` = `expr1 >= expr2 AND expr1 \<= expr2`.
-This equaltion is also valid for null values.
+`expr1 = expr2 := expr1 >= expr2 AND expr1 \<= expr2`.
+This equation is also valid for null values.
 
 
 Comparability and equality produce <<unknown-null,"unknown" `null` values>>.
@@ -217,13 +217,13 @@ We propose that <<comparability-con,comparability>> should be defined between an
 [[equality-def,equality]]
 ==== Equality ====
 
-Given that values are only comparable within their most specific type, and comparability and equality are tied together, equlity of values of different types always evaluates to `null`.
+Given that values are only comparable within their type, and comparability and equality are tied together, equality for values of different types generally evaluate to `null`.
 In order to align equality with <<comparability-def>>, we change equality of lists and maps that contain `null` values to treat those values in the same way as if they would have been compared outside of those lists and maps, as individual, simple values.
 
 ===== List equality =====
 
 Specifically, we propose to redefine how equality works for lists in Cypher.
-The equality of two lists `a` and `b` is defined as the <<conjunction>> of `size(a) = size(b)` and a pairwise comparison of all elements of the list.
+The equality of two lists `a` and `b` is defined as the <<conjunction>> of `size(a) = size(b)` and a pairwise comparison of all elements in the list.
 If `a = b` evaluates to `null` these lists are <<incomparable>>.
 
 ----

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -119,8 +119,8 @@ We propose that <<comparability-con,comparability>> should be defined between an
 - Lists
   * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including `null` values).
   For example, `[1] < [1, 0]` but also `[1] < [1, null]`.
-  * If comparing two lists requires comparing at least a single `null` value to some other value, these lists are <<incomparable>>.
-  For example, `[1, 2] >= [1, null]` evaluates to `null` (incomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
+  * If comparing two lists requires comparing any pair of incomparable values, these lists are <<incomparable>>.
+  For example, `[1, 2] >= [1, null]` and `[1, 2] >= [1, 'text']` both evaluate to `null` (incomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
   * Lists are <<incomparable>> to any value that is not also a list.
 - Maps
   * [[regular-maps,regular maps]]Regular maps
@@ -179,7 +179,7 @@ To determine if two lists `l1` and `l2` are equal, we propose two simple tests, 
 <=>
 a1 = b1 && a2 = b2 && ... && an = bn
 ----
-* If the second test requires comparing at least a single `null` value to some other value, these lists are <<incomparable>>. E.g., `[1, 2] = [1, null]` evaluates to `null` (incomparable), but `[1, 2] = [null, 'foo']` evaluates to `false`.
+* If the second test evaluates to `null`, these lists are <<incomparable>>. This will only happen if at least one element in one of the lists is `null` while all non-null elements are pairwise equal. For example, `[1, 2] = [1, null]` evaluates to `null` (incomparable), while `[1, 2] = [null, 'foo']` evaluates to `false`.
 * For nested lists, the two tests above are carried out recursively, i.e.
 ---
 [[1]] = [[1], [null]] evaluates to false

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -120,7 +120,7 @@ We propose that <<comparability-con,comparability>> should be defined between an
   * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including `null` values).
   For example, `[1] < [1, 0]` but also `[1] < [1, null]`.
   * If comparing two lists requires comparing at least a single `null` value to some other value, these lists are <<incomparable>>.
-  For example, `[1, 2] >= [1, null]` evaluates to `null`.
+  For example, `[1, 2] >= [1, null]` evaluates to `null` (ncomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
   * Lists are <<incomparable>> to any value that is not also a list.
 - Maps
   * [[regular-maps,regular maps]]Regular maps
@@ -172,13 +172,20 @@ In order to align equality with <<comparability-def>>, we change equality of lis
 Specifically, we propose to redefine how equality works for lists in Cypher.
 To determine if two lists `l1` and `l2` are equal, we propose two simple tests, as exemplified by the following:
 
-* `l1` and `l2` must have the same size, i.e. inversely `size(l1) <> size(l2) \=> l1 <> l2`
+* `l1` and `l2` must have the same size, i.e. inversely `size(l1) <> size(l2) \=> l1 <> l2`. This also applies when any of the lists contains null, i.e. `[a1, a2, ..., an] = [b1, b2, ..., null, ..., bm]` evaluates to false if `m <> n`.
 * the pairwise elements of both `l1` and `l2` must be equal, i.e.
 ----
 [a1, a2, ..., an] = [b1, b2, ..., bn]
 <=>
 a1 = b1 && a2 = b2 && ... && an = bn
 ----
+* If the second test requires comparing at least a single `null` value to some other value, these lists are <<incomparable>>. E.g., `[1, 2] = [1, null]` evaluates to `null` (incomparable), but `[1, 2] = [null, 'foo']` evaluates to `false`.
+* For nested lists, the two tests above are carried out recursively, i.e.
+---
+[[1]] = [[1], [null]] evaluates to false
+[[1, 2], [1, 3]] = [[1, 2], [null, 'foo']] evaluates to false
+[[1, 2], ['foo', 'bar']] = [[1, 2], [null, 'bar']] evaluates to null (incomparable)
+---
 
 ===== Map equality =====
 

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -77,7 +77,8 @@ Allowing null for an unknown boolean value requires defining ternary logic for b
 The truth tables for the boolean operators `NOT`, `AND` and `OR` are given below.
 The `XOR` in Cypher is defined by these basic operators as `a XOR b = (a AND NOT(b)) OR (NOT(a) AND b)`.
 
-*Negation*
+[[negation,negation]]
+.Negation
 [width="50%",options="header"]
 |===========
 |a    |NOT a
@@ -86,8 +87,8 @@ The `XOR` in Cypher is defined by these basic operators as `a XOR b = (a AND NOT
 |false|true
 |===========
 
-
-*Conjunction*
+[[conjunction,conjunction]]
+.Conjunction
 [width="50%",options="header"]
 |===================
 |a    |b    |a AND B
@@ -102,8 +103,8 @@ The `XOR` in Cypher is defined by these basic operators as `a XOR b = (a AND NOT
 |false|false|false
 |===================
 
-
-*Disjunction*
+[[disjunction,disjunction]]
+.Disjunction
 [width="50%",options="header"]
 |==================
 |a    |b    |a OR B
@@ -174,7 +175,7 @@ We propose that <<comparability-con,comparability>> should be defined between an
   ** The comparison order for maps is unspecified and left to implementations.
   ** The comparison order for maps must align with the <<equality-def,equality semantics>> outlined below.
   In consequence, any map that contains an entry that maps its key to a `null` value is <<incomparable>>.
-  For exampe, `{a: 1} \<= {a: 1, b: null}` evaluates to `null`.
+  For example, `{a: 1} \<= {a: 1, b: null}` evaluates to `null`.
   ** Regular maps are <<incomparable>> to any value that is not also a regular map.
   * Nodes
   ** The comparison order for nodes is based on an implementation specific internal total order of node identities.
@@ -212,27 +213,40 @@ We propose that <<comparability-con,comparability>> should be defined between an
 [[equality-def,equality]]
 ==== Equality ====
 
+Given that values are only comparable within their most specific type, and comparability and equality are tied together, equlity of values of different types always evaluates to `null`.
 In order to align equality with <<comparability-def>>, we change equality of lists and maps that contain `null` values to treat those values in the same way as if they would have been compared outside of those lists and maps, as individual, simple values.
 
 ===== List equality =====
 
 Specifically, we propose to redefine how equality works for lists in Cypher.
-To determine if two lists `l1` and `l2` are equal, we propose two simple tests, as exemplified by the following:
+The equality of two lists `a` and `b` is defined is the <<conjunction>> of `size(a) = size(b)` and a pairwise comparison of all elements of the list.
+If `a = b` evaluates to `null` these lists are <<incomparable>>.
 
-* `l1` and `l2` must have the same size, i.e. inversely `size(l1) <> size(l2) \=> l1 <> l2`. This also applies when any of the lists contains null, i.e. `[a1, a2, ..., an] = [b1, b2, ..., null, ..., bm]` evaluates to false if `m <> n`.
-* the pairwise elements of both `l1` and `l2` must be equal, i.e.
+In the following example `=>` means "evaluates to".
 ----
-[a1, a2, ..., an] = [b1, b2, ..., bn]
-<=>
-a1 = b1 && a2 = b2 && ... && an = bn
+[1, 2] = [1]
+    => size([1, 2]) = size([1]) AND 1 = 1 AND 2 = null
+    => false                    AND true  AND null
+    => false
+
+[null] = [1]
+    => size([null]) = size[1]) AND null = 1
+    => true                    AND null
+    => null
+
+["a"] = [1]
+    => size(["a"]) = size[1]) AND "a" = 1
+    => true                   AND null
+    => null
 ----
-* If the second test evaluates to `null`, these lists are <<incomparable>>. This will only happen if at least one element in one of the lists is `null` while all non-null elements are pairwise equal. For example, `[1, 2] = [1, null]` evaluates to `null` (incomparable), while `[1, 2] = [null, 'foo']` evaluates to `false`.
-* For nested lists, the two tests above are carried out recursively, i.e.
----
-[[1]] = [[1], [null]] evaluates to false
-[[1, 2], [1, 3]] = [[1, 2], [null, 'foo']] evaluates to false
-[[1, 2], ['foo', 'bar']] = [[1, 2], [null, 'bar']] evaluates to null (incomparable)
----
+
+The same logic applies recursively when comparing nested lists.
+----
+[[1]] = [[1], [null]]
+    => size([[1]]) = size([[1], [null]]) AND [1] = [1] AND null = [null]
+    => false                             AND true      AND null
+    => false
+----
 
 ===== Map equality =====
 
@@ -254,14 +268,13 @@ However, this definition is aligned with the most common use case for maps with 
 
 ====== New map equality ======
 
-To rectify this, we propose instead that two maps `m1` and `m2` should be equal if:
+To rectify this, we propose instead to define the equality of two maps `m1` and `m2` as:
 
-* `m1` and `m2` have the same keys,
-** including keys that map to a `null` value (the order of keys as returned by `keys()` does not matter here).
-* Additionally, for each such key `k`,
-** `m1.k = m2.k` is `true`.
+* `m1` and `m2` have the same keys, including keys that map to a `null` value (the order of keys as returned by `keys()` does not matter here) `AND`
+* the <<conjunction>> of `m1.k = m2.k` for each key `k`.
 
-As a consequence of these changes, plain <<equality-def>> is not reflexive for all values (consider: `{a: null} = {a: null}`, `[null] = [null]`). However this was already the case (consider: `null = null` \=> `null`).
+As a consequence of these changes, plain <<equality-def>> is not reflexive for all values (consider: `{a: null} = {a: null}`, `[null] = [null]`).
+However this was already the case (consider: `null = null` \=> `null`).
 
 Note that <<equality-def>> is reflexive for values that do not involve `null` though.
 

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -129,7 +129,10 @@ Cypher today has one supertype `MAP` for all map values. This includes nodes (of
 
 We propose that comparability and equality should be aligned with each other, i.e.
 
-`expr1 = expr2` if and only if `expr1 >= expr2 && expr1 \<= expr2`.
+
+`expr1 = expr2` = `expr1 >= expr2 AND expr1 \<= expr2`.
+This equaltion is also valid for null values.
+
 
 Comparability and equality produce <<unknown-null,"unknown" `null` values>>.
 
@@ -167,8 +170,9 @@ We propose that <<comparability-con,comparability>> should be defined between an
 - Lists
   * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including `null` values).
   For example, `[1] < [1, 0]` but also `[1] < [1, null]`.
-  * If comparing two lists requires comparing any pair of incomparable values, these lists are <<incomparable>>.
-  For example, `[1, 2] >= [1, null]` and `[1, 2] >= [1, 'text']` both evaluate to `null` (incomparable), but `[1, 2] >= [3, null]` evaluates to `false`.
+  * If comparing two lists includes comparing any pair of incomparable values, these lists may be <<incomparable>>.
+  On the one hand, `[1, 2] >= [1, null]`  and `[1, 2] >= [1, 'text']` both evaluate to `null` (incomparable), because `2` is incomparable with both `null` and `'text'`, and `1 \<= 1`.
+  On the other hand, `[1, 2] >= [3, null]` evaluates to `false`, because `1 < 3`.
   * Lists are <<incomparable>> to any value that is not also a list.
 - Maps
   * [[regular-maps,regular maps]]Regular maps
@@ -189,11 +193,11 @@ We propose that <<comparability-con,comparability>> should be defined between an
 
       p1 < p2
   <=> [n1, r1, n3] < [n1, r2, n2]
-  <=> n1 < n1 || (n1 = n1 && [r1, n3] < [r2, n2])
-  <=> false || (true && [r1, n3] < [r2, n2])
+  <=> n1 < n1 OR (n1 = n1 AND [r1, n3] < [r2, n2])
+  <=> false OR (true AND [r1, n3] < [r2, n2])
   <=> [r1, n3] < [r2, n2]
-  <=> r1 < r2 || (r1 = r2 && n3 < n2)
-  <=> true || (false && false)
+  <=> r1 < r2 OR (r1 = r2 AND n3 < n2)
+  <=> true OR (false AND false)
   <=> true
 
   ** Paths are <<incomparable>> to any value that is not also a path.
@@ -219,33 +223,33 @@ In order to align equality with <<comparability-def>>, we change equality of lis
 ===== List equality =====
 
 Specifically, we propose to redefine how equality works for lists in Cypher.
-The equality of two lists `a` and `b` is defined is the <<conjunction>> of `size(a) = size(b)` and a pairwise comparison of all elements of the list.
+The equality of two lists `a` and `b` is defined as the <<conjunction>> of `size(a) = size(b)` and a pairwise comparison of all elements of the list.
 If `a = b` evaluates to `null` these lists are <<incomparable>>.
 
-In the following example `=>` means "evaluates to".
 ----
-[1, 2] = [1]
-    => size([1, 2]) = size([1]) AND 1 = 1 AND 2 = null
-    => false                    AND true  AND null
-    => false
+    [1, 2] = [1]
+<=> size([1, 2]) = size([1]) AND 1 = 1 AND 2 = null
+<=> false                    AND true  AND null
+<=> false
 
-[null] = [1]
-    => size([null]) = size[1]) AND null = 1
-    => true                    AND null
-    => null
+    [null] = [1]
+<=> size([null]) = size[1]) AND null = 1
+<=> true                    AND null
+<=> null
 
-["a"] = [1]
-    => size(["a"]) = size[1]) AND "a" = 1
-    => true                   AND null
-    => null
+    ["a"] = [1]
+<=> size(["a"]) = size[1]) AND "a" = 1
+<=> size(["a"]) = size[1]) AND "a" = 1
+<=> true                   AND null
+<=> null
 ----
 
 The same logic applies recursively when comparing nested lists.
 ----
-[[1]] = [[1], [null]]
-    => size([[1]]) = size([[1], [null]]) AND [1] = [1] AND null = [null]
-    => false                             AND true      AND null
-    => false
+    [[1]] = [[1], [null]]
+<=> size([[1]]) = size([[1], [null]]) AND [1] = [1] AND null = [null]
+<=> false                             AND true      AND null
+<=> false
 ----
 
 ===== Map equality =====
@@ -263,8 +267,8 @@ This is at odds with the decision to produce <<unknown-null,"unknown" `null` val
 
 However, this definition is aligned with the most common use case for maps with `null` entries: updating multiple properties through the use of a single `SET` clause, e.g. `SET n += { size: 12, remove_this_key: null }`. In this case, there is no need to differentiate between different `null` values, as `null` merely serves as a marker for keys to be removed (i.e. is a <<missing-null,"missing" `null` value>>). Current equality semantics make it easy to check if two maps would correspond to the same property update in this scenario. We note though that this type of update map comparison is rare and could be emulated using a more complex predicate. The current rules do however break symmetry with how equality handles `null` in all other cases. This becomes more apparent by considering these two examples:
 
-* `expr1 = expr2` evaluates to `null` if `expr1 IS NULL && expr2 IS NULL`
-* `{a: expr1} = {a: expr2}` evaluates to `true` if `expr1 IS NULL && expr2 IS NULL`
+* `expr1 = expr2` evaluates to `null` if `expr1 IS NULL AND expr2 IS NULL`
+* `{a: expr1} = {a: expr2}` evaluates to `true` if `expr1 IS NULL AND expr2 IS NULL`
 
 ====== New map equality ======
 

--- a/tck/features/Comparability.feature
+++ b/tck/features/Comparability.feature
@@ -98,3 +98,22 @@ Feature: Comparability
       | <=       | 1    | 3.14 |
       | >=       | 3.14 | 1    |
       | >        | 3.14 | 1    |
+
+  Scenario Outline: Comparing lists
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <lhs> >= <rhs> AS result
+      """
+    Then the result should be:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | lhs       | rhs       | result |
+      | [1, 0]    | [1]       | true   |
+      | [1, null] | [1]       | true   |
+      | [1, 2]    | [1, null] | null   |
+      | [1, 'a']  | [1, null] | null   |
+      | [1, 2]    | [3, null] | false  |

--- a/tck/features/EqualsAcceptance.feature
+++ b/tck/features/EqualsAcceptance.feature
@@ -122,3 +122,23 @@ Feature: EqualsAcceptance
       | count(b) |
       | 1        |
     And no side effects
+
+  Scenario Outline: Comparing lists to lists
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <lhs> = <rhs> AS result
+      """
+    Then the result should be:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | lhs           | rhs           | result |
+      | [1, 2]        | [1]           | false  |
+      | [null]        | [1]           | null   |
+      | ['a']         | [1]           | null   |
+      | [[1]]         | [[1], [null]] | false  |
+      | [[1], [2]]    | [[1], [null]] | null   |
+      | [[1], [2, 3]] | [[1], [null]] | false  |

--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -246,6 +246,96 @@ Feature: OrderByAcceptance
       | 1.3    |
     And no side effects
 
+  Scenario: ORDER BY should order lists in the expected order
+    When executing query:
+      """
+      UNWIND [[], ['a'], ['a', 1], [1], [1, 'a'], [1, null], [null, 1], [null, 2]] AS lists
+      RETURN lists
+      ORDER BY lists
+      """
+    Then the result should be, in order:
+      | types     |
+      | []        |
+      | ['a']     |
+      | ['a', 1]  |
+      | [1]       |
+      | [1, 'a']  |
+      | [1, null] |
+      | [null, 1] |
+      | [null, 2] |
+    And no side effects
+
+  Scenario: ORDER BY DESC should order lists in the expected order
+    When executing query:
+      """
+      UNWIND [[], ['a'], ['a', 1], [1], [1, 'a'], [1, null], [null, 1], [null, 2]] AS lists
+      RETURN lists
+      ORDER BY lists DESC
+      """
+    Then the result should be, in order:
+      | types     |
+      | [null, 2] |
+      | [null, 1] |
+      | [1, null] |
+      | [1, 'a']  |
+      | [1]       |
+      | ['a', 1]  |
+      | ['a']     |
+      | []        |
+    And no side effects
+
+  Scenario: ORDER BY should order distinct types in the expected order
+    And having executed:
+      """
+      CREATE (:N)-[:REL]->()
+      """
+    When executing query:
+      """
+      MATCH p = (n:N)-[r:REL]->()
+      UNWIND [n, r, p, 1.5, ['list'], 'text', null, false, toFloat(null), {a: 'map'}] AS types
+      RETURN types
+      ORDER BY types
+      """
+    Then the result should be, in order:
+      | types             |
+      | {a: 'map'}        |
+      | (:N)              |
+      | [:REL]            |
+      | ['list']          |
+      | <(:N)-[:REL]->()> |
+      | 'text'            |
+      | false             |
+      | 1.5               |
+      | NaN               |
+      | null              |
+    And no side effects
+
+  Scenario: ORDER BY DESC should order distinct types in the expected order
+    And having executed:
+      """
+      CREATE (:N)-[:REL]->()
+      """
+    When executing query:
+      """
+      MATCH p = (n:N)-[r:REL]->()
+      UNWIND [n, r, p, 1.5, ['list'], 'text', null, false, toFloat(null), {a: 'map'}] AS types
+      RETURN types
+      ORDER BY types DESC
+      """
+    Then the result should be, in order:
+      | types             |
+      | null              |
+      | NaN               |
+      | 1.5               |
+      | false             |
+      | 'text'            |
+      | <(:N)-[:REL]->()> |
+      | ['list']          |
+      | [:REL]            |
+      | (:N)              |
+      | {a: 'map'}        |
+    And no side effects
+
   Scenario: Handle ORDER BY with LIMIT 1
     And having executed:
       """

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
@@ -145,6 +145,10 @@ case object CypherNull extends CypherValue {
   override def toString: String = "null"
 }
 
+case object CypherNaN extends CypherValue {
+  override def toString: String = "NaN"
+}
+
 case class CypherPath(startingNode: CypherNode, connections: List[Connection] = List.empty) extends CypherValue {
   override def toString: String = s"<$startingNode${connections.mkString("")}>"
 }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValueParser.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValueParser.scala
@@ -69,7 +69,8 @@ class CypherValueParser(val orderedLists: Boolean) {
       float |
       integer |
       boolean |
-      nullValue
+      nullValue |
+      nanValue
 
   private def node[_: P]: P[CypherNode] =
     P("(" ~~/ label.rep ~/ map.? ~/ ")").map { case (labels, properties) =>
@@ -125,6 +126,11 @@ class CypherValueParser(val orderedLists: Boolean) {
   private def nullValue[_: P]: P[CypherNull.type] =
     P("null").!.map { _ =>
       CypherNull
+    }
+
+  private def nanValue[_: P]: P[CypherNaN.type] =
+    P("NaN").!.map { _ =>
+      CypherNaN
     }
 
   // Sub-parsers:

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/CypherValueParserTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/CypherValueParserTest.scala
@@ -62,6 +62,7 @@ class CypherValueParserTest extends FunSuite with Matchers {
     CypherValue("''") should equal(CypherString(""))
     CypherValue("'-1'") should equal(CypherString("-1"))
     CypherValue("null") should equal(CypherNull)
+    CypherValue("NaN") should equal(CypherNaN)
   }
 
   test("string escaping") {


### PR DESCRIPTION
The Neo4j Cypher team recently fixed that our implementation didn't follow the 2016-06-14 CIP regarding comparisons and equality with lists containing null. However, during the work we found the CIP more confusing than helpful so I have tried to clarify the relevant parts of it and increase the number of examples.