### PR TITLE
List Operations TCK

### DIFF
--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -126,7 +126,7 @@ Feature: ExpressionAcceptance
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
 
-  Scenario: Fail at runtime when trying to index something which is not a map or collection
+  Scenario: Fail at runtime when trying to index something which is not a map or list
     And parameters are:
       | expr | 100 |
       | idx  | 0   |

--- a/tck/features/ExpressionAcceptance.feature
+++ b/tck/features/ExpressionAcceptance.feature
@@ -33,58 +33,6 @@ Feature: ExpressionAcceptance
   Background:
     Given any graph
 
-  Scenario: IN should work with nested list subscripting
-    When executing query:
-      """
-      WITH [[1, 2, 3]] AS list
-      RETURN 3 IN list[0] AS r
-      """
-    Then the result should be:
-      | r    |
-      | true |
-    And no side effects
-
-  Scenario: IN should work with nested literal list subscripting
-    When executing query:
-      """
-      RETURN 3 IN [[1, 2, 3]][0] AS r
-      """
-    Then the result should be:
-      | r    |
-      | true |
-    And no side effects
-
-  Scenario: IN should work with list slices
-    When executing query:
-      """
-      WITH [1, 2, 3] AS list
-      RETURN 3 IN list[0..1] AS r
-      """
-    Then the result should be:
-      | r     |
-      | false |
-    And no side effects
-
-  Scenario: IN should work with literal list slices
-    When executing query:
-      """
-      RETURN 3 IN [1, 2, 3][0..1] AS r
-      """
-    Then the result should be:
-      | r     |
-      | false |
-    And no side effects
-
-  Scenario: Execute n[0]
-    When executing query:
-      """
-      RETURN [1, 2, 3][0] AS value
-      """
-    Then the result should be:
-      | value |
-      | 1     |
-    And no side effects
-
   Scenario: Execute n['name'] in read queries
     And having executed:
       """
@@ -156,47 +104,6 @@ Feature: ExpressionAcceptance
       | 'Apa' |
     And no side effects
 
-  Scenario: Use collection lookup based on parameters when there is no type information
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | 0       |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx] AS value
-      """
-    Then the result should be:
-      | value |
-      | 'Apa' |
-    And no side effects
-
-  Scenario: Use collection lookup based on parameters when there is lhs type information
-    And parameters are:
-      | idx | 0 |
-    When executing query:
-      """
-      WITH ['Apa'] AS expr
-      RETURN expr[$idx] AS value
-      """
-    Then the result should be:
-      | value |
-      | 'Apa' |
-    And no side effects
-
-  Scenario: Use collection lookup based on parameters when there is rhs type information
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | 0       |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[toInteger(idx)] AS value
-      """
-    Then the result should be:
-      | value |
-      | 'Apa' |
-    And no side effects
-
   Scenario: Fail at runtime when attempting to index with an Int into a Map
     And parameters are:
       | expr | {name: 'Apa'} |
@@ -218,36 +125,6 @@ Feature: ExpressionAcceptance
       RETURN expr[idx]
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
-
-  Scenario: Fail at runtime when attempting to index with a String into a Collection
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | 'name'  |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx]
-      """
-    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
-
-  Scenario: Fail at runtime when trying to index into a list with a list
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | ['Apa'] |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx]
-      """
-    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
-
-  Scenario: Fail at compile time when attempting to index with a non-integer into a list
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5] AS list, 3.14 AS idx
-      RETURN list[idx]
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
   Scenario: Fail at runtime when trying to index something which is not a map or collection
     And parameters are:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -123,7 +123,7 @@ Feature: ListOperations
       RETURN [1] IN [1, 2, [1]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -133,7 +133,7 @@ Feature: ListOperations
       RETURN [1, 2] IN [1, [1, 2]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -173,7 +173,7 @@ Feature: ListOperations
       RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4]]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -183,7 +183,7 @@ Feature: ListOperations
       RETURN [[1, 2], 3] IN [1, [[1, 2], 3]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -193,7 +193,7 @@ Feature: ListOperations
       RETURN [[1]] IN [2, [[1]]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -203,7 +203,7 @@ Feature: ListOperations
       RETURN [[1, 3]] IN [2, [[1, 3]]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -229,24 +229,24 @@ Feature: ListOperations
 
   # IN operator - null
 
-  Scenario: IN should return null if LHS and RHS null
+  Scenario: IN should return null if LHS and RHS are null
     When executing query:
       """
       RETURN null IN [null] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
-  Scenario: IN should return null if LHS and RHS null - list version
+  Scenario: IN should return null if LHS and RHS are null - list version
     When executing query:
       """
       RETURN [null] IN [[null]] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: IN should return null when LHS and RHS both ultimately contain null, even if LHS and RHS are of different types (nested list and flat list)
@@ -255,8 +255,8 @@ Feature: ListOperations
       RETURN [null] IN [null] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: IN with different length lists should return false despite nulls
@@ -275,7 +275,7 @@ Feature: ListOperations
       RETURN 3 IN [1, null, 3] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -285,7 +285,7 @@ Feature: ListOperations
       RETURN 4 IN [1, null, 3] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | null |
     And no side effects
 
@@ -295,7 +295,7 @@ Feature: ListOperations
       RETURN [1, 2] IN [[null, 'foo'], [1, 2]] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -305,7 +305,7 @@ Feature: ListOperations
       RETURN [1, 2] IN [1, [1, 2], null] AS res
       """
     Then the result should be:
-      | res   |
+      | res  |
       | true |
     And no side effects
 
@@ -325,8 +325,8 @@ Feature: ListOperations
       RETURN [1, 2] IN [[null, 2]] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: IN should return false if different length lists compared, even if the extra element is null
@@ -336,7 +336,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: IN should return null when comparing two so-called identical lists where one element is null
@@ -345,8 +345,8 @@ Feature: ListOperations
       RETURN [1, 2, null] IN [1, [1, 2, null]] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: IN should return true with previous null match, list version
@@ -355,8 +355,8 @@ Feature: ListOperations
       RETURN [1, 2] IN [[null, 2], [1, 2]] AS res
       """
     Then the result should be:
-      | res   |
-      | true  |
+      | res  |
+      | true |
     And no side effects
 
   Scenario: IN should return false if different length lists with nested elements compared, even if the extra element is null
@@ -366,7 +366,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: IN should return null if comparison with null is required, list version 2
@@ -375,8 +375,8 @@ Feature: ListOperations
       RETURN [1, 2] IN [[null, 2], [1, 3]] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   # IN operator - empty list
@@ -387,8 +387,8 @@ Feature: ListOperations
       RETURN [] IN [[]] AS res
       """
     Then the result should be:
