### PR TITLE
allow WHERE directly after YIELD

### DIFF
--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -251,7 +251,11 @@
   </production>
 
   <production name="InQueryCall">
-    <seq>CALL &SP; <non-terminal ref="ExplicitProcedureInvocation"/> <opt>&WS; YIELD &SP; <non-terminal ref="YieldItems"/></opt></seq>
+    <seq>
+      CALL &SP;
+      <non-terminal ref="ExplicitProcedureInvocation"/>
+      <opt>&WS; YIELD &SP; <non-terminal ref="YieldItems"/></opt>
+    </seq>
   </production>
 
   <production name="StandaloneCall">
@@ -266,10 +270,16 @@
   </production>
 
   <production name="YieldItems" rr:inline="true">
-    <alt>
-      <seq><non-terminal ref="YieldItem"/> <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat></seq>
-      -
-    </alt>
+    <seq>
+      <alt>
+        *
+        <seq>
+          <non-terminal ref="YieldItem"/>
+          <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat>
+        </seq>
+      </alt>
+      <opt>&WS; <non-terminal ref="Where"/></opt>
+    </seq>
   </production>
 
   <production name="YieldItem" rr:inline="true">

--- a/tools/grammar/src/test/resources/cypher-error.txt
+++ b/tools/grammar/src/test/resources/cypher-error.txt
@@ -19,3 +19,9 @@ MERGE () UNWIND [] AS foo RETURN 1§
 //
 // Label check predicates shouldn't precede property lookup, see #288
 MATCH (p) WHERE p:Person:Teacher.name RETURN p§
+CALL db.labels() YIELD -§
+CALL db.labels() YIELD -
+RETURN count(label) AS numLabels§
+CALL db.labels() YIELD -
+WHERE label CONTAINS 'User' AND foo + bar = foo
+RETURN count(label) AS numLabels§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -302,3 +302,13 @@ DETACH DELETE null§
 DELETE a WITH 1 RETURN 2§
 MATCH (a  ) DELETE a        RETURN a   §
 MATCH   (a) DELETE    a   WITH  a RETURN   a§
+CALL db.labels() YIELD label
+WHERE label CONTAINS 'User'
+RETURN count(label) AS numLabels§
+CALL db.labels() YIELD label, foo, bar
+WHERE label CONTAINS 'User' AND foo + bar = foo
+RETURN count(label) AS numLabels§
+CALL db.labels() YIELD *
+WHERE label CONTAINS 'User' AND foo + bar = foo
+RETURN count(label) AS numLabels§
+CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§


### PR DESCRIPTION
allow YIELD *
forbid YIELD -
editorial change in InQueryCall

Co-Authored-By: Mats Rydberg <mats@neotechnology.com>

Fixes #344