### PR TITLE
build on windows - avoid backslash n

### DIFF
--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
@@ -73,11 +73,11 @@ public class Antlr4 extends BnfWriter
         String header = grammar.header();
         if ( header != null )
         {
-            output.append( "/*\n * " )
+            output.println( "/*").append(" * " )
                   .printLines( header, " * " )
                   .println( " */" );
         }
-        output.append( "grammar " ).append( grammar.language() ).println( ";\n" );
+        output.append( "grammar " ).append( grammar.language() ).println( ";" ).println(); // PRF was ";\n"
 
         try ( Antlr4 antlr = new Antlr4( output ) )
         {
@@ -128,14 +128,14 @@ public class Antlr4 extends BnfWriter
                 set.accept( new SetFormatter( output ) );
                 output.append( ']' );
             }
-            output.println( " ;\n" );
+            output.println( " ;" ).println();  // PRF was " ;\n"
         }
     }
 
     @Override
     protected void productionCommentPrefix()
     {
-        output.append( "/**\n * " );
+        output.println( "/**").append(" * " );
     }
 
     @Override

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4ParserTest.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4ParserTest.java
@@ -32,6 +32,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -109,7 +110,11 @@ public class Antlr4ParserTest
     private List<String> getQueries( String queryFile ) throws FileNotFoundException, URISyntaxException
     {
         URL resource = getClass().getResource( queryFile );
-        Scanner scanner = new Scanner( new FileReader( Paths.get( resource.toURI() ).toFile() ) );
+        // using new FileReader( ) will assume the platform default encoding, which on Windows is liable to
+        // be CP1252. This will cause the scanner to split at SectionSign §, but leave the escape
+        // octet (C2) in the extracted string (appearing as Â).
+//        Scanner scanner = new Scanner( new FileReader( Paths.get( resource.toURI() ).toFile() ) );
+        Scanner scanner = new Scanner( Paths.get( resource.toURI() ).toFile() , "UTF-8" );
         scanner.useDelimiter( "§\n(//.*\n)*" );
         ArrayList<String> queries = new ArrayList<>();
             while ( scanner.hasNext() )

--- a/tools/grammar/src/test/java/org/opencypher/tools/io/OutputTest.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/io/OutputTest.java
@@ -109,10 +109,15 @@ public class OutputTest
         assertThat( multiplexed, instanceOf( MultiplexedOutput.class ) );
         Output[] output = ((MultiplexedOutput) multiplexed).output;
         assertEquals( 4, output.length );
-        assertThat( output, allOf(
-                arrayWithSize( 4 ),
-                arrayContainingInAnyOrder( a, b, c, d ),
-                not( arrayContaining( instanceOf( MultiplexedOutput.class ) ) ) ) );
+//        originally:  this failed with a compilation error on Windows 
+//                     (possibly because of Eclipse's java compiler)
+//        assertThat( output, allOf(
+//                arrayWithSize( 4 ),
+//                arrayContainingInAnyOrder( a, b, c, d ),
+//                not( arrayContaining( instanceOf( MultiplexedOutput.class ) ) ) ) );
+        assertThat( output, arrayWithSize( 4 ));
+        assertThat( output, arrayContainingInAnyOrder( a, b, c, d ));
+        assertThat( output, not( arrayContaining( instanceOf( MultiplexedOutput.class ) ) ) );
     }
 
     @Test

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -63,11 +63,11 @@ object TCKEventsTest {
       "Step 'Measure -> executing query:' started",
       "Step 'Measure' finished. Result: <empty result>",
       "Step 'Execute -> executing query:' started",
-      "Step 'Execute' finished. Result: | n |\n| 3 |",
+      "Step 'Execute' finished. Result: | n |" + System.lineSeparator + "| 3 |",
       "Step 'ExpectResult -> the result should be:' started",
-      "Step 'ExpectResult' finished. Result: | n |\n| 3 |",
+      "Step 'ExpectResult' finished. Result: | n |" + System.lineSeparator + "| 3 |",
       "Step 'SideEffects -> no side effects' started",
-      "Step 'SideEffects' finished. Result: | n |\n| 3 |"
+      "Step 'SideEffects' finished. Result: | n |" + System.lineSeparator + "| 3 |"
     )
     assertEquals(expected.asJava, events.toList.asJava, s"${expected.asJava} did not equal ${events.toList.asJava}")
   }


### PR DESCRIPTION
Building on windows failed because some of the grammar tools and tests of same assumed System.lineSeparator was \n. Corrected to use lineSeparator or println as appropriate

Also the separation of example cypher queries in a test needs to specify that file character set is UTF-8 if the System default is different

OutputTest combined 3 assertions into one method call, but the Windows compiler failed to find that method. Split into three calls