-      | res   |
-      | true  |
+      | res  |
+      | true |
     And no side effects
 
   Scenario: IN should return false for the empty list if the LHS and RHS types differ
@@ -398,7 +398,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: IN should work with an empty list in the presence of other list elements: matching
@@ -407,8 +407,8 @@ Feature: ListOperations
       RETURN [] IN [1, []] AS res
       """
     Then the result should be:
-      | res   |
-      | true  |
+      | res  |
+      | true |
     And no side effects
 
   Scenario: IN should work with an empty list in the presence of other list elements: not matching
@@ -418,7 +418,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: IN should work with an empty list when comparing nested lists
@@ -427,8 +427,8 @@ Feature: ListOperations
       RETURN [[]] IN [1, [[]]] AS res
       """
     Then the result should be:
-      | res   |
-      | true  |
+      | res  |
+      | true |
     And no side effects
 
   Scenario: IN should return null if comparison with null is required for empty list
@@ -437,8 +437,8 @@ Feature: ListOperations
       RETURN [] IN [1, 2, null] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: IN should return true when LHS and RHS contain nested list with multiple empty lists
@@ -447,9 +447,10 @@ Feature: ListOperations
       RETURN [[], []] IN [1, [[], []]] AS res
       """
     Then the result should be:
-      | res   |
-      | true  |
+      | res  |
+      | true |
     And no side effects
+
   # Equality
 
   Scenario: Equality between list and literal should return false
@@ -459,7 +460,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: Equality of lists of different length should return false despite nulls
@@ -469,7 +470,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: Equality between different lists with null should return false
@@ -479,7 +480,7 @@ Feature: ListOperations
       """
     Then the result should be:
       | res   |
-      | false  |
+      | false |
     And no side effects
 
   Scenario: Equality between almost equal lists with null should return null
@@ -488,8 +489,8 @@ Feature: ListOperations
       RETURN [1, 2] = [null, 2] AS res
       """
     Then the result should be:
-      | res   |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   Scenario: Equality of nested lists of different length should return false despite nulls
@@ -498,8 +499,8 @@ Feature: ListOperations
       RETURN [[1]] = [[1], [null]] AS res
       """
     Then the result should be:
-      | res    |
-      | false  |
+      | res   |
+      | false |
     And no side effects
 
   Scenario: Equality between different nested lists with null should return false
@@ -508,8 +509,8 @@ Feature: ListOperations
       RETURN [[1, 2], [1, 3]] = [[1, 2], [null, 'foo']] AS res
       """
     Then the result should be:
-      | res    |
-      | false  |
+      | res   |
+      | false |
     And no side effects
 
   Scenario: Equality between almost equal nested lists with null should return null
@@ -518,8 +519,8 @@ Feature: ListOperations
       RETURN [[1, 2], ['foo', 'bar']] = [[1, 2], [null, 'bar']] AS res
       """
     Then the result should be:
-      | res    |
-      | null  |
+      | res  |
+      | null |
     And no side effects
 
   # General
@@ -535,6 +536,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Setting and returning the size of a list property
+    Given an empty graph
     And having executed:
       """
       CREATE (:Label)
@@ -562,6 +564,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Returning nested expressions based on list property
+    Given an empty graph
     And having executed:
       """
       CREATE (:Label)
@@ -577,6 +580,16 @@ Feature: ListOperations
       | [3, 4, 5]           |
     And the side effects should be:
       | +properties | 1 |
+
+  Scenario: Indexing into literal list
+    When executing query:
+      """
+      RETURN [1, 2, 3][0] AS value
+      """
+    Then the result should be:
+      | value |
+      | 1     |
+    And no side effects
 
   Scenario: Indexing into nested literal lists
     When executing query:
@@ -598,7 +611,7 @@ Feature: ListOperations
       | [1, 10, 100, 4, 5] |
     And no side effects
 
-  Scenario: Appending lists of same type
+  Scenario: Concatenating lists of same type
     When executing query:
       """
       RETURN [false, true] + false AS foo
@@ -608,17 +621,8 @@ Feature: ListOperations
       | [false, true, false] |
     And no side effects
 
-  Scenario: Execute n[0]
-    When executing query:
-      """
-      RETURN [1, 2, 3][0] AS value
-      """
-    Then the result should be:
-      | value |
-      | 1     |
-    And no side effects
-
-  Scenario: Extract eagerly
+  Scenario: Collect and extract using a list comprehension
+    Given an empty graph
     And having executed:
       """
       CREATE (:Label1 {name: 'original'})
@@ -627,19 +631,20 @@ Feature: ListOperations
       """
       MATCH (a:Label1)
       WITH collect(a) AS nodes
-      WITH nodes, extract(x IN nodes | x.name) AS oldNames
+      WITH nodes, [x IN nodes | x.name] AS oldNames
       UNWIND nodes AS n
       SET n.name = 'newName'
       RETURN n.name, oldNames
       """
     Then the result should be:
-      | n.name    | oldNames   |
+      | n.name    | oldNames     |
       | 'newName' | ['original'] |
     And the side effects should be:
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: Filter eagerly
+  Scenario: Collect and filter using a list comprehension
+    Given an empty graph
     And having executed:
       """
       CREATE (:Label1 {name: 'original'})
@@ -648,24 +653,25 @@ Feature: ListOperations
       """
       MATCH (a:Label1)
       WITH collect(a) AS nodes
-      WITH nodes, filter(x IN nodes WHERE x.name = 'original') AS noopFiltered
+      WITH nodes, [x IN nodes WHERE x.name = 'original'] AS noopFiltered
       UNWIND nodes AS n
       SET n.name = 'newName'
       RETURN n.name, length(noopFiltered)
       """
     Then the result should be:
-      | n.name    | length(noopFiltered)   |
-      | 'newName' | 1                      |
+      | n.name    | length(noopFiltered) |
+      | 'newName' | 1                    |
     And the side effects should be:
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: Length on filter
+  Scenario: Size of list comprehension
+    Given an empty graph
     When executing query:
       """
       MATCH (n)
       OPTIONAL MATCH (n)-[r]->(m)
