### PR TITLE
Tag to switch off code style checker

### DIFF
--- a/tck/features/uncategorized/ColumnNameAcceptance.feature
+++ b/tck/features/uncategorized/ColumnNameAcceptance.feature
@@ -58,6 +58,7 @@ Feature: ColumnNameAcceptance
       | nOdEs( p ) |
     And no side effects
 
+  @withIntentionalStyleViolation
   Scenario: Keeping used expression 3
     When executing query:
       """


### PR DESCRIPTION
OBSOLETE – REPLACED BY [PR 408](https://github.com/opencypher/openCypher/pull/408)

This PR adapts FeatureFormatChecker to not check code style if a scenario has a @withIntentionalStyleViolation tag. This allow to write scenarios with intentional code style violations (or work around limitation of the code style checker).