### PR TITLE
Moved upload-release script to top level

### DIFF
--- a/upload-release.sh
+++ b/upload-release.sh
@@ -53,5 +53,5 @@ echo "Done!"
 echo "Artifacts all built!"
 
 echo "Uploading artifacts to S3..."
-aws s3 sync --acl public-read M10 s3://artifacts.opencypher.org/M10
+aws s3 sync --acl public-read ${RELEASE_VERSION} s3://artifacts.opencypher.org/${RELEASE_VERSION}
 echo "Done!"


### PR DESCRIPTION
The script would not work from the sub-directory.
Until this is fixed, it should live in the top-level.
This also fixes some small issues with the script.