### PR TITLE
Grammar: move the IN operator from string operators to the list operators

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -253,8 +253,8 @@
   <production name="ListOperatorExpression" rr:inline="true">
     <alt>
       <seq>&SP; IN &WS; <non-terminal ref="PropertyOrLabelsExpression"/> </seq>
-      <seq> &WS; [ &expr; ] </seq>
-      <seq> &WS; [ <opt>&expr;</opt> .. <opt>&expr;</opt> ] </seq>
+      <seq>&WS; [ &expr; ] </seq>
+      <seq>&WS; [ <opt>&expr;</opt> .. <opt>&expr;</opt> ] </seq>
     </alt>
   </production>
 

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -252,6 +252,7 @@
 
   <production name="ListOperatorExpression" rr:inline="true">
     <alt>
+      <seq>&SP; IN &WS; <non-terminal ref="PropertyOrLabelsExpression"/> </seq>
       <seq> &WS; [ &expr; ] </seq>
       <seq> &WS; [ <opt>&expr;</opt> .. <opt>&expr;</opt> ] </seq>
     </alt>
@@ -261,7 +262,6 @@
     <seq>
       <alt>
         <non-terminal ref="RegularExpression"/>
-        <seq>&SP; IN</seq>
         <seq>&SP; STARTS &SP; WITH</seq>
         <seq>&SP; ENDS &SP; WITH</seq>
         <seq>&SP; CONTAINS</seq>


### PR DESCRIPTION
This is a correction to the semantical partitioning of operators in #321.

Thanks @Izhaki for raising this issue in https://github.com/opencypher/openCypher/pull/324#commitcomment-31161870.