### PR TITLE
Grammar simplifications

### DIFF
--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -106,7 +106,7 @@
       </seq>
       <seq>
         <non-terminal ref="UpdateOnlyQueryPartBody"/>
-        <opt>&WS; <non-terminal ref="Return"/></opt>
+        <opt><non-terminal ref="Return"/></opt>
       </seq>
     </alt>
   </production>
@@ -131,9 +131,8 @@
   </production>
 
   <production name="UpdateOnlyQueryPartBody" rr:inline="true">
-    <non-terminal ref="UpdatingStartClause"/>
-    <repeat>
-      &WS; <non-terminal ref="UpdatingClause"/>
+    <repeat min="1">
+      <non-terminal ref="UpdatingClause"/> &WS;
     </repeat>
   </production>
 
@@ -156,7 +155,6 @@
       </seq>
       <seq>
         <non-terminal ref="UpdateOnlyQueryPartBody"/>
-        &WS;
       </seq>
     </alt>
     <non-terminal ref="With"/>
@@ -188,15 +186,6 @@
         </repeat>
         <opt>&WS; <non-terminal ref="Return"/></opt>
       </seq>
-    </alt>
-  </production>
-
-  <production name="UpdatingStartClause" rr:inline="true">
-    <alt>
-      <non-terminal ref="Create"/>
-      <non-terminal ref="Merge"/>
-      <non-terminal ref="CreateUnique"/>
-      <non-terminal ref="Foreach"/>
     </alt>
   </production>
 

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -137,37 +137,14 @@
   </production>
 
   <production name="MultiPartQuery">
-    <non-terminal ref="MultiPartQueryBegin"/>
-    &WS;
-    <repeat>
-      <non-terminal ref="MultiPartQueryMiddle"/>
-      &WS;
+    <repeat min="1">
+      <non-terminal ref="ReadOnlyQueryPartBody"/>
+      <repeat>
+        <non-terminal ref="UpdatingClause"/> &WS;
+      </repeat>
+      <non-terminal ref="With"/> &WS;
     </repeat>
     <non-terminal ref="SinglePartQuery"/>
-  </production>
-
-  <production name="MultiPartQueryBegin" rr:inline="true">
-    <alt>
-      <non-terminal ref="ReadOnlyQueryPartBody"/><!-- whitespace that follows already consumed in rule -->
-      <seq>
-        <non-terminal ref="ReadUpdateQueryPartBody"/>
-        &WS;
-      </seq>
-      <seq>
-        <non-terminal ref="UpdateOnlyQueryPartBody"/>
-      </seq>
-    </alt>
-    <non-terminal ref="With"/>
-  </production>
-
-  <production name="MultiPartQueryMiddle" rr:inline="true">
-    <repeat>
-      <non-terminal ref="ReadingClause"/> &WS;
-    </repeat>
-    <repeat>
-      <non-terminal ref="UpdatingClause"/> &WS;
-    </repeat>
-    <non-terminal ref="With"/>
   </production>
 
   <production name="UpdatingClause" rr:inline="true">

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -97,48 +97,29 @@
   <production name="SinglePartQuery">
     <alt>
       <seq>
-        <non-terminal ref="ReadOnlyQueryPartBody"/><!-- whitespace that follows already consumed in rule -->
+        <repeat>
+          <non-terminal ref="ReadingClause"/> &WS;
+        </repeat>
         <non-terminal ref="Return"/>
       </seq>
       <seq>
-        <non-terminal ref="ReadUpdateQueryPartBody"/>
+        <repeat>
+          <non-terminal ref="ReadingClause"/> &WS;
+        </repeat>
+        <non-terminal ref="UpdatingClause"/>
+        <repeat>
+          &WS; <non-terminal ref="UpdatingClause"/>
+        </repeat>
         <opt>&WS; <non-terminal ref="Return"/></opt>
-      </seq>
-      <seq>
-        <non-terminal ref="UpdateOnlyQueryPartBody"/>
-        <opt><non-terminal ref="Return"/></opt>
       </seq>
     </alt>
   </production>
 
