### PR TITLE
Correct wrong assertions for SKIP/LIMIT.

### DIFF
--- a/tck/features/OrderByAcceptance.feature
+++ b/tck/features/OrderByAcceptance.feature
@@ -365,32 +365,3 @@ Feature: OrderByAcceptance
     Then the result should be, in order:
       | name |
     And no side effects
-
-  Scenario: ORDER BY with negative parameter for LIMIT should not generate errors
-    And parameters are:
-      | limit | -1 |
-    When executing query:
-      """
-      MATCH (p:Person)
-      RETURN p.name AS name
-      ORDER BY p.name
-      LIMIT $`limit`
-      """
-    Then the result should be, in order:
-      | name |
-    And no side effects
-
-  Scenario: ORDER BY with a negative LIMIT should fail with a syntax exception
-    And having executed:
-      """
-      CREATE (s:Person {name: 'Steven'}),
-        (c:Person {name: 'Craig'})
-      """
-    When executing query:
-      """
-      MATCH (p:Person)
-      RETURN p.name AS name
-      ORDER BY p.name
-      LIMIT -1
-      """
-    Then a SyntaxError should be raised at compile time: NegativeIntegerArgument

--- a/tck/features/SkipLimitAcceptance.feature
+++ b/tck/features/SkipLimitAcceptance.feature
@@ -30,8 +30,10 @@
 
 Feature: SkipLimitAcceptanceTest
 
-  Scenario: SKIP with an expression that depends on variables should fail
+  Background:
     Given any graph
+
+  Scenario: SKIP with an expression that depends on variables should fail
     When executing query:
       """
       MATCH (n) RETURN n SKIP n.count
@@ -39,7 +41,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
   Scenario: LIMIT with an expression that depends on variables should fail
-    Given any graph
     When executing query:
       """
       MATCH (n) RETURN n LIMIT n.count
@@ -47,7 +48,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
   Scenario: SKIP with an expression that does not depend on variables
-    Given any graph
     And having executed:
       """
       UNWIND range(1, 10) AS i
@@ -67,7 +67,6 @@ Feature: SkipLimitAcceptanceTest
 
 
   Scenario: LIMIT with an expression that does not depend on variables
-    Given an empty graph
     And having executed:
       """
       UNWIND range(1, 3) AS i
@@ -85,7 +84,6 @@ Feature: SkipLimitAcceptanceTest
     And no side effects
 
   Scenario: Negative parameter for LIMIT should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -102,7 +100,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
   Scenario: Negative parameter for LIMIT with ORDER BY should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -119,7 +116,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
   Scenario: Negative LIMIT should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -134,7 +130,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
 
   Scenario: Negative parameter for SKIP should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -151,7 +146,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
   Scenario: Negative SKIP should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -166,7 +160,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
 
   Scenario: Floating point parameter for LIMIT should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -183,7 +176,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
   Scenario: Floating point parameter for LIMIT with ORDER BY should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -200,7 +192,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
   Scenario: Floating point LIMIT should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -215,7 +206,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
   Scenario: Floating point parameter for SKIP should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),
@@ -232,7 +222,6 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
   Scenario: Floating point SKIP should fail
-    Given any graph
     And having executed:
       """
       CREATE (s:Person {name: 'Steven'}),

--- a/tck/features/SkipLimitAcceptance.feature
+++ b/tck/features/SkipLimitAcceptance.feature
@@ -47,7 +47,7 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
   Scenario: SKIP with an expression that does not depend on variables
-    Given an empty graph
+    Given any graph
     And having executed:
       """
       UNWIND range(1, 10) AS i
@@ -101,7 +101,7 @@ Feature: SkipLimitAcceptanceTest
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  Scenario: Negative parameter for TOP should fail
+  Scenario: Negative parameter for LIMIT with ORDER BY should fail
     Given any graph
     And having executed:
       """
@@ -118,7 +118,7 @@ Feature: SkipLimitAcceptanceTest
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  Scenario: Negative LIMIT should fail with a syntax exception
+  Scenario: Negative LIMIT should fail
     Given any graph
     And having executed:
       """
@@ -141,16 +141,16 @@ Feature: SkipLimitAcceptanceTest
              (c:Person {name: 'Craig'})
       """
     And parameters are:
-      | limit | -1 |
+      | skip | -1 |
     When executing query:
       """
       MATCH (p:Person)
       RETURN p.name AS name
-      SKIP $limit
+      SKIP $skip
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  Scenario: Negative SKIP should fail with a syntax exception
+  Scenario: Negative SKIP should fail
     Given any graph
     And having executed:
       """
@@ -173,7 +173,7 @@ Feature: SkipLimitAcceptanceTest
              (c:Person {name: 'Craig'})
       """
     And parameters are:
