### PR TITLE
Replace deprecated syntax in TCK tests.

### DIFF
--- a/tck/features/FunctionsAcceptance.feature
+++ b/tck/features/FunctionsAcceptance.feature
@@ -53,11 +53,11 @@ Feature: FunctionsAcceptance
       """
       WITH null AS a
       OPTIONAL MATCH p = (a)-[r]->()
-      RETURN length(nodes(p)), type(r), nodes(p), relationships(p)
+      RETURN size(nodes(p)), type(r), nodes(p), relationships(p)
       """
     Then the result should be:
-      | length(nodes(p)) | type(r) | nodes(p) | relationships(p) |
-      | null             | null    | null     | null             |
+      | size(nodes(p)) | type(r) | nodes(p) | relationships(p) |
+      | null           | null    | null     | null             |
     And no side effects
 
   Scenario: `split()`

--- a/tck/features/ListComprehension.feature
+++ b/tck/features/ListComprehension.feature
@@ -78,7 +78,7 @@ Feature: ListComprehension
     When executing query:
       """
       MATCH (n)-->(b)
-      WHERE n.name IN [x IN labels(b) | lower(x)]
+      WHERE n.name IN [x IN labels(b) | toLower(x)]
       RETURN b
       """
     Then the result should be:

--- a/tck/features/ListOperations.feature
+++ b/tck/features/ListOperations.feature
@@ -707,10 +707,10 @@ Feature: ListOperations
       WITH nodes, [x IN nodes WHERE x.name = 'original'] AS noopFiltered
       UNWIND nodes AS n
       SET n.name = 'newName'
-      RETURN n.name, length(noopFiltered)
+      RETURN n.name, size(noopFiltered)
       """
     Then the result should be:
-      | n.name    | length(noopFiltered) |
+      | n.name    | size(noopFiltered) |
       | 'newName' | 1                    |
     And the side effects should be:
       | +properties | 1 |


### PR DESCRIPTION
The lower() function and length() of a collection is deprecated and
will be removed in Neo4j 4.0.