### PR TITLE
Prefix Antlr4 parser rules to avoid target language keywords

### DIFF
--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
@@ -32,9 +32,7 @@ import org.opencypher.grammar.Production;
 import org.opencypher.tools.io.Output;
 
 import static java.lang.Character.charCount;
-import static java.lang.Character.isLowerCase;
 import static java.lang.Character.isUpperCase;
-import static java.lang.Character.toLowerCase;
 import static java.lang.Character.toUpperCase;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,6 +45,8 @@ import static org.opencypher.tools.io.Output.output;
  */
 public class Antlr4 extends BnfWriter
 {
+    static String PREFIX = "oC_";
+
     public static void write( Grammar grammar, Writer writer )
     {
         write( grammar, output( writer ) );
@@ -76,7 +76,6 @@ public class Antlr4 extends BnfWriter
 
     public static void main( String... args ) throws Exception
     {
-        // We need to do some custom post-processing to get the lexer rules right
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         execute( Antlr4::write, out, "grammar/cypher.xml" );
 
@@ -324,20 +323,7 @@ public class Antlr4 extends BnfWriter
 
     private Output parserRule( String name )
     {
-        int cp = name.codePointAt( 0 );
-        if ( !isLowerCase( cp ) )
-        {
-            if ( name.codePoints().noneMatch( Character::isLowerCase ) )
-            {
-                return output.append( name.toLowerCase() );
-            }
-            return output.appendCodePoint( toLowerCase( cp ) )
-                         .append( name, charCount( cp ), name.length() );
-        }
-        else
-        {
-            return output.append( name );
-        }
+        return output.append( prefix( name ) );
     }
 
     private Output lexerRule( String name )
@@ -356,6 +342,12 @@ public class Antlr4 extends BnfWriter
         {
             return output.append( name );
         }
+    }
+
+    @Override
+    protected String prefix( String s )
+    {
+        return Antlr4.PREFIX + s;
     }
 
     @Override

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/BnfWriter.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/BnfWriter.java
@@ -57,6 +57,8 @@ abstract class BnfWriter implements ProductionVisitor<RuntimeException>, TermVis
 
     protected abstract void productionStart( Production p );
 
+    protected abstract String prefix( String s );
+
     protected abstract void productionEnd();
 
     protected abstract void alternativesLinePrefix( int altPrefix );
@@ -126,7 +128,7 @@ abstract class BnfWriter implements ProductionVisitor<RuntimeException>, TermVis
             }
             productionCommentSuffix();
         }
-        this.altPrefix = production.name().length();
+        this.altPrefix = prefix( production.name() ).length();
         group = false;
         productionStart( production );
         production.definition().accept( this );

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
@@ -206,6 +206,12 @@ public class ISO14977 extends BnfWriter
     }
 
     @Override
+    protected String prefix( String s )
+    {
+        return s;
+    }
+
+    @Override
     protected void productionEnd()
     {
         output.println( " ;" ).println();

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4Test.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4Test.java
@@ -50,11 +50,11 @@ public class Antlr4Test
                         .build( Grammar.Builder.Option.ALLOW_ROOTLESS ),
                 "grammar foo;",
                 "",
-                "thing1 : '1' ;",
+                "oC_thing1 : '1' ;",
                 "",
-                "thing2 : '2' ;",
+                "oC_thing2 : '2' ;",
                 "",
-                "bar : ( thing1 thing2 )* ;",
+                "oC_bar : ( oC_thing1 oC_thing2 )* ;",
                 "" );
     }
 
@@ -67,7 +67,7 @@ public class Antlr4Test
                         .build( Grammar.Builder.Option.ALLOW_ROOTLESS ),
                 "grammar foo;",
                 "",
-                "bar : 'LIteR@L' ;",
+                "oC_bar : 'LIteR@L' ;",
                 "" );
     }
 
@@ -81,12 +81,12 @@ public class Antlr4Test
                         .build( Grammar.Builder.Option.ALLOW_ROOTLESS ),
                 "grammar foo;",
                 "",
-                "other : 'abc' ;",
+                "oC_other : 'abc' ;",
                 "",
-                "bar : other",
-                "    | '=>~`$&@'",
-                "    | other",
-                "    ;",
+                "oC_bar : oC_other",
+                "       | '=>~`$&@'",
+                "       | oC_other",
+                "       ;",
                 "" );
     }
 
@@ -99,7 +99,7 @@ public class Antlr4Test
                         .build( Grammar.Builder.Option.ALLOW_ROOTLESS ),
                 "grammar foo;",
                 "",
-                "bar : LITER@L ;",
+                "oC_bar : LITER@L ;",
                 "",
                 "LITER@L : ( 'L' | 'l' ) ( 'I' | 'i' ) ( 'T' | 't' ) ( 'E' | 'e' ) ( 'R' | 'r' ) ( '@' | '@' ) ( 'L' | 'l' )  ;",
                 "" );
@@ -116,15 +116,15 @@ public class Antlr4Test
                         .production( "beta", literal( "b" ) ),
                 "grammar MyLanguage;",
                 "",
-                "myLanguage : value ;",
+                "oC_MyLanguage : oC_value ;",
                 "",
-                "value : alpha",
-                "      | beta",
-                "      ;",
+                "oC_value : oC_alpha",
+                "         | oC_beta",
+                "         ;",
                 "",
-                "alpha : 'a' ;",
+                "oC_alpha : 'a' ;",
                 "",
-                "beta : 'b' ;",
+                "oC_beta : 'b' ;",
                 "" );
     }
 
@@ -136,7 +136,7 @@ public class Antlr4Test
                         .production( "FooBar", optional( literal( "foo" ), literal( "bar" ) ) ),
                 "grammar FooBar;",
                 "",
-                "fooBar : ( 'foo' 'bar' )? ;",
+                "oC_FooBar : ( 'foo' 'bar' )? ;",
                 "" );
     }
 
@@ -161,7 +161,7 @@ public class Antlr4Test
                                 '\uFF04', '\uFFE0', '\uFFE1', '\uFFE5', '\uFFE6' ) ),
                 "grammar test;",
                 "",
-                "test : TEST_0 ;",
+                "oC_test : TEST_0 ;",
                 "",
                 "fragment TEST_0 : [$\\u00A2-\\u00A5\\u20A0-\\u20BA] ;",
                 "" );
@@ -174,7 +174,7 @@ public class Antlr4Test
                         .production( "test", charactersOfSet( name ) ),
                 "grammar test;",
                 "",
-                "test : " + name + " ;",
+                "oC_test : " + name + " ;",
                 "",
                 "fragment " + name + " : " + def + " ;",
                 "" );

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
@@ -120,7 +120,7 @@ public class Antlr4TestUtils
         parser.removeErrorListeners();
         lexer.addErrorListener( lexerListener );
         parser.addErrorListener( parserListener );
-        parser.parse( grammar.getRule( "cypher" ).index );
+        parser.parse( grammar.getRule( Antlr4.PREFIX + "Cypher" ).index );
     }
 
     private static class FailingErrorListener implements ANTLRErrorListener


### PR DESCRIPTION
Uses the prefix `oC_` for all parser rules. Lexer rules are treated
differently by ANTLR and are not subject to the same kind of conflicts.

Fixes #251