-      RETURN length(filter(x IN collect(r) WHERE x <> null)) AS cn
+      RETURN size([x IN collect(r) WHERE x <> null]) AS cn
       """
     Then the result should be:
       | cn |

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -187,6 +187,36 @@ Feature: ListOperations
       | true |
     And no side effects
 
+  Scenario: IN should return null if LHS and RHS null
+    When executing query:
+      """
+      RETURN null IN [null] AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  Scenario: IN should return null if LHS and RHS null - list version
+    When executing query:
+      """
+      RETURN [null] IN [[null]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  Scenario: IN should return null when LHS and RHS both ultimately contain null, even if LHS and RHS are of different types (nested list and flat list)
+    When executing query:
+      """
+      RETURN [null] IN [null] AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
   Scenario: IN with different length lists should return false despite nulls
     When executing query:
       """
@@ -227,7 +257,15 @@ Feature: ListOperations
       | true |
     And no side effects
 
-    #a
+  Scenario: IN should return true if correct list found despite null being another element within containing list
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [1, 2], null] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
 
   Scenario: IN should return false if no match can be found, despite nulls
     When executing query:
@@ -249,7 +287,25 @@ Feature: ListOperations
       | null  |
     And no side effects
 
-    #b
+  Scenario: IN should return false if different length lists compared, even if the extra element is null
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [1, 2, null]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: IN should return null when comparing two so-called identical lists where one element is null
+    When executing query:
+      """
+      RETURN [1, 2, null] IN [1, [1, 2, null]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
 
   Scenario: IN should return true with previous null match, list version
     When executing query:
@@ -261,7 +317,15 @@ Feature: ListOperations
       | true  |
     And no side effects
 
-    #c
+  Scenario: IN should return false if different length lists with nested elements compared, even if the extra element is null
+    When executing query:
+      """
+      RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4], null]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
 
   Scenario: IN should return null if comparison with null is required, list version 2
     When executing query:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -75,6 +75,97 @@ Feature: ListOperations
       | false |
     And no side effects
 
+  Scenario: Return collection size
+    Given any graph
+    When executing query:
+      """
+      RETURN size([1, 2, 3]) AS n
+      """
+    Then the result should be:
+      | n |
+      | 3 |
+    And no side effects
+
+  Scenario: Setting and returning the size of a list property
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n.x = [1, 2, 3]
+      RETURN size(n.x)
+      """
+    Then the result should be:
+      | size(n.x) |
+      | 3         |
+    And the side effects should be:
+      | +properties | 1 |
+
+  Scenario: Concatenating and returning the size of literal lists
+    Given any graph
+    When executing query:
+      """
+      RETURN size([[], []] + [[]]) AS l
+      """
+    Then the result should be:
+      | l |
+      | 3 |
+    And no side effects
+
+  Scenario: Returning nested expressions based on list property
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()
+      """
+    When executing query:
+      """
+      MATCH (n)
+      SET n.array = [1, 2, 3, 4, 5]
+      RETURN tail(tail(n.array))
+      """
+    Then the result should be:
+      | tail(tail(n.array)) |
+      | [3, 4, 5]           |
+    And the side effects should be:
+      | +properties | 1 |
+
+  Scenario: Indexing into nested literal lists
+    Given any graph
+    When executing query:
+      """
+      RETURN [[1]][0][0]
+      """
+    Then the result should be:
+      | [[1]][0][0] |
+      | 1           |
+    And no side effects
+
+  Scenario: Concatenating lists of same type
+    Given any graph
+    When executing query:
+      """
+      RETURN [1, 10, 100] + [4, 5] AS foo
+      """
+    Then the result should be:
+      | foo                |
+      | [1, 10, 100, 4, 5] |
+    And no side effects
+
+  Scenario: Appending lists of same type
+    Given any graph
+    When executing query:
+      """
+      RETURN [false, true] + false AS foo
+      """
+    Then the result should be:
+      | foo                  |
+      | [false, true, false] |
+    And no side effects
+
   Scenario: Execute n[0]
     When executing query:
       """

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -1,0 +1,157 @@
+#
+# Copyright (c) 2015-2018 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: ListOperations
+
+  Background:
+    Given any graph
+
+  Scenario: IN should work with nested list subscripting
+    When executing query:
+      """
+      WITH [[1, 2, 3]] AS list
+      RETURN 3 IN list[0] AS r
+      """
+    Then the result should be:
+      | r    |
+      | true |
+    And no side effects
+
+  Scenario: IN should work with nested literal list subscripting
+    When executing query:
+      """
+      RETURN 3 IN [[1, 2, 3]][0] AS r
+      """
+    Then the result should be:
+      | r    |
+      | true |
+    And no side effects
+
+  Scenario: IN should work with list slices
+    When executing query:
+      """
+      WITH [1, 2, 3] AS list
+      RETURN 3 IN list[0..1] AS r
+      """
+    Then the result should be:
+      | r     |
+      | false |
+    And no side effects
+
+  Scenario: IN should work with literal list slices
+    When executing query:
+      """
+      RETURN 3 IN [1, 2, 3][0..1] AS r
+      """
+    Then the result should be:
+      | r     |
+      | false |
+    And no side effects
+
+  Scenario: Execute n[0]
+    When executing query:
+      """
+      RETURN [1, 2, 3][0] AS value
+      """
+    Then the result should be:
+      | value |
+      | 1     |
+    And no side effects
+
+  Scenario: Use collection lookup based on parameters when there is no type information
+    And parameters are:
+      | expr | ['Apa'] |
+      | idx  | 0       |
+    When executing query:
+      """
+      WITH $expr AS expr, $idx AS idx
+      RETURN expr[idx] AS value
+      """
+    Then the result should be:
+      | value |
+      | 'Apa' |
+    And no side effects
+
+  Scenario: Use collection lookup based on parameters when there is lhs type information
+    And parameters are:
+      | idx | 0 |
+    When executing query:
+      """
+      WITH ['Apa'] AS expr
+      RETURN expr[$idx] AS value
+      """
+    Then the result should be:
+      | value |
+      | 'Apa' |
+    And no side effects
+
+  Scenario: Use collection lookup based on parameters when there is rhs type information
+    And parameters are:
+      | expr | ['Apa'] |
+      | idx  | 0       |
+    When executing query:
+      """
+      WITH $expr AS expr, $idx AS idx
+      RETURN expr[toInteger(idx)] AS value
+      """
+    Then the result should be:
+      | value |
+      | 'Apa' |
+    And no side effects
+
+  Scenario: Fail at runtime when attempting to index with a String into a Collection
+    And parameters are:
+      | expr | ['Apa'] |
+      | idx  | 'name'  |
+    When executing query:
+      """
+      WITH $expr AS expr, $idx AS idx
+      RETURN expr[idx]
+      """
+    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
+
+  Scenario: Fail at runtime when trying to index into a list with a list
+    And parameters are:
+      | expr | ['Apa'] |
+      | idx  | ['Apa'] |
+    When executing query:
+      """
+      WITH $expr AS expr, $idx AS idx
+      RETURN expr[idx]
+      """
+    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
+
+  Scenario: Fail at compile time when attempting to index with a non-integer into a list
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5] AS list, 3.14 AS idx
+      RETURN list[idx]
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -77,6 +77,106 @@ Feature: ListOperations
       | false |
     And no side effects
 
