### PR TITLE
Tag to switch off code style checker – cleaned up history

### DIFF
--- a/tck/features/uncategorized/ColumnNameAcceptance.feature
+++ b/tck/features/uncategorized/ColumnNameAcceptance.feature
@@ -58,6 +58,7 @@ Feature: ColumnNameAcceptance
       | nOdEs( p ) |
     And no side effects
 
+  @withIntentionalStyleViolation
   Scenario: Keeping used expression 3
     When executing query:
       """

--- a/tck/features/uncategorized/ColumnNameAcceptance.feature
+++ b/tck/features/uncategorized/ColumnNameAcceptance.feature
@@ -58,7 +58,7 @@ Feature: ColumnNameAcceptance
       | nOdEs( p ) |
     And no side effects
 
-  @withIntentionalStyleViolation
+  @skipStyleCheck
   Scenario: Keeping used expression 3
     When executing query:
       """

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -45,6 +45,7 @@ import org.opencypher.tools.tck.constants.TCKErrorDetails
 import org.opencypher.tools.tck.constants.TCKErrorPhases
 import org.opencypher.tools.tck.constants.TCKErrorTypes
 import org.opencypher.tools.tck.constants.TCKStepDefinitions._
+import org.opencypher.tools.tck.constants.TCKTags
 import org.opencypher.tools.tck.values.CypherValue
 
 import scala.collection.JavaConverters._
@@ -130,8 +131,8 @@ object CypherTCK {
     }
     val compiler = new Compiler
     val pickles = compiler.compile(gherkinDocument).asScala
-    // filters out scenarios with @ignore
-    val included = pickles.filterNot(tagNames(_) contains "@ignore")
+    // filters out scenarios with TCKTags.IGNORE
+    val included = pickles.filterNot(tagNames(_) contains TCKTags.IGNORE)
 
     val includedGroupedByName = included.groupBy(_.getName)
     val includedGroupedAndSorted = includedGroupedByName.
@@ -156,7 +157,7 @@ object CypherTCK {
   private def toScenario(categories: Seq[String], featureName: String, pickle: gherkin.pickles.Pickle, exampleIndex: Option[Int], sourceFile: Path): Scenario = {
 
     val tags = tagNames(pickle)
-    val shouldValidate = !tags.contains("@allowCustomErrors")
+    val shouldValidate = !tags.contains(TCKTags.ALLOW_CUSTOM_ERRORS)
 
     val steps = pickle.getSteps.asScala.flatMap { step =>
       def stepArguments = step.getArgument.asScala
@@ -229,7 +230,7 @@ object CypherTCK {
                 throw InvalidFeatureFormatException(
                   s"""Invalid error format in scenario "${pickle.getName}" from feature "$featureName":
                     $errorMessage
-                    If this is a custom error, then disable this validation with tag "@allowCustomErrors"""")
+                    If this is a custom error, then disable this validation with tag "${TCKTags.ALLOW_CUSTOM_ERRORS}"""")
             }
           }
           List(expectedError, SideEffects(source = step).fillInZeros)

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKTags.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKTags.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015-2020 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.constants
+
+object TCKTags {
+
+  val IGNORE = "@ignore"
+  val ALLOW_CUSTOM_ERRORS = "@allowCustomErrors"
+  val SKIP_STYLE_CHECK = "@skipStyleCheck"
+}

--- a/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
+++ b/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import io.cucumber.datatable.DataTable
 import org.opencypher.tools.tck.api.InvalidFeatureFormatException
 import org.opencypher.tools.tck.constants.TCKStepDefinitions._
+import org.opencypher.tools.tck.constants.TCKTags
 
 import scala.util.Failure
 import scala.util.Success
@@ -40,12 +41,12 @@ import scala.util.Try
 class FeatureFormatChecker extends TCKCucumberTemplate {
 
   private var currentScenarioName = ""
-  private var withIntentionalStyleViolation: Boolean = false
+  private var skipStyleCheck: Boolean = false
 
   Before { (scenario: cucumber.api.Scenario) =>
     validateDuplicateNames(scenario).map(msg => throw InvalidFeatureFormatException(msg))
     currentScenarioName = scenario.getName
-    withIntentionalStyleViolation = scenario.getSourceTagNames.contains("@withIntentionalStyleViolation")
+    skipStyleCheck = scenario.getSourceTagNames.contains(TCKTags.SKIP_STYLE_CHECK)
   }
 
   private var lastSeenQuery = ""
@@ -145,7 +146,7 @@ class FeatureFormatChecker extends TCKCucumberTemplate {
   After(_ => stepValidator.checkRequiredSteps())
 
   private def codeStyle(query: String): Option[String] = {
-    if (withIntentionalStyleViolation) None
+    if (skipStyleCheck) None
     else validateCodeStyle(query)
   }
 


### PR DESCRIPTION
This PR adapts FeatureFormatChecker to not check code style if a scenario has a @withIntentionalStyleViolation tag. This allow to write scenarios with intentional code style violations (or work around limitation of the code style checker).

This PR replaces [PR 405](https://github.com/opencypher/openCypher/pull/405), which had a messed-up history.