### PR TITLE
Fix faulty use of system default file separator

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -36,7 +36,7 @@ import scala.util.{Failure, Success, Try}
 
 object CypherTCK {
 
-  val featuresPath = s"${File.separator}features"
+  val featuresPath = "/features"
   val featureSuffix = ".feature"
 
   private lazy val parser = new Parser[GherkinDocument](new AstBuilder)


### PR DESCRIPTION
The previous version led to problems when running on windows where file.separator equals "\\"
( getClass.getResource does not handle "\\" )