+  Scenario: IN should return false when matching a number with a string
+    When executing query:
+      """
+      RETURN 1 IN ['1', 2] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return false when matching a number with a string - list version
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [1, '2']] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return false when types of LHS and RHS don't match - singleton list
+    When executing query:
+      """
+      RETURN [1] IN [1, 2] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return false when types of LHS and RHS don't match - list
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, 2] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return true when types of LHS and RHS match - singleton list
+    When executing query:
+      """
+      RETURN [1] IN [1, 2, [1]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return true when types of LHS and RHS match - list
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [1, 2]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return false when order of elements in LHS list and RHS list don't match
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [2, 1]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN with different length lists should return false
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [1, 2, 3]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return false when matching a list with a nested list with same elements
+    When executing query:
+      """
+      RETURN [1, 2] IN [1, [[1, 2]]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return true when both LHS and RHS contain nested lists
+    When executing query:
+      """
+      RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4]]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
   Scenario: IN with different length lists should return false despite nulls
     When executing query:
       """

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -33,7 +33,7 @@ Feature: ListOperations
   Background:
     Given any graph
 
-  # IN operator
+  # IN operator - general
 
   Scenario: IN should work with nested list subscripting
     When executing query:
@@ -187,6 +187,8 @@ Feature: ListOperations
       | true |
     And no side effects
 
+  # IN operator - null
+
   Scenario: IN should return null if LHS and RHS null
     When executing query:
       """
@@ -337,6 +339,77 @@ Feature: ListOperations
       | null  |
     And no side effects
 
+  # IN operator - empty list
+
+  Scenario: IN should work with an empty list
+    When executing query:
+      """
+      RETURN [] IN [[]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true  |
+    And no side effects
+
+  Scenario: IN should return false for the empty list if the LHS and RHS types differ
+    When executing query:
+      """
+      RETURN [] IN [] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: IN should work with an empty list in the presence of other list elements: matching
+    When executing query:
+      """
+      RETURN [] IN [1, []] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true  |
+    And no side effects
+
+  Scenario: IN should work with an empty list in the presence of other list elements: not matching
+    When executing query:
+      """
+      RETURN [] IN [1, 2] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: IN should work with an empty list when comparing nested lists
+    When executing query:
+      """
+      RETURN [[]] IN [1, [[]]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true  |
+    And no side effects
+
+  Scenario: IN should return null if comparison with null is required for empty list
+    When executing query:
+      """
+      RETURN [] IN [1, 2, null] AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  Scenario: IN should return true when LHS and RHS contain nested list with multiple empty lists
+    When executing query:
+      """
+      RETURN [[], []] IN [1, [[], []]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true  |
+    And no side effects
   # Equality
 
   Scenario: Equality between list and literal should return false

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -124,7 +124,7 @@ Feature: ListOperations
   Scenario: IN should return false if no match can be found, despite nulls
     When executing query:
       """
-      WITH [1,2] AS l1, [[null, 'foo']] AS l2
+      WITH [1, 2] AS l1, [[null, 'foo']] AS l2
       RETURN l1 IN l2 AS res
       """
     Then the result should be:
@@ -135,7 +135,7 @@ Feature: ListOperations
   Scenario: IN should return null if comparison with null is required, list version
     When executing query:
       """
-      WITH [1,2] AS l1, [[null, 2]] AS l2
+      WITH [1, 2] AS l1, [[null, 2]] AS l2
       RETURN l1 IN l2 AS res
       """
     Then the result should be:
@@ -146,7 +146,7 @@ Feature: ListOperations
   Scenario: IN should return true with previous null match, list version
     When executing query:
       """
-      WITH [1,2] AS l1, [[null, 2], [1, 2]] AS l2
+      WITH [1, 2] AS l1, [[null, 2], [1, 2]] AS l2
       RETURN l1 IN l2 AS res
       """
     Then the result should be:
@@ -157,7 +157,7 @@ Feature: ListOperations
   Scenario: IN should return null if comparison with null is required, list version 2
     When executing query:
       """
-      WITH [1,2] AS l1, [[null, 2], [1, 3]] AS l2
+      WITH [1, 2] AS l1, [[null, 2], [1, 3]] AS l2
       RETURN l1 IN l2 AS res
       """
     Then the result should be:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -33,6 +33,8 @@ Feature: ListOperations
   Background:
     Given any graph
 
+  # IN operator
+
   Scenario: IN should work with nested list subscripting
     When executing query:
       """
@@ -74,6 +76,175 @@ Feature: ListOperations
       | r     |
       | false |
     And no side effects
+
+  Scenario: IN with different length lists should return false despite nulls
+    When executing query:
+      """
+      WITH [1] AS l1, [1, null] AS l2
+      RETURN l1 IN [l2] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return true if match despite nulls
+    When executing query:
+      """
+      WITH 3 AS l1, [1, null, 3] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return null if comparison with null is required
+    When executing query:
+      """
+      WITH 4 AS l1, [1, null, 3] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | null |
+    And no side effects
+
+  Scenario: IN should return true if correct list found despite other lists having nulls
+    When executing query:
+      """
+      WITH [1, 2] AS l1, [[null, 'foo'], [1, 2]] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return false if no match can be found, despite nulls
+    When executing query:
+      """
+      WITH [1,2] AS l1, [[null, 'foo']] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return null if comparison with null is required, list version
+    When executing query:
+      """
+      WITH [1,2] AS l1, [[null, 2]] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  Scenario: IN should return true with previous null match, list version
+    When executing query:
+      """
+      WITH [1,2] AS l1, [[null, 2], [1, 2]] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | true  |
+    And no side effects
+
+  Scenario: IN should return null if comparison with null is required, list version 2
+    When executing query:
+      """
+      WITH [1,2] AS l1, [[null, 2], [1, 3]] AS l2
+      RETURN l1 IN l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  # Equality
+
+  Scenario: Equality between list and literal should return false
+    When executing query:
+      """
+      WITH [1, 2] AS l1, 'foo' AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: Equality of lists of different length should return false despite nulls
+    When executing query:
+      """
+      WITH [1] AS l1, [1, null] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: Equality between different lists with null should return false
+    When executing query:
+      """
+      WITH [1, 2] AS l1, [null, 'foo'] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | false  |
+    And no side effects
+
+  Scenario: Equality between almost equal lists with null should return null
+    When executing query:
+      """
+      WITH [1, 2] AS l1, [null, 2] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res   |
+      | null  |
+    And no side effects
+
+  Scenario: Equality of nested lists of different length should return false despite nulls
+    When executing query:
+      """
+      WITH [[1]] AS l1, [[1], [null]] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res    |
+      | false  |
+    And no side effects
+
+  Scenario: Equality between different nested lists with null should return false
+    When executing query:
+      """
+      WITH [[1, 2], [1, 3]] AS l1, [[1, 2], [null, 'foo']] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res    |
+      | false  |
+    And no side effects
+
+  Scenario: Equality between almost equal nested lists with null should return null
+    When executing query:
+      """
+      WITH [[1, 2], ['foo', 'bar']] AS l1, [[1, 2], [null, 'bar']] AS l2
+      RETURN l1 = l2 AS res
+      """
+    Then the result should be:
+      | res    |
+      | null  |
+    And no side effects
+
+  # General
 
   Scenario: Return list size
     When executing query:
@@ -223,6 +394,8 @@ Feature: ListOperations
       | 0  |
     And no side effects
 
+  # List lookup based on parameters
+
   Scenario: Use list lookup based on parameters when there is no type information
     And parameters are:
       | expr | ['Apa'] |
@@ -263,6 +436,8 @@ Feature: ListOperations
       | value |
       | 'Apa' |
     And no side effects
+
+  # Failures at runtime
 
   Scenario: Fail at runtime when attempting to index with a String into a List
     And parameters are:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -30,12 +30,10 @@
 
 Feature: ListOperations
 
-  Background:
-    Given any graph
-
   # IN operator - general
 
   Scenario: IN should work with nested list subscripting
+    Given any graph
     When executing query:
       """
       WITH [[1, 2, 3]] AS list
@@ -47,6 +45,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with nested literal list subscripting
+    Given any graph
     When executing query:
       """
       RETURN 3 IN [[1, 2, 3]][0] AS r
@@ -57,6 +56,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with list slices
+    Given any graph
     When executing query:
       """
       WITH [1, 2, 3] AS list
@@ -68,6 +68,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with literal list slices
+    Given any graph
     When executing query:
       """
       RETURN 3 IN [1, 2, 3][0..1] AS r
@@ -78,6 +79,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when matching a number with a string
+    Given any graph
     When executing query:
       """
       RETURN 1 IN ['1', 2] AS res
@@ -88,6 +90,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when matching a number with a string - list version
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [1, '2']] AS res
@@ -98,6 +101,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when types of LHS and RHS don't match - singleton list
+    Given any graph
     When executing query:
       """
       RETURN [1] IN [1, 2] AS res
@@ -108,6 +112,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when types of LHS and RHS don't match - list
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, 2] AS res
@@ -118,6 +123,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when types of LHS and RHS match - singleton list
+    Given any graph
     When executing query:
       """
       RETURN [1] IN [1, 2, [1]] AS res
@@ -128,6 +134,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when types of LHS and RHS match - list
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [1, 2]] AS res
@@ -138,6 +145,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when order of elements in LHS list and RHS list don't match
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [2, 1]] AS res
@@ -148,6 +156,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN with different length lists should return false
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [1, 2, 3]] AS res
@@ -158,6 +167,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when matching a list with a nested list with same elements
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [[1, 2]]] AS res
@@ -168,6 +178,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when both LHS and RHS contain nested lists
+    Given any graph
     When executing query:
       """
       RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4]]] AS res
@@ -178,6 +189,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when both LHS and RHS contain a nested list alongside a scalar element
+    Given any graph
     When executing query:
       """
       RETURN [[1, 2], 3] IN [1, [[1, 2], 3]] AS res
