### PR TITLE
TCK: Make 'LIMIT TO TWO HITS' test more explicit

### DIFF
--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -43,7 +43,7 @@ Feature: ReturnAcceptanceTest
       LIMIT 2
       """
     Then the result should be:
-      | i             |
+      | i |
       | 1 |
       | 1 |
     And no side effects

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -36,6 +36,20 @@ Feature: ReturnAcceptanceTest
 
   Scenario: Limit to two hits
     Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 1, 1, 1, 1] AS i
+      RETURN i
+      LIMIT 2
+      """
+    Then the result should be:
+      | i             |
+      | 1 |
+      | 1 |
+    And no side effects
+
+  Scenario: Limit to two hits with explicit order
+    Given an empty graph
     And having executed:
       """
       CREATE ({name: 'A'}),
@@ -48,6 +62,7 @@ Feature: ReturnAcceptanceTest
       """
       MATCH (n)
       RETURN n
+      ORDER BY n.name ASC
       LIMIT 2
       """
     Then the result should be:


### PR DESCRIPTION
Currently the test `ReturnAcceptanceTest.Limit to two hits` is ambiguous. 
It selects all nodes from a graph and then limits this set to two with out an explicit order. The expectation however tests for specific nodes to be return although every combination would be valid.

This PR splits the above test into two tests. One test returns a set of equal elements and limits this set. Another test is equal to the original one but introduces a specific order on the nodes. 