### PR TITLE
oC grammar: make PropertyOrLabelsExpression more specific. Fixes #288

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -258,12 +258,9 @@
   <production name="PropertyOrLabelsExpression" rr:inline="true">
     <non-terminal ref="Atom"/>
     <repeat>
-      &WS;
-      <alt>
-        <non-terminal ref="PropertyLookup"/>
-        <non-terminal ref="NodeLabels"/>
-      </alt>
+      &WS; <non-terminal ref="PropertyLookup"/>
     </repeat>
+    <opt>&WS; <non-terminal ref="NodeLabels"/></opt>
   </production>
 
   <production name="Atom">

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
@@ -133,9 +133,9 @@ public class Antlr4TestUtils
         }
 
         @Override
-        public void syntaxError( Recognizer<?,?> recognizer, Object o, int i, int i1, String s, RecognitionException e )
+        public void syntaxError( Recognizer<?,?> recognizer, Object o, int line, int charPositionInLine, String msg, RecognitionException e )
         {
-            fail( "syntax error in query: " + query );
+            fail( "syntax error in query at line " + line + ":" + charPositionInLine + ": " + msg + ": " + query );
         }
 
         @Override

--- a/tools/grammar/src/test/resources/cypher-error.txt
+++ b/tools/grammar/src/test/resources/cypher-error.txt
@@ -25,3 +25,8 @@ CREATE ()
 WITH *
 DELETE a
 RETURN a§
+//
+// Miscellaneous errors
+//
+// Label check predicates shouldn't precede property lookup, see #288
+MATCH (p) WHERE p:Person:Teacher.name RETURN p§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -281,3 +281,6 @@ WITH *
 CREATE ()
 WITH *
 RETURN 1§
+// see: #288
+MATCH (p) WHERE p:Person:Teacher RETURN p§
+MATCH (p) WHERE {foo: p}.foo:Person:Teacher RETURN p§


### PR DESCRIPTION
The grammar used to allow mixing of property lookups and node labels
in a sequence. In reality, however, all property lookups perede all
the label constraints.

This grammar modification reflects the real structure.