### PR TITLE
Allow MATCH after OPTIONAL MATCH.

### DIFF
--- a/tck/features/SemanticErrorAcceptance.feature
+++ b/tck/features/SemanticErrorAcceptance.feature
@@ -241,15 +241,6 @@ Feature: SemanticErrorAcceptance
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  Scenario: Failing when using MATCH after OPTIONAL MATCH
-    When executing query:
-      """
-      OPTIONAL MATCH ()-->()
-      MATCH ()-->(d)
-      RETURN d
-      """
-    Then a SyntaxError should be raised at compile time: InvalidClauseComposition
-
   Scenario: Failing when float value is too large
     When executing query:
       """


### PR DESCRIPTION
There is no mention of this being an invalid clause composition anywhere
in neo4j or opencypher except this scenario.

In Neo4j, we decided to simply support it after this issue has been
opened: https://github.com/neo4j/neo4j/issues/12252