-  <production name="ReadOnlyQueryPartBody" rr:inline="true">
-    <!-- whitespaces consumed at end of rule -->
-    <repeat>
-      <non-terminal ref="ReadingClause"/>
-      &WS;
-    </repeat>
-  </production>
-
-  <production name="ReadUpdateQueryPartBody" rr:inline="true">
-    <!-- no whitespaces consumed at begin/end of rule -->
-    <non-terminal ref="ReadingClause"/>
-    <repeat>
-      &WS; <non-terminal ref="ReadingClause"/>
-    </repeat>
-    <repeat min="1">
-      &WS; <non-terminal ref="UpdatingClause"/>
-    </repeat>
-  </production>
-
-  <production name="UpdateOnlyQueryPartBody" rr:inline="true">
-    <repeat min="1">
-      <non-terminal ref="UpdatingClause"/> &WS;
-    </repeat>
-  </production>
-
   <production name="MultiPartQuery">
     <repeat min="1">
-      <non-terminal ref="ReadOnlyQueryPartBody"/>
+      <repeat>
+        <non-terminal ref="ReadingClause"/> &WS;
+      </repeat>
       <repeat>
         <non-terminal ref="UpdatingClause"/> &WS;
       </repeat>

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -143,7 +143,7 @@
       <non-terminal ref="MultiPartQueryMiddle"/>
       &WS;
     </repeat>
-    <non-terminal ref="MultiPartQueryEnd"/>
+    <non-terminal ref="SinglePartQuery"/>
   </production>
 
   <production name="MultiPartQueryBegin" rr:inline="true">
@@ -168,25 +168,6 @@
       <non-terminal ref="UpdatingClause"/> &WS;
     </repeat>
     <non-terminal ref="With"/>
-  </production>
-
-  <production name="MultiPartQueryEnd" rr:inline="true">
-    <alt>
-      <seq>
-        <non-terminal ref="ReadOnlyQueryPartBody"/><!-- whitespace that follows already consumed in rule -->
-        <non-terminal ref="Return"/>
-      </seq>
-      <seq>
-        <repeat>
-          <non-terminal ref="ReadingClause"/> &WS;
-        </repeat>
-        <non-terminal ref="UpdatingClause"/>
-        <repeat>
-          &WS; <non-terminal ref="UpdatingClause"/>
-        </repeat>
-        <opt>&WS; <non-terminal ref="Return"/></opt>
-      </seq>
-    </alt>
   </production>
 
   <production name="UpdatingClause" rr:inline="true">

--- a/tools/grammar/src/test/resources/cypher-error.txt
+++ b/tools/grammar/src/test/resources/cypher-error.txt
@@ -7,12 +7,6 @@ WITH 1 AS a§
 UNWIND [] AS foo§
 LOAD CSV from $url AS list§
 //
-// clauses that are invalid as first clause
-SET n.prop = 2§
-REMOVE n.prop§
-DELETE n§
-DETACH DELETE n§
-//
 // invalid combinations of clauses
 RETURN 1 RETURN 2§
 RETURN 1 MATCH ()§
@@ -20,7 +14,6 @@ RETURN 1 WITH 2 AS foo§
 CREATE () MATCH () RETURN 1§
 CREATE () UNWIND [] AS foo RETURN 1§
 MERGE () UNWIND [] AS foo RETURN 1§
-DELETE a WITH 1 RETURN 2§
 //
 // Miscellaneous errors
 //

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -294,3 +294,9 @@ CREATE ()
 WITH *
 DELETE a
 RETURN a§
+SET null.p = 2§
+REMOVE null.p§
+DELETE null§
+DETACH DELETE null§
+// syntactically correct, although semantically invalid
+DELETE a WITH 1 RETURN 2§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -300,3 +300,5 @@ DELETE null§
 DETACH DELETE null§
 // syntactically correct, although semantically invalid
 DELETE a WITH 1 RETURN 2§
+MATCH (a  ) DELETE a        RETURN a   §
+MATCH   (a) DELETE    a   WITH  a RETURN   a§


### PR DESCRIPTION
This change allows any updating clause to begin a query (part).

A continuation from #300 

A multi-part query now follows this simple outline:

1. one or more of
  a. zero or more reading clauses
  b. zero or more updating clauses
  c. a WITH clause
2. one SinglePartQuery

<img width="815" alt="screen shot 2018-03-01 at 11 57 28" src="https://user-images.githubusercontent.com/2419675/36841622-2b4b9bf2-1d49-11e8-94b4-a0e591728281.png">