-      | limit | 1.0 |
+      | limit | 1.5 |
     When executing query:
       """
       MATCH (p:Person)
@@ -182,7 +182,7 @@ Feature: SkipLimitAcceptanceTest
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  Scenario: Floating point parameter for TOP should fail
+  Scenario: Floating point parameter for LIMIT with ORDER BY should fail
     Given any graph
     And having executed:
       """
@@ -190,7 +190,7 @@ Feature: SkipLimitAcceptanceTest
              (c:Person {name: 'Craig'})
       """
     And parameters are:
-      | limit | 1.0 |
+      | limit | 1.5 |
     When executing query:
       """
       MATCH (p:Person)
@@ -199,7 +199,7 @@ Feature: SkipLimitAcceptanceTest
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  Scenario: Floating point LIMIT should fail with a syntax exception
+  Scenario: Floating point LIMIT should fail
     Given any graph
     And having executed:
       """
@@ -210,7 +210,7 @@ Feature: SkipLimitAcceptanceTest
       """
       MATCH (p:Person)
       RETURN p.name AS name
-      LIMIT 1.0
+      LIMIT 1.5
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
@@ -222,7 +222,7 @@ Feature: SkipLimitAcceptanceTest
              (c:Person {name: 'Craig'})
       """
     And parameters are:
-      | limit | 1.0 |
+      | limit | 1.5 |
     When executing query:
       """
       MATCH (p:Person)
@@ -231,7 +231,7 @@ Feature: SkipLimitAcceptanceTest
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  Scenario: Floating point SKIP should fail with a syntax exception
+  Scenario: Floating point SKIP should fail
     Given any graph
     And having executed:
       """
@@ -242,6 +242,6 @@ Feature: SkipLimitAcceptanceTest
       """
       MATCH (p:Person)
       RETURN p.name AS name
-      SKIP 1.0
+      SKIP 1.5
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/SkipLimitAcceptance.feature
+++ b/tck/features/SkipLimitAcceptance.feature
@@ -30,10 +30,8 @@
 
 Feature: SkipLimitAcceptanceTest
 
-  Background:
-    Given any graph
-
   Scenario: SKIP with an expression that depends on variables should fail
+    Given any graph
     When executing query:
       """
       MATCH (n) RETURN n SKIP n.count
@@ -41,6 +39,7 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
   Scenario: LIMIT with an expression that depends on variables should fail
+    Given any graph
     When executing query:
       """
       MATCH (n) RETURN n LIMIT n.count
@@ -48,6 +47,7 @@ Feature: SkipLimitAcceptanceTest
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
   Scenario: SKIP with an expression that does not depend on variables
+    Given an empty graph
     And having executed:
       """
       UNWIND range(1, 10) AS i
@@ -67,6 +67,7 @@ Feature: SkipLimitAcceptanceTest
 
 
   Scenario: LIMIT with an expression that does not depend on variables
+    Given an empty graph
     And having executed:
       """
       UNWIND range(1, 3) AS i
@@ -82,3 +83,165 @@ Feature: SkipLimitAcceptanceTest
       | count |
       | 2     |
     And no side effects
+
+  Scenario: Negative parameter for LIMIT should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | -1 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT $limit
+      """
+    Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
+
+  Scenario: Negative parameter for TOP should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | -1 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY name LIMIT $limit
+      """
+    Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
+
+  Scenario: Negative LIMIT should fail with a syntax exception
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT -1
+      """
+    Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
+
+  Scenario: Negative parameter for SKIP should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | -1 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      SKIP $limit
+      """
+    Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
+
+  Scenario: Negative SKIP should fail with a syntax exception
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      SKIP -1
+      """
+    Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
+
+  Scenario: Floating point parameter for LIMIT should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | 1.0 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT $limit
+      """
+    Then a SyntaxError should be raised at runtime: InvalidArgumentType
+
+  Scenario: Floating point parameter for TOP should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | 1.0 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      ORDER BY name LIMIT $limit
+      """
+    Then a SyntaxError should be raised at runtime: InvalidArgumentType
+
+  Scenario: Floating point LIMIT should fail with a syntax exception
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      LIMIT 1.0
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+  Scenario: Floating point parameter for SKIP should fail
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    And parameters are:
+      | limit | 1.0 |
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      SKIP $limit
+      """
+    Then a SyntaxError should be raised at runtime: InvalidArgumentType
+
+  Scenario: Floating point SKIP should fail with a syntax exception
+    Given any graph
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'}),
+             (c:Person {name: 'Craig'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      RETURN p.name AS name
+      SKIP 1.0
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType


### PR DESCRIPTION
This corrects the wrong assertion that SKIP/LIMIT should succeed with
negative integers at runtime, to make it consistent with the compile
time behavior.

It adds more tests and asserts on the same behavior for floating point
numbers.