### PR TITLE
Add TCK execution events to allow custom test report

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -27,17 +27,20 @@
  */
 package org.opencypher.tools.tck.api
 
+import gherkin.pickles.Pickle
 import org.junit.jupiter.api.function.Executable
 import org.opencypher.tools.tck.SideEffectOps
 import org.opencypher.tools.tck.SideEffectOps._
 import org.opencypher.tools.tck.api.Graph.Result
+import org.opencypher.tools.tck.api.events.TCKEvents
+import org.opencypher.tools.tck.api.events.TCKEvents.{StepFinished, StepStarted, setStepFinished, setStepStarted}
 import org.opencypher.tools.tck.values.CypherValue
 
 import scala.compat.Platform.EOL
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-case class Scenario(featureName: String, name: String, tags: Set[String], steps: List[Step]) {
+case class Scenario(featureName: String, name: String, tags: Set[String], steps: List[Step], source: Pickle) {
 
   self =>
 
@@ -47,77 +50,92 @@ case class Scenario(featureName: String, name: String, tags: Set[String], steps:
     override def execute(): Unit = {
       val g = graph // ensure that lazy parameter is only evaluated once
       try {
+        TCKEvents.setScenario(self)
         executeOnGraph(g)
       } finally g.close()
     }
   }
 
   def executeOnGraph(empty: Graph): Unit = {
-    steps.foldLeft(ScenarioExecutionContext(empty)) {
+    steps.foldLeft(ScenarioExecutionContext(empty)) { (context, step) =>
+      {
+        val eventId = setStepStarted(StepStarted(step))
+        var exception: Option[Throwable] = None
+        val result: ScenarioExecutionContext = (context, step) match {
 
-      case (ctx, Execute(query, qt)) =>
-        ctx.execute(query, qt)
+          case (ctx, Execute(query, qt, _)) =>
+            ctx.execute(query, qt)
 
-      case (ctx, Measure) =>
-        ctx.measure
+          case (ctx, Measure(_)) =>
+            ctx.measure
 
-      case (ctx, RegisterProcedure(signature, table)) =>
-        ctx.graph match {
-          case support: ProcedureSupport =>
-            support.registerProcedure(signature, table)
-          case _ =>
-        }
-        ctx
-
-      case (ctx, ExpectResult(expected, sorted)) =>
-        ctx.lastResult match {
-          case Right(records) =>
-            val correctResult =
-              if (sorted)
-                expected == records
-              else
-                expected.equalsUnordered(records)
-
-            if (!correctResult) {
-              val detail = if (sorted) "ordered rows" else "in any order of rows"
-              throw ScenarioFailedException(
-                s"${EOL}Expected ($detail):$EOL$expected${EOL}Actual:$EOL$records")
+          case (ctx, RegisterProcedure(signature, table, _)) =>
+            ctx.graph match {
+              case support: ProcedureSupport =>
+                support.registerProcedure(signature, table)
+              case _ =>
             }
-          case Left(error) =>
-            throw ScenarioFailedException(s"Expected: $expected, got error $error", error.exception.orNull)
+            ctx
+
+          case (ctx, ExpectResult(expected, _, sorted)) =>
+            ctx.lastResult match {
+              case Right(records) =>
+                val correctResult =
+                  if (sorted)
+                    expected == records
+                  else
+                    expected.equalsUnordered(records)
+
+                if (!correctResult) {
+                  val detail = if (sorted) "ordered rows" else "in any order of rows"
+                  exception =
+                    Some(ScenarioFailedException(s"${EOL}Expected ($detail):$EOL$expected${EOL}Actual:$EOL$records"))
+                }
+              case Left(error) =>
+                exception =
+                  Some(ScenarioFailedException(s"Expected: $expected, got error $error", error.exception.orNull))
+            }
+            ctx
+
+          case (ctx, e @ ExpectError(errorType, phase, detail, _)) =>
+            ctx.lastResult match {
+              case Left(error) =>
+                if (error.errorType != errorType)
+                  exception =
+                    Some(ScenarioFailedException(s"Wrong error type: expected $errorType, got ${error.errorType}"))
+                if (error.phase != phase)
+                  exception = Some(ScenarioFailedException(s"Wrong error phase: expected $phase, got ${error.phase}"))
+                if (error.detail != detail)
+                  exception =
+                    Some(ScenarioFailedException(s"Wrong error detail: expected $detail, got ${error.detail}"))
+
+              case Right(records) =>
+                exception = Some(ScenarioFailedException(s"Expected: $e, got records $records"))
+            }
+
+            ctx
+
+          case (ctx, SideEffects(expected, _)) =>
+            val before = ctx.state
+            val after = ctx.measure.state
+            val diff = before diff after
+            if (diff != expected)
+              exception = Some(
+                ScenarioFailedException(
+                  s"${EOL}Expected side effects:$EOL$expected${EOL}Actual side effects:$EOL$diff"))
+            ctx
+
+          case (ctx, Parameters(ps, _)) =>
+            ctx.copy(parameters = ps)
+
+          case (ctx, Dummy(_)) => ctx
+          case (_, s) =>
+            throw new UnsupportedOperationException(s"Unsupported step: $s")
         }
-        ctx
-
-      case (ctx, e @ ExpectError(errorType, phase, detail)) =>
-        ctx.lastResult match {
-          case Left(error) =>
-            if (error.errorType != errorType)
-              throw ScenarioFailedException(s"Wrong error type: expected $errorType, got ${error.errorType}")
-            if (error.phase != phase)
-              throw ScenarioFailedException(s"Wrong error phase: expected $phase, got ${error.phase}")
-            if (error.detail != detail)
-              throw ScenarioFailedException(s"Wrong error detail: expected $detail, got ${error.detail}")
-
-          case Right(records) =>
-            throw ScenarioFailedException(s"Expected: $e, got records $records")
-        }
-
-        ctx
-
-      case (ctx, SideEffects(expected)) =>
-        val before = ctx.state
-        val after = ctx.measure.state
-        val diff = before diff after
-        if (diff != expected)
-          throw ScenarioFailedException(
-            s"${EOL}Expected side effects:$EOL$expected${EOL}Actual side effects:$EOL$diff")
-        ctx
-
-      case (ctx, Parameters(ps)) =>
-        ctx.copy(parameters = ps)
-
-      case (_, step) =>
-        throw new UnsupportedOperationException(s"Unsupported step: $step")
+        setStepFinished(StepFinished(step, result.lastResult, exception, eventId))
+        exception.foreach(throw _)
+        result
+      }
     }
   }
 
@@ -150,5 +168,6 @@ case class Scenario(featureName: String, name: String, tags: Set[String], steps:
     }
   }
 
-  case class ScenarioFailedException(msg: String, cause: Throwable = null) extends Throwable(s"$self failed with message: $msg", cause)
+  case class ScenarioFailedException(msg: String, cause: Throwable = null)
+      extends Throwable(s"$self failed with message: $msg", cause)
 }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
@@ -30,10 +30,9 @@ package org.opencypher.tools.tck.api.events
 import java.util.UUID
 
 import org.opencypher.tools.tck.api.Graph.Result
-import org.opencypher.tools.tck.api.{Feature, Scenario, Step}
+import org.opencypher.tools.tck.api.{Scenario, Step}
 
 import scala.collection.mutable
-import scala.collection.mutable.Publisher
 
 /** Publishes TCK scenario execution events.
   *
@@ -55,12 +54,13 @@ object TCKEvents {
     val correlationId: String
   }
 
+  type StepResult = Either[Throwable, Result]
+
   case class StepStarted(step: Step) extends CorrelationId {
     override val correlationId: String = UUID.randomUUID().toString
   }
 
-  case class StepFinished(step: Step, result: Result, exception: Option[Throwable] = None, correlationId: String)
-      extends CorrelationId
+  case class StepFinished(step: Step, result: StepResult, correlationId: String) extends CorrelationId
 
   case class FeatureRead(name: String, uri: String, source: String)
 

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.api.events
+
+import java.util.UUID
+
+import org.opencypher.tools.tck.api.Graph.Result
+import org.opencypher.tools.tck.api.{Feature, Scenario, Step}
+
+import scala.collection.mutable
+import scala.collection.mutable.Publisher
+
+/** Publishes TCK scenario execution events.
+  *
+  * The available event sources are:
+  *
+  * <li>[[TCKEvents.feature]] - sent for each feature file read, contains the feature file source.
+  * <li>[[TCKEvents.scenario]]  - sent before starting the execution of a Scenario.
+  * <li>[[TCKEvents.stepStarted]] - sent before starting the execution of a Test Step, contains the Test Step.
+  * <li>[[TCKEvents.stepFinished]] - sent after the execution of a Test Step, contains the Test Step and its Result.
+  * <p>
+  * Usage example, subscribing to [[TCKEvents.scenario]] events:
+  * <pre>{@code
+  * TCKEvents.scenario.subscribe(scenario => { println scenario.name })
+  * }</pre>
+  */
+object TCKEvents {
+
+  trait CorrelationId {
+    val correlationId: String
+  }
+
+  case class StepStarted(step: Step) extends CorrelationId {
+    override val correlationId: String = UUID.randomUUID().toString
+  }
+
+  case class StepFinished(step: Step, result: Result, exception: Option[Throwable] = None, correlationId: String)
+      extends CorrelationId
+
+  case class FeatureRead(name: String, uri: String, source: String)
+
+  object Publish {
+    def apply[T](): Publish[T] = new Publish[T]
+  }
+
+  class Publish[T] extends mutable.Publisher[T] {
+    def send(event: T): Unit = publish(event)
+    def subscribe(callback: T => Unit): Unit = {
+      subscribe(new mutable.Subscriber[T, mutable.Publisher[T]] {
+        override def notify(pub: mutable.Publisher[T], event: T): Unit = {
+          callback(event)
+        }
+      })
+    }
+  }
+
+  val feature: Publish[FeatureRead] = Publish[FeatureRead]()
+  val scenario: Publish[Scenario] = Publish[Scenario]()
+  val stepStarted: Publish[StepStarted] = Publish[StepStarted]()
+  val stepFinished: Publish[StepFinished] = Publish[StepFinished]()
+
+  def setFeature(feature: FeatureRead): Unit = {
+    this.feature.send(feature)
+  }
+
+  def setScenario(scenario: Scenario): Unit = {
+    this.scenario.send(scenario)
+  }
+
+  def setStepStarted(step: StepStarted): String = {
+    this.stepStarted.send(step)
+    step.correlationId
+  }
+
+  def setStepFinished(step: StepFinished): Unit = {
+    this.stepFinished.send(step)
+  }
+}

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.api.events
+
+import java.util
+
+import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.{AfterAll, BeforeAll, DynamicTest, TestFactory}
+import org.opencypher.tools.tck.api.{
+  CypherTCK,
+  CypherValueRecords,
+  ExecQuery,
+  Graph,
+  InitQuery,
+  ProcedureSupport,
+  QueryType,
+  SideEffectQuery,
+  StringRecords
+}
+import org.opencypher.tools.tck.values.CypherValue
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+object TCKEventsTest {
+
+  private val events = ListBuffer[String]()
+
+  @BeforeAll
+  def subscribe(): Unit = {
+    TCKEvents.feature.subscribe(
+      f => { if (f.name == "ReturnAcceptanceTest") { events += s"Feature '${f.name}' read" } })
+    TCKEvents.scenario.subscribe(s => events += s"Scenario '${s.name}' started")
+    TCKEvents.stepStarted.subscribe(s =>
+      events += s"Step '${s.step.getClass.getSimpleName} -> ${s.step.source.getText}' started")
+    TCKEvents.stepFinished.subscribe(s =>
+      events += s"Step '${s.step.getClass.getSimpleName}' finished. Result: ${s.result.right.get.right.get}")
+  }
+
+  @AfterAll
+  def assertEvents(): Unit = {
+    val expected = List[String](
+      "Feature 'ReturnAcceptanceTest' read",
+      "Scenario 'Return collection size' started",
+      "Step 'Execute -> any graph' started",
+      "Step 'Execute' finished. Result: <empty result>",
+      "Step 'Measure -> executing query:' started",
+      "Step 'Measure' finished. Result: <empty result>",
+      "Step 'Execute -> executing query:' started",
+      "Step 'Execute' finished. Result: | n |\n| 3 |",
+      "Step 'ExpectResult -> the result should be:' started",
+      "Step 'ExpectResult' finished. Result: | n |\n| 3 |",
+      "Step 'SideEffects -> no side effects' started",
+      "Step 'SideEffects' finished. Result: | n |\n| 3 |"
+    )
+    assertIterableEquals(expected.asJava, events.asJava)
+  }
+}
+
+class TCKEventsTest {
+
+  @TestFactory
+  def testSingleScenario(): util.Collection[DynamicTest] = {
+    val scenarios = CypherTCK.allTckScenarios.filter(s => s.name == "Return collection size")
+
+    def createTestGraph(): Graph = FakeGraph
+
+    val dynamicTests = scenarios.map { scenario =>
+      val name = scenario.toString()
+      val executable = scenario(createTestGraph())
+      DynamicTest.dynamicTest(name, executable)
+    }
+    dynamicTests.asJavaCollection
+  }
+
+  private object FakeGraph extends Graph with ProcedureSupport {
+    override def cypher(query: String, params: Map[String, CypherValue], queryType: QueryType): Result = {
+      queryType match {
+        case InitQuery =>
+          CypherValueRecords.empty
+        case SideEffectQuery =>
+          CypherValueRecords.empty
+        case ExecQuery =>
+          StringRecords(List("n"), List(Map("n" -> "3")))
+      }
+    }
+    override def registerProcedure(signature: String, values: CypherValueRecords): Unit =
+      ()
+  }
+}


### PR DESCRIPTION
This change extends TCK tools Scala API with scenario execution events model. Extension makes possible to integrate external test reports (such as Cucumber report) via event listener. The model includes scenario steps that enables more detailed report to be created comparing to the current JUnit 5 report, that only shows results at scenario level.