### PR TITLE
Fix duplicate scenario name

### DIFF
--- a/tck/features/uncategorized/ListOperations.feature
+++ b/tck/features/uncategorized/ListOperations.feature
@@ -661,7 +661,7 @@ Feature: ListOperations
       | [1, 10, 100, 4, 5] |
     And no side effects
 
-  Scenario: Concatenating lists of same type
+  Scenario: Concatenating a list with a scalar of same type
     Given any graph
     When executing query:
       """


### PR DESCRIPTION
This PR fixes a the name of one scenario. The name was equal to the name of another scenario within the same feature file, which is not supposed to happen.