### PR TITLE
Mark extract and filter functions legacy in the grammar

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -299,8 +299,7 @@
       <seq>COUNT &WS; ( &WS; * &WS; )</seq>
       <non-terminal ref="ListComprehension"/>
       <non-terminal ref="PatternComprehension"/>
-      <seq>FILTER  &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; ) </seq>
-      <seq>EXTRACT &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; <opt>&WS; | &expr;</opt> ) </seq>
+      <non-terminal ref="LegacyListExpression"/>
       <non-terminal ref="Reduce"/>
       <seq>ALL     &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; ) </seq>
       <seq>ANY     &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; ) </seq>
@@ -363,6 +362,13 @@
   <production name="FilterExpression">
     <non-terminal ref="IdInColl"/>
     <opt>&WS;<non-terminal ref="Where"/></opt>
+  </production>
+
+  <production name="LegacyListExpression" rr:inline="true" oc:legacy="true">
+    <alt>
+      <seq>FILTER  &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; ) </seq>
+      <seq>EXTRACT &WS; ( &WS; <non-terminal ref="FilterExpression"/> &WS; <opt>&WS; | &expr;</opt> ) </seq>
+    </alt>
   </production>
 
   <production name="IdInColl" rr:inline="true">


### PR DESCRIPTION
@Mats-SX I took a stab at updating the grammar to fix #340. Please review.