### PR TITLE
Add namespace to function names

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -379,7 +379,10 @@
 
   <production name="FunctionName" rr:inline="true">
     <alt>
-      <non-terminal ref="SymbolicName" rr:title="function name"/>
+      <seq>
+        <non-terminal ref="Namespace" rr:title="function namespace"/>
+        <non-terminal ref="SymbolicName" rr:title="function name"/>
+      </seq>
       EXISTS
     </alt>
   </production>


### PR DESCRIPTION
We added the missing namespace for function names in the grammar. Please review. 