@@ -188,6 +200,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when LHS and RHS contain a nested list - singleton version
+    Given any graph
     When executing query:
       """
       RETURN [[1]] IN [2, [[1]]] AS res
@@ -198,6 +211,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when LHS and RHS contain a nested list
+    Given any graph
     When executing query:
       """
       RETURN [[1, 3]] IN [2, [[1, 3]]] AS res
@@ -208,6 +222,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when LHS contains a nested list and type mismatch on RHS - singleton version
+    Given any graph
     When executing query:
       """
       RETURN [[1]] IN [2, [1]] AS res
@@ -218,6 +233,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false when LHS contains a nested list and type mismatch on RHS
+    Given any graph
     When executing query:
       """
       RETURN [[1, 3]] IN [2, [1, 3]] AS res
@@ -230,6 +246,7 @@ Feature: ListOperations
   # IN operator - null
 
   Scenario: IN should return null if LHS and RHS are null
+    Given any graph
     When executing query:
       """
       RETURN null IN [null] AS res
@@ -240,6 +257,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null if LHS and RHS are null - list version
+    Given any graph
     When executing query:
       """
       RETURN [null] IN [[null]] AS res
@@ -250,6 +268,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null when LHS and RHS both ultimately contain null, even if LHS and RHS are of different types (nested list and flat list)
+    Given any graph
     When executing query:
       """
       RETURN [null] IN [null] AS res
@@ -260,6 +279,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN with different length lists should return false despite nulls
+    Given any graph
     When executing query:
       """
       RETURN [1] IN [[1, null]] AS res
@@ -270,6 +290,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true if match despite nulls
+    Given any graph
     When executing query:
       """
       RETURN 3 IN [1, null, 3] AS res
@@ -280,6 +301,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null if comparison with null is required
+    Given any graph
     When executing query:
       """
       RETURN 4 IN [1, null, 3] AS res
@@ -290,6 +312,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true if correct list found despite other lists having nulls
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [[null, 'foo'], [1, 2]] AS res
@@ -300,6 +323,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true if correct list found despite null being another element within containing list
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [1, 2], null] AS res
@@ -310,6 +334,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false if no match can be found, despite nulls
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [[null, 'foo']] AS res
@@ -320,6 +345,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null if comparison with null is required, list version
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [[null, 2]] AS res
@@ -330,6 +356,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false if different length lists compared, even if the extra element is null
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [1, [1, 2, null]] AS res
@@ -340,6 +367,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null when comparing two so-called identical lists where one element is null
+    Given any graph
     When executing query:
       """
       RETURN [1, 2, null] IN [1, [1, 2, null]] AS res
@@ -350,6 +378,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true with previous null match, list version
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [[null, 2], [1, 2]] AS res
@@ -360,6 +389,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false if different length lists with nested elements compared, even if the extra element is null
+    Given any graph
     When executing query:
       """
       RETURN [[1, 2], [3, 4]] IN [5, [[1, 2], [3, 4], null]] AS res
