### PR TITLE
Removed scenario with unclear goal.

### DIFF
--- a/tck/features/ProcedureCallAcceptance.feature
+++ b/tck/features/ProcedureCallAcceptance.feature
@@ -479,16 +479,6 @@ Feature: ProcedureCallAcceptance
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  Scenario: In-query call to procedure that both takes arguments and has outputs fails if the arguments are passed implicitly and no outputs are yielded
-    And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
-      | in | out |
-    When executing query:
-      """
-      CALL test.my.proc
-      RETURN out
-      """
-    Then a SyntaxError should be raised at compile time: UndefinedVariable
-
   Scenario: Standalone call to unknown procedure should fail
     When executing query:
       """


### PR DESCRIPTION
This scenario was weird and unclear. One can only pass implicit arguments when no RETURN clause is used, thus the title did not match the actual test.

Fixes #345 