### PR TITLE
Annotate all feature files with their encoding

### DIFF
--- a/tck/features/Aggregation.feature
+++ b/tck/features/Aggregation.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: Aggregation
 
   Scenario: `max()` over strings

--- a/tck/features/AggregationAcceptance.feature
+++ b/tck/features/AggregationAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: AggregationAcceptance
 
   Scenario: Support multiple divisions in aggregate function

--- a/tck/features/ColumnNameAcceptance.feature
+++ b/tck/features/ColumnNameAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ColumnNameAcceptance
 
   Background:

--- a/tck/features/Comparability.feature
+++ b/tck/features/Comparability.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: Comparability
 
   Scenario: Comparing strings and integers using > in an AND'd predicate

--- a/tck/features/ComparisonOperatorAcceptance.feature
+++ b/tck/features/ComparisonOperatorAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ComparisonOperatorAcceptance
 
   Scenario: Handling numerical ranges 1

--- a/tck/features/Create.feature
+++ b/tck/features/Create.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: Create
 
   Scenario: Creating a node

--- a/tck/features/CreateAcceptance.feature
+++ b/tck/features/CreateAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: CreateAcceptance
 
   Scenario: Create a single node with multiple labels

--- a/tck/features/DeleteAcceptance.feature
+++ b/tck/features/DeleteAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: DeleteAcceptance
 
   Scenario: Delete nodes

--- a/tck/features/EqualsAcceptance.feature
+++ b/tck/features/EqualsAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: EqualsAcceptance
 
   Scenario: Number-typed integer comparison

--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ExpressionAcceptance
 
   Background:

--- a/tck/features/FunctionsAcceptance.feature
+++ b/tck/features/FunctionsAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: FunctionsAcceptance
 
   Scenario: Run coalesce

--- a/tck/features/JoinAcceptance.feature
+++ b/tck/features/JoinAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ValueHashJoinAcceptance
 
   Scenario: Find friends of others

--- a/tck/features/KeysAcceptance.feature
+++ b/tck/features/KeysAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: KeysAcceptance
 
   Scenario: Using `keys()` on a single node, non-empty result

--- a/tck/features/LabelsAcceptance.feature
+++ b/tck/features/LabelsAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: LabelsAcceptance
 
   Background:

--- a/tck/features/LargeCreateQuery.feature
+++ b/tck/features/LargeCreateQuery.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: LargeCreateQuery
 
   Scenario: Generate the movie graph correctly

--- a/tck/features/LargeIntegerEquality.feature
+++ b/tck/features/LargeIntegerEquality.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: LargeIntegerEquality
 
   Background:

--- a/tck/features/ListComprehension.feature
+++ b/tck/features/ListComprehension.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ListComprehension
 
   Scenario: Returning a list comprehension

--- a/tck/features/Literals.feature
+++ b/tck/features/Literals.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: Literals
 
   Background:

--- a/tck/features/MatchAcceptance.feature
+++ b/tck/features/MatchAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MatchAcceptance
 
   Scenario: Path query should return results in written order

--- a/tck/features/MatchAcceptance2.feature
+++ b/tck/features/MatchAcceptance2.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MatchAcceptance2
 
   Scenario: Do not return non-existent nodes

--- a/tck/features/MatchingSelfRelationships.feature
+++ b/tck/features/MatchingSelfRelationships.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MatchingSelfRelationships
 
   Scenario: Undirected match in self-relationship graph

--- a/tck/features/MergeIntoAcceptance.feature
+++ b/tck/features/MergeIntoAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MergeIntoAcceptance
 
   Background:

--- a/tck/features/MergeNodeAcceptance.feature
+++ b/tck/features/MergeNodeAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MergeNodeAcceptance
 
   Scenario: Merge node when no nodes exist

--- a/tck/features/MergeRelationshipAcceptance.feature
+++ b/tck/features/MergeRelationshipAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MergeRelationshipAcceptance
 
   Scenario: Creating a relationship

--- a/tck/features/MiscellaneousErrorAcceptance.feature
+++ b/tck/features/MiscellaneousErrorAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: MiscellaneousErrorAcceptance
 
   Background:

--- a/tck/features/NullAcceptance.feature
+++ b/tck/features/NullAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: NullAcceptance
 
   Scenario: Ignore null when setting property

--- a/tck/features/OptionalMatch.feature
+++ b/tck/features/OptionalMatch.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: OptionalMatch
 
   Scenario: Satisfies the open world assumption, relationships between same nodes

--- a/tck/features/OptionalMatchAcceptance.feature
+++ b/tck/features/OptionalMatchAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: OptionalMatchAcceptance
 
   Background:

--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: OrderByAcceptance
 
   Background:

--- a/tck/features/PathEquality.feature
+++ b/tck/features/PathEquality.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: PathEquality
 
   Scenario: Direction of traversed relationship is not significant for path equality, simple

--- a/tck/features/PatternComprehension.feature
+++ b/tck/features/PatternComprehension.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: PatternComprehension
 
   Scenario: Pattern comprehension and ORDER BY

--- a/tck/features/ProcedureCallAcceptance.feature
+++ b/tck/features/ProcedureCallAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ProcedureCallAcceptance
 
   Background:

--- a/tck/features/RemoveAcceptance.feature
+++ b/tck/features/RemoveAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: RemoveAcceptance
 
   Scenario: Should ignore nulls

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ReturnAcceptanceTest
 
   Scenario: Allow addition

--- a/tck/features/ReturnAcceptance2.feature
+++ b/tck/features/ReturnAcceptance2.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: ReturnAcceptance2
 
   Scenario: Fail when returning properties of deleted nodes

--- a/tck/features/SemanticErrorAcceptance.feature
+++ b/tck/features/SemanticErrorAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: SemanticErrorAcceptance
 
   Background:

--- a/tck/features/SetAcceptance.feature
+++ b/tck/features/SetAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: SetAcceptance
 
   Scenario: Setting a node property to null removes the existing property

--- a/tck/features/SkipLimitAcceptance.feature
+++ b/tck/features/SkipLimitAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: SkipLimitAcceptanceTest
 
   Background:

--- a/tck/features/StartingPointAcceptance.feature
+++ b/tck/features/StartingPointAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: StartingPointAcceptance
 
   Scenario: Find all nodes

--- a/tck/features/StartsWithAcceptance.feature
+++ b/tck/features/StartsWithAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: StartsWithAcceptance
 
   Background:

--- a/tck/features/SyntaxErrorAcceptance.feature
+++ b/tck/features/SyntaxErrorAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: SyntaxErrorAcceptance
 
   Background:

--- a/tck/features/TernaryLogicAcceptance.feature
+++ b/tck/features/TernaryLogicAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: TernaryLogicAcceptanceTest
 
   Background:

--- a/tck/features/TriadicSelection.feature
+++ b/tck/features/TriadicSelection.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: TriadicSelection
 
   Scenario: Handling triadic friend of a friend

--- a/tck/features/TypeConversionFunctions.feature
+++ b/tck/features/TypeConversionFunctions.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: TypeConversionFunctions
 
   Scenario: `toBoolean()` on valid literal string

--- a/tck/features/UnionAcceptance.feature
+++ b/tck/features/UnionAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: UnionAcceptance
 
   Scenario: Should be able to create text output from union queries

--- a/tck/features/UnwindAcceptance.feature
+++ b/tck/features/UnwindAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: UnwindAcceptance
 
   Scenario: Unwinding a list

--- a/tck/features/VarLengthAcceptance.feature
+++ b/tck/features/VarLengthAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: VarLengthAcceptance
 
   # TODO: Replace this with a named graph (or two)

--- a/tck/features/VarLengthAcceptance2.feature
+++ b/tck/features/VarLengthAcceptance2.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: VarLengthAcceptance2
 
   Scenario: Handling relationships that are already bound in variable length paths

--- a/tck/features/WhereAcceptance.feature
+++ b/tck/features/WhereAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: WhereAcceptance
 
   Scenario: NOT and false

--- a/tck/features/WithAcceptance.feature
+++ b/tck/features/WithAcceptance.feature
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+#encoding: utf-8
+
 Feature: WithAcceptance
 
   Scenario: Passing on pattern nodes


### PR DESCRIPTION
This might fix a problem we are experiencing on certain builds but it is anyway a better form to include that information in the feature files