@@ -370,6 +400,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null if comparison with null is required, list version 2
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] IN [[null, 2], [1, 3]] AS res
@@ -382,6 +413,7 @@ Feature: ListOperations
   # IN operator - empty list
 
   Scenario: IN should work with an empty list
+    Given any graph
     When executing query:
       """
       RETURN [] IN [[]] AS res
@@ -392,6 +424,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return false for the empty list if the LHS and RHS types differ
+    Given any graph
     When executing query:
       """
       RETURN [] IN [] AS res
@@ -402,6 +435,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with an empty list in the presence of other list elements: matching
+    Given any graph
     When executing query:
       """
       RETURN [] IN [1, []] AS res
@@ -412,6 +446,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with an empty list in the presence of other list elements: not matching
+    Given any graph
     When executing query:
       """
       RETURN [] IN [1, 2] AS res
@@ -422,6 +457,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should work with an empty list when comparing nested lists
+    Given any graph
     When executing query:
       """
       RETURN [[]] IN [1, [[]]] AS res
@@ -432,6 +468,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return null if comparison with null is required for empty list
+    Given any graph
     When executing query:
       """
       RETURN [] IN [1, 2, null] AS res
@@ -442,6 +479,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: IN should return true when LHS and RHS contain nested list with multiple empty lists
+    Given any graph
     When executing query:
       """
       RETURN [[], []] IN [1, [[], []]] AS res
@@ -454,6 +492,7 @@ Feature: ListOperations
   # Equality
 
   Scenario: Equality between list and literal should return false
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] = 'foo' AS res
@@ -464,6 +503,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality of lists of different length should return false despite nulls
+    Given any graph
     When executing query:
       """
       RETURN [1] = [1, null] AS res
@@ -474,6 +514,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality between different lists with null should return false
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] = [null, 'foo'] AS res
@@ -484,6 +525,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality between almost equal lists with null should return null
+    Given any graph
     When executing query:
       """
       RETURN [1, 2] = [null, 2] AS res
@@ -494,6 +536,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality of nested lists of different length should return false despite nulls
+    Given any graph
     When executing query:
       """
       RETURN [[1]] = [[1], [null]] AS res
@@ -504,6 +547,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality between different nested lists with null should return false
+    Given any graph
     When executing query:
       """
       RETURN [[1, 2], [1, 3]] = [[1, 2], [null, 'foo']] AS res
@@ -514,6 +558,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Equality between almost equal nested lists with null should return null
+    Given any graph
     When executing query:
       """
       RETURN [[1, 2], ['foo', 'bar']] = [[1, 2], [null, 'bar']] AS res
@@ -526,6 +571,7 @@ Feature: ListOperations
   # General
 
   Scenario: Return list size
+    Given any graph
     When executing query:
       """
       RETURN size([1, 2, 3]) AS n
@@ -554,6 +600,7 @@ Feature: ListOperations
       | +properties | 1 |
 
   Scenario: Concatenating and returning the size of literal lists
+    Given any graph
     When executing query:
       """
       RETURN size([[], []] + [[]]) AS l
@@ -582,6 +629,7 @@ Feature: ListOperations
       | +properties | 1 |
 
   Scenario: Indexing into literal list
+    Given any graph
     When executing query:
       """
       RETURN [1, 2, 3][0] AS value
@@ -592,6 +640,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Indexing into nested literal lists
+    Given any graph
     When executing query:
       """
       RETURN [[1]][0][0]
@@ -602,6 +651,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Concatenating lists of same type
+    Given any graph
     When executing query:
       """
       RETURN [1, 10, 100] + [4, 5] AS foo
@@ -612,6 +662,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Concatenating lists of same type
+    Given any graph
     When executing query:
       """
       RETURN [false, true] + false AS foo
@@ -681,6 +732,7 @@ Feature: ListOperations
   # List lookup based on parameters
 
   Scenario: Use list lookup based on parameters when there is no type information
+    Given any graph
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
@@ -695,6 +747,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Use list lookup based on parameters when there is lhs type information
+    Given any graph
     And parameters are:
       | idx | 0 |
     When executing query:
@@ -708,6 +761,7 @@ Feature: ListOperations
     And no side effects
 
   Scenario: Use list lookup based on parameters when there is rhs type information
+    Given any graph
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
@@ -724,6 +778,7 @@ Feature: ListOperations
   # Failures at runtime
 
   Scenario: Fail at runtime when attempting to index with a String into a List
+    Given any graph
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 'name'  |
@@ -735,6 +790,7 @@ Feature: ListOperations
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
 
   Scenario: Fail at runtime when trying to index into a list with a list
+    Given any graph
     And parameters are:
       | expr | ['Apa'] |
       | idx  | ['Apa'] |
@@ -746,6 +802,7 @@ Feature: ListOperations
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
 
   Scenario: Fail at compile time when attempting to index with a non-integer into a list
