### PR TITLE
Remove tck-api non-test dependency on junit...

### DIFF
--- a/tools/tck-api/pom.xml
+++ b/tools/tck-api/pom.xml
@@ -56,11 +56,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>gherkin</artifactId>
     </dependency>

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -29,7 +29,6 @@ package org.opencypher.tools.tck.api
 
 import java.nio.file.Path
 
-import org.junit.jupiter.api.function.Executable
 import org.opencypher.tools.tck.SideEffectOps
 import org.opencypher.tools.tck.SideEffectOps._
 import org.opencypher.tools.tck.api.Graph.Result
@@ -72,15 +71,14 @@ case class Scenario(categories: List[String], featureName: String, name: String,
     hash
   }
 
-  def apply(graph: => Graph): Executable = new Executable {
-    override def execute(): Unit = {
+  def apply(graph: => Graph): Runnable =
+    () => {
       val g = graph // ensure that lazy parameter is only evaluated once
       try {
         TCKEvents.setScenario(self)
         executeOnGraph(g)
       } finally g.close()
     }
-  }
 
   def executeOnGraph(empty: Graph): Unit = {
     steps.foldLeft(ScenarioExecutionContext(empty)) { (context, step) =>

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/TckTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/TckTest.scala
@@ -70,8 +70,8 @@ class TckTest {
 
     val dynamicTests = scenarios.map { scenario =>
       val name = scenario.toString()
-      val executable = scenario(createTestGraph())
-      DynamicTest.dynamicTest(name, executable)
+      val runnable = scenario(createTestGraph())
+      DynamicTest.dynamicTest(name, () => runnable.run())
     }
     dynamicTests.asJavaCollection
   }

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -83,8 +83,8 @@ class TCKEventsTest {
 
     val dynamicTests = scenarios.map { scenario =>
       val name = scenario.toString()
-      val executable = scenario(createTestGraph())
-      DynamicTest.dynamicTest(name, executable)
+      val runnable = scenario(createTestGraph())
+      DynamicTest.dynamicTest(name, () => runnable.run())
     }
     dynamicTests.asJavaCollection
   }

--- a/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
+++ b/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
@@ -72,8 +72,8 @@ public class CucumberReportAdapterTest {
         return scenarios.stream()
             .map(scenario -> {
                 String name = scenario.toString();
-                Executable executable = scenario.apply(graph);
-                return DynamicTest.dynamicTest(name, executable);
+                Runnable runnable = scenario.apply(graph);
+                return DynamicTest.dynamicTest(name, runnable::run);
             });
     }
 


### PR DESCRIPTION
As tck-api can be used for non-test code like benchmarks, it is very inconvenient to depend on junit, because some rule based tools will fail to compile modules with dependencies on test-libraries from production code.