### PR TITLE
Expose categories in TCK API

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -105,7 +105,7 @@ object CypherTCK {
     parseFeature(featureFile.toAbsolutePath.toString, featureString, category)
   }
 
-  def parseFeature(source: String, featureString: String, category: List[String]): Feature = {
+  def parseFeature(source: String, featureString: String, category: Seq[String]): Feature = {
     val gherkinDocument = Try(parser.parse(featureString, matcher)) match {
       case Success(doc) => doc
       case Failure(error) =>
@@ -121,7 +121,7 @@ object CypherTCK {
     Feature(scenarios)
   }
 
-  private def toScenario(featureName: String, pickle: Pickle, category: List[String]): Scenario = {
+  private def toScenario(featureName: String, pickle: Pickle, category: Seq[String]): Scenario = {
 
     val tags = tagNames(pickle)
     val shouldValidate = !tags.contains("@allowCustomErrors")
@@ -213,7 +213,7 @@ object CypherTCK {
       }
       scenarioSteps
     }.toList
-    Scenario(featureName, pickle.getName, category, tags, steps, pickle)
+    Scenario(featureName, pickle.getName, category.toList, tags, steps, pickle)
   }
 
   private def tagNames(pickle: Pickle): Set[String] = pickle.getTags.asScala.map(_.getName).toSet

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -98,14 +98,14 @@ object CypherTCK {
   def parsePathFeature(featureFile: Path, directoryPath: Path): Feature = {
     val featureString = new String(Files.readAllBytes(featureFile), StandardCharsets.UTF_8)
     val relativeFeaturePath = directoryPath.relativize(featureFile.getParent)
-    val category = (0 until relativeFeaturePath.getNameCount)
+    val categories = (0 until relativeFeaturePath.getNameCount)
       .map(index => relativeFeaturePath.getName(index).toString)
       .filter(_.nonEmpty)
       .toList
-    parseFeature(featureFile.toAbsolutePath.toString, featureString, category)
+    parseFeature(featureFile.toAbsolutePath.toString, featureString, categories)
   }
 
-  def parseFeature(source: String, featureString: String, category: Seq[String]): Feature = {
+  def parseFeature(source: String, featureString: String, categories: Seq[String]): Feature = {
     val gherkinDocument = Try(parser.parse(featureString, matcher)) match {
       case Success(doc) => doc
       case Failure(error) =>
@@ -116,12 +116,12 @@ object CypherTCK {
     // filters out scenarios with @ignore
     val included = pickles.filterNot(tagNames(_) contains "@ignore")
     val featureName = gherkinDocument.getFeature.getName
-    val scenarios = included.map(toScenario(featureName, _, category))
+    val scenarios = included.map(toScenario(featureName, _, categories))
     TCKEvents.setFeature(FeatureRead(featureName, source, featureString))
     Feature(scenarios)
   }
 
-  private def toScenario(featureName: String, pickle: Pickle, category: Seq[String]): Scenario = {
+  private def toScenario(featureName: String, pickle: Pickle, categories: Seq[String]): Scenario = {
 
     val tags = tagNames(pickle)
     val shouldValidate = !tags.contains("@allowCustomErrors")
@@ -213,7 +213,7 @@ object CypherTCK {
       }
       scenarioSteps
     }.toList
-    Scenario(featureName, pickle.getName, category.toList, tags, steps, pickle)
+    Scenario(featureName, pickle.getName, categories.toList, tags, steps, pickle)
   }
 
   private def tagNames(pickle: Pickle): Set[String] = pickle.getTags.asScala.map(_.getName).toSet

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -85,7 +85,7 @@ object CypherTCK {
       }
       // Note that converting to list is necessary to cut off lazy evaluation
       // otherwise evaluation of parsePathFeature will happen after the file system is already closed
-      featurePaths.iterator().asScala.toList.map(fp => parsePathFeature(fp, directoryPath))
+      featurePaths.iterator().asScala.toList.map(parsePathFeature(_, directoryPath))
     } finally {
       try {
         fs.foreach(_.close())

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -100,7 +100,7 @@ object CypherTCK {
     val relativeFeaturePath = directoryPath.relativize(featureFile.getParent)
     val category = (0 until relativeFeaturePath.getNameCount)
       .map(index => relativeFeaturePath.getName(index).toString)
-      .filter(_ != "")
+      .filter(_.nonEmpty)
       .toList
     parseFeature(featureFile.toAbsolutePath.toString, featureString, category)
   }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -40,11 +40,11 @@ import scala.compat.Platform.EOL
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-case class Scenario(featureName: String, name: String, category: List[String], tags: Set[String], steps: List[Step], source: Pickle) {
+case class Scenario(featureName: String, name: String, categories: List[String], tags: Set[String], steps: List[Step], source: Pickle) {
 
   self =>
 
-  override def toString = s"""Feature "$featureName": Scenario "$name" (Category: "${ category.mkString("::") }", Tags: "${ if (tags.size > 0) tags.mkString(", ") else "-" }")"""
+  override def toString = s"""Feature "$featureName": Scenario "$name" (Categories: "${ categories.mkString("/") }", Tags: "${ if (tags.nonEmpty) tags.mkString(" ") else "-" }")"""
 
   def apply(graph: => Graph): Executable = new Executable {
     override def execute(): Unit = {

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -40,11 +40,11 @@ import scala.compat.Platform.EOL
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-case class Scenario(featureName: String, name: String, tags: Set[String], steps: List[Step], source: Pickle) {
+case class Scenario(featureName: String, name: String, category: List[String], tags: Set[String], steps: List[Step], source: Pickle) {
 
   self =>
 
-  override def toString = s"""Feature "$featureName": Scenario "$name""""
+  override def toString = s"""Feature "$featureName": Scenario "$name" (Category: "${ category.mkString("::") }", Tags: "${ if (tags.size > 0) tags.mkString(", ") else "-" }")"""
 
   def apply(graph: => Graph): Executable = new Executable {
     override def execute(): Unit = {

--- a/tools/tck-api/src/test/resources/org/opencypher/tools/tck/foo/bar/boo/Test.feature
+++ b/tools/tck-api/src/test/resources/org/opencypher/tools/tck/foo/bar/boo/Test.feature
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2015-2020 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+Feature: Test
+
+  Scenario: Return literal
+    Given an empty graph
+    When executing query:
+      """
+      RETURN 1
+      """
+    Then the result should be, in any order:
+      | 1 |
+      | 1 |
+    And no side effects
+
+  Scenario: Fail
+    Given an empty graph
+    When executing query:
+      """
+      RETURN foo()
+      """
+    Then a SyntaxError should be raised at compile time: UnknownFunction
+
+  @ignore
+  Scenario: Ignored
+    Given an unsupported step
+    When executing query:
+      """
+      not really a query
+      """

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CategoriesTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CategoriesTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015-2020 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.api
+
+import org.junit.jupiter.api.Test
+import org.scalatest.{FunSuite, Matchers}
+
+class CategoriesTest extends FunSuite with Matchers {
+  val fooUri = getClass.getResource("..").toURI
+  val scenarios = CypherTCK.parseFeatures(fooUri).flatMap(_.scenarios)
+
+  test("category of top-level scenarios") {
+    val topLevelScenarios = scenarios.filter(_.featureName == "Foo")
+    topLevelScenarios.foreach(_.category should equal(List[String]()))
+  }
+
+  test("category of some-level scenarios") {
+    val someLevelScenarios = scenarios.filter(_.featureName == "Test")
+    someLevelScenarios.foreach(_.category should equal(List("foo", "bar", "boo")))
+  }
+}

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CategoriesTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CategoriesTest.scala
@@ -36,11 +36,11 @@ class CategoriesTest extends FunSuite with Matchers {
 
   test("category of top-level scenarios") {
     val topLevelScenarios = scenarios.filter(_.featureName == "Foo")
-    topLevelScenarios.foreach(_.category should equal(List[String]()))
+    topLevelScenarios.foreach(_.categories should equal(List[String]()))
   }
 
   test("category of some-level scenarios") {
     val someLevelScenarios = scenarios.filter(_.featureName == "Test")
-    someLevelScenarios.foreach(_.category should equal(List("foo", "bar", "boo")))
+    someLevelScenarios.foreach(_.categories should equal(List("foo", "bar", "boo")))
   }
 }

--- a/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
+++ b/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
@@ -59,7 +59,7 @@ public class CucumberReportAdapterTest {
     public Stream<DynamicTest> runFeatures() throws Exception {
         String content = getResource("Foo.feature");
 
-        Seq<Scenario> scenariosSeq = CypherTCK.parseFeature("Foo.feature", content).scenarios();
+        Seq<Scenario> scenariosSeq = CypherTCK.parseFeature("Foo.feature", content, JavaConverters.asScalaBuffer(new java.util.ArrayList<String>())).scenarios();
         java.util.List<Scenario> scenarios = JavaConverters.seqAsJavaList(scenariosSeq);
 
         AbstractFunction0<Graph> graph = graph();


### PR DESCRIPTION
This pull request changes the TCK API to expose the category hierarchy of a scenario in the `Scenario` case class so that scenarios can be filtered, counted, reported, etc. by category. 

The `Scenario` case class gains a new field `category: List[String]` which lists top-down the category names of a scenario's feature file. Example: Any scenario from `clauses/match/Match1.feature` will have a list `List("clauses", "match")`.