+    Given any graph
     When executing query:
       """
       WITH [1, 2, 3, 4, 5] AS list, 3.14 AS idx

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -177,6 +177,16 @@ Feature: ListOperations
       | true |
     And no side effects
 
+  Scenario: IN should return true when both LHS and RHS contain a nested list alongside a scalar element
+    When executing query:
+      """
+      RETURN [[1, 2], 3] IN [1, [[1, 2], 3]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
   Scenario: IN with different length lists should return false despite nulls
     When executing query:
       """
@@ -217,6 +227,8 @@ Feature: ListOperations
       | true |
     And no side effects
 
+    #a
+
   Scenario: IN should return false if no match can be found, despite nulls
     When executing query:
       """
@@ -237,6 +249,8 @@ Feature: ListOperations
       | null  |
     And no side effects
 
+    #b
+
   Scenario: IN should return true with previous null match, list version
     When executing query:
       """
@@ -246,6 +260,8 @@ Feature: ListOperations
       | res   |
       | true  |
     And no side effects
+
+    #c
 
   Scenario: IN should return null if comparison with null is required, list version 2
     When executing query:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -75,7 +75,7 @@ Feature: ListOperations
       | false |
     And no side effects
 
-  Scenario: Return collection size
+  Scenario: Return list size
     Given any graph
     When executing query:
       """
@@ -176,7 +176,7 @@ Feature: ListOperations
       | 1     |
     And no side effects
 
-  Scenario: Use collection lookup based on parameters when there is no type information
+  Scenario: Use list lookup based on parameters when there is no type information
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
@@ -190,7 +190,7 @@ Feature: ListOperations
       | 'Apa' |
     And no side effects
 
-  Scenario: Use collection lookup based on parameters when there is lhs type information
+  Scenario: Use list lookup based on parameters when there is lhs type information
     And parameters are:
       | idx | 0 |
     When executing query:
@@ -203,7 +203,7 @@ Feature: ListOperations
       | 'Apa' |
     And no side effects
 
-  Scenario: Use collection lookup based on parameters when there is rhs type information
+  Scenario: Use list lookup based on parameters when there is rhs type information
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 0       |
@@ -217,7 +217,7 @@ Feature: ListOperations
       | 'Apa' |
     And no side effects
 
-  Scenario: Fail at runtime when attempting to index with a String into a Collection
+  Scenario: Fail at runtime when attempting to index with a String into a List
     And parameters are:
       | expr | ['Apa'] |
       | idx  | 'name'  |

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -180,8 +180,7 @@ Feature: ListOperations
   Scenario: IN with different length lists should return false despite nulls
     When executing query:
       """
-      WITH [1] AS l1, [1, null] AS l2
-      RETURN l1 IN [l2] AS res
+      RETURN [1] IN [[1, null]] AS res
       """
     Then the result should be:
       | res   |
@@ -191,8 +190,7 @@ Feature: ListOperations
   Scenario: IN should return true if match despite nulls
     When executing query:
       """
-      WITH 3 AS l1, [1, null, 3] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN 3 IN [1, null, 3] AS res
       """
     Then the result should be:
       | res   |
@@ -202,8 +200,7 @@ Feature: ListOperations
   Scenario: IN should return null if comparison with null is required
     When executing query:
       """
-      WITH 4 AS l1, [1, null, 3] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN 4 IN [1, null, 3] AS res
       """
     Then the result should be:
       | res   |
@@ -213,8 +210,7 @@ Feature: ListOperations
   Scenario: IN should return true if correct list found despite other lists having nulls
     When executing query:
       """
-      WITH [1, 2] AS l1, [[null, 'foo'], [1, 2]] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN [1, 2] IN [[null, 'foo'], [1, 2]] AS res
       """
     Then the result should be:
       | res   |
@@ -224,8 +220,7 @@ Feature: ListOperations
   Scenario: IN should return false if no match can be found, despite nulls
     When executing query:
       """
-      WITH [1, 2] AS l1, [[null, 'foo']] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN [1, 2] IN [[null, 'foo']] AS res
       """
     Then the result should be:
       | res   |
@@ -235,8 +230,7 @@ Feature: ListOperations
   Scenario: IN should return null if comparison with null is required, list version
     When executing query:
       """
-      WITH [1, 2] AS l1, [[null, 2]] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN [1, 2] IN [[null, 2]] AS res
       """
     Then the result should be:
       | res   |
@@ -246,8 +240,7 @@ Feature: ListOperations
   Scenario: IN should return true with previous null match, list version
     When executing query:
       """
-      WITH [1, 2] AS l1, [[null, 2], [1, 2]] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN [1, 2] IN [[null, 2], [1, 2]] AS res
       """
     Then the result should be:
       | res   |
@@ -257,8 +250,7 @@ Feature: ListOperations
   Scenario: IN should return null if comparison with null is required, list version 2
     When executing query:
       """
-      WITH [1, 2] AS l1, [[null, 2], [1, 3]] AS l2
-      RETURN l1 IN l2 AS res
+      RETURN [1, 2] IN [[null, 2], [1, 3]] AS res
       """
     Then the result should be:
       | res   |
@@ -270,8 +262,7 @@ Feature: ListOperations
   Scenario: Equality between list and literal should return false
     When executing query:
       """
-      WITH [1, 2] AS l1, 'foo' AS l2
-      RETURN l1 = l2 AS res
+      RETURN [1, 2] = 'foo' AS res
       """
     Then the result should be:
       | res   |
@@ -281,8 +272,7 @@ Feature: ListOperations
   Scenario: Equality of lists of different length should return false despite nulls
     When executing query:
       """
-      WITH [1] AS l1, [1, null] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [1] = [1, null] AS res
       """
     Then the result should be:
       | res   |
@@ -292,8 +282,7 @@ Feature: ListOperations
   Scenario: Equality between different lists with null should return false
     When executing query:
       """
-      WITH [1, 2] AS l1, [null, 'foo'] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [1, 2] = [null, 'foo'] AS res
       """
     Then the result should be:
       | res   |
@@ -303,8 +292,7 @@ Feature: ListOperations
   Scenario: Equality between almost equal lists with null should return null
     When executing query:
       """
-      WITH [1, 2] AS l1, [null, 2] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [1, 2] = [null, 2] AS res
       """
     Then the result should be:
       | res   |
@@ -314,8 +302,7 @@ Feature: ListOperations
   Scenario: Equality of nested lists of different length should return false despite nulls
     When executing query:
       """
-      WITH [[1]] AS l1, [[1], [null]] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [[1]] = [[1], [null]] AS res
       """
     Then the result should be:
       | res    |
@@ -325,8 +312,7 @@ Feature: ListOperations
   Scenario: Equality between different nested lists with null should return false
     When executing query:
       """
-      WITH [[1, 2], [1, 3]] AS l1, [[1, 2], [null, 'foo']] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [[1, 2], [1, 3]] = [[1, 2], [null, 'foo']] AS res
       """
     Then the result should be:
       | res    |
@@ -336,8 +322,7 @@ Feature: ListOperations
   Scenario: Equality between almost equal nested lists with null should return null
     When executing query:
       """
-      WITH [[1, 2], ['foo', 'bar']] AS l1, [[1, 2], [null, 'bar']] AS l2
-      RETURN l1 = l2 AS res
+      RETURN [[1, 2], ['foo', 'bar']] = [[1, 2], [null, 'bar']] AS res
       """
     Then the result should be:
       | res    |

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -187,6 +187,46 @@ Feature: ListOperations
       | true |
     And no side effects
 
+  Scenario: IN should return true when LHS and RHS contain a nested list - singleton version
+    When executing query:
+      """
+      RETURN [[1]] IN [2, [[1]]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return true when LHS and RHS contain a nested list
+    When executing query:
+      """
+      RETURN [[1, 3]] IN [2, [[1, 3]]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | true |
+    And no side effects
+
+  Scenario: IN should return false when LHS contains a nested list and type mismatch on RHS - singleton version
+    When executing query:
+      """
+      RETURN [[1]] IN [2, [1]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
+  Scenario: IN should return false when LHS contains a nested list and type mismatch on RHS
+    When executing query:
+      """
+      RETURN [[1, 3]] IN [2, [1, 3]] AS res
+      """
+    Then the result should be:
+      | res   |
+      | false |
+    And no side effects
+
   # IN operator - null
 
   Scenario: IN should return null if LHS and RHS null

--- a/tck/features/ReturnAcceptance.feature
+++ b/tck/features/ReturnAcceptance.feature
@@ -312,14 +312,3 @@ Feature: ReturnAcceptanceTest
       | abs(-1) |
       | 1       |
     And no side effects
-
-  Scenario: Return collection size
-    Given any graph
-    When executing query:
-      """
-      RETURN size([1, 2, 3]) AS n
-      """
-    Then the result should be:
-      | n |
-      | 3 |
-    And no side effects

--- a/tck/features/ReturnAcceptance2.feature
+++ b/tck/features/ReturnAcceptance2.feature
@@ -181,24 +181,6 @@ Feature: ReturnAcceptance2
       | (:Start) | () | <(:Start)-[:T]->()> |
     And no side effects
 
-  Scenario: Setting and returning the size of a list property
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()
-      """
-    When executing query:
-      """
-      MATCH (n)
-      SET n.x = [1, 2, 3]
-      RETURN size(n.x)
-      """
-    Then the result should be:
-      | size(n.x) |
-      | 3         |
-    And the side effects should be:
-      | +properties | 1 |
-
   Scenario: `sqrt()` returning float values
     Given any graph
     When executing query:
@@ -321,35 +303,6 @@ Feature: ReturnAcceptance2
       | false        | true          |
     And no side effects
 
-  Scenario: Concatenating and returning the size of literal lists
-    Given any graph
-    When executing query:
-      """
-      RETURN size([[], []] + [[]]) AS l
-      """
-    Then the result should be:
-      | l |
-      | 3 |
-    And no side effects
-
-  Scenario: Returning nested expressions based on list property
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()
-      """
-    When executing query:
-      """
-      MATCH (n)
-      SET n.array = [1, 2, 3, 4, 5]
-      RETURN tail(tail(n.array))
-      """
-    Then the result should be:
-      | tail(tail(n.array)) |
-      | [3, 4, 5]           |
-    And the side effects should be:
-      | +properties | 1 |
-
   Scenario: Limiting amount of rows when there are fewer left than the LIMIT argument
     Given an empty graph
     And having executed:
@@ -451,17 +404,6 @@ Feature: ReturnAcceptance2
       | null |
     And no side effects
 
-  Scenario: Indexing into nested literal lists
-    Given any graph
-    When executing query:
-      """
-      RETURN [[1]][0][0]
-      """
-    Then the result should be:
-      | [[1]][0][0] |
-      | 1           |
-    And no side effects
-
   Scenario: Aliasing expressions
     Given an empty graph
     And having executed:
@@ -546,28 +488,6 @@ Feature: ReturnAcceptance2
     Then the result should be, in order:
       | likeTime |
       | 20160614 |
-    And no side effects
-
-  Scenario: Concatenating lists of same type
-    Given any graph
-    When executing query:
-      """
-      RETURN [1, 10, 100] + [4, 5] AS foo
-      """
-    Then the result should be:
-      | foo                |
-      | [1, 10, 100, 4, 5] |
-    And no side effects
-
-  Scenario: Appending lists of same type
-    Given any graph
-    When executing query:
-      """
-      RETURN [false, true] + false AS foo
-      """
-    Then the result should be:
-      | foo                  |
-      | [false, true, false] |
     And no side effects
 
   Scenario: DISTINCT inside aggregation should work with lists in maps

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -29,7 +29,7 @@ package org.opencypher.tools.tck.api.events
 
 import java.util
 
-import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterAll, BeforeAll, DynamicTest, TestFactory}
 import org.opencypher.tools.tck.IdeDetection
 import org.opencypher.tools.tck.api._
@@ -45,7 +45,7 @@ object TCKEventsTest {
   @BeforeAll
   def subscribe(): Unit = {
     TCKEvents.feature.subscribe(
-      f => { if (f.name == "ReturnAcceptanceTest") { events += s"Feature '${f.name}' read" } })
+      f => { if (f.name == "ListOperations") { events += s"Feature '${f.name}' read" } })
     TCKEvents.scenario.subscribe(s => events += s"Scenario '${s.name}' started")
     TCKEvents.stepStarted.subscribe(s =>
       events += s"Step '${s.step.getClass.getSimpleName} -> ${s.step.source.getText}' started")
@@ -56,8 +56,8 @@ object TCKEventsTest {
   @AfterAll
   def assertEvents(): Unit = {
     val expected = List[String](
-      "Feature 'ReturnAcceptanceTest' read",
-      "Scenario 'Return collection size' started",
+      "Feature 'ListOperations' read",
+      "Scenario 'Return list size' started",
       "Step 'Execute -> any graph' started",
       "Step 'Execute' finished. Result: <empty result>",
       "Step 'Measure -> executing query:' started",
@@ -69,7 +69,7 @@ object TCKEventsTest {
       "Step 'SideEffects -> no side effects' started",
       "Step 'SideEffects' finished. Result: | n |\n| 3 |"
     )
-    assertIterableEquals(expected.asJava, events.asJava)
+    assertEquals(expected.asJava, events.toList.asJava, s"${expected.asJava} did not equal ${events.toList.asJava}")
   }
 }
 
@@ -77,7 +77,7 @@ class TCKEventsTest {
 
   @TestFactory
   def testSingleScenario(): util.Collection[DynamicTest] = {
-    val scenarios = IdeDetection.allTckScenarios.filter(s => s.name == "Return collection size")
+    val scenarios = IdeDetection.allTckScenarios.filter(s => s.name == "Return list size")
 
     def createTestGraph(): Graph = FakeGraph
 


### PR DESCRIPTION
@Mats-SX please review and merge when you can. 

The new file `ListOperations` fully subsumes the following two files in the neo4j repo: 

- `NullListAcceptanceTest` 
- `ListExpressionAcceptanceTest`

I will make a note to the Cypher Team that they delete these two files once this PR has been merged and a new milestone created.