### PR TITLE
Generator for tck/index.adoc

### DIFF
--- a/tck/index.adoc
+++ b/tck/index.adoc
@@ -8,10 +8,10 @@ Within each member, there are additional categories.
 There is also an `uncategorized` and `precategorized` directory containing uncategorized features.
 
 
-== clauses
+== Clauses
 
 
-=== create
+=== Create
 
 * Create1 - Creating nodes
 * Create2 - Creating relationships
@@ -20,7 +20,7 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * Create5 - Multiple hops create patterns
 * Create6 - Negative tests
 
-=== delete
+=== Delete
 
 * Delete1 - Deleting nodes
 * Delete2 - Deleting relationships
@@ -29,7 +29,7 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * Delete5 - Delete clause interoperation with built-in data types
 * Delete6 - Negative scenarios
 
-=== match
+=== Match
 
 * Match1 - Match Nodes scenarios
 * Match10 - Match clause failure scenarios
@@ -42,7 +42,12 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * Match8 - Match clause Interoperation with other clauses
 * Match9 - Match deprecated scenarios
 
-=== set
+=== Remove
+
+* Remove1 - Remove a Property
+* Remove2 - Remove a Label
+
+=== Set
 
 * Set1 - Set a Property
 * Set2 - Set a Property to Null
@@ -50,20 +55,27 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * Set4 - Set Multiple Properties
 * Set5 - Set Multiple Properties with a Map
 
-=== union
+=== Union
 
 * Union1 - Union
 * Union2 - Union All
 * Union3 - Union in combination with Union All
 
-=== unwind
+=== Unwind
 
 * Unwind1
 
-== expressions
+== Expressions
 
 
-=== list
+=== Comparison
+
+* Comparison1 - Equality
+* Comparison2 - Half-bounded Range
+* Comparison3 - Full-Bound Range
+* Comparison4 - Combination of Comparisons
+
+=== List
 
 * List1 - Dynamic Element Access
 * List11 - List Comprehension
@@ -75,7 +87,7 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * List6 - List Size
 * List9 - List Tail
 
-=== literals
+=== Literals
 
 * Literals1 - Boolean and Null
 * Literals2 - Integer
@@ -85,20 +97,32 @@ There is also an `uncategorized` and `precategorized` directory containing uncat
 * Literals6 - Maps
 * Literals7 - Negative tests
 
-=== map
+=== Map
 
 * Map2 - Dynamic Value Access
 * Map3 - Keys Function
 * Map4 - Negative Tests
 
-=== mathematical
+=== Mathematical
 
 * Addition
 * ArithmeticPrecedence
 * SignedNumbersFunctions
 * SquareRoot
 
-=== typeConversion
+=== Temporal
+
+* Temporal1 - Create Temporal Values from a Map
+* Temporal2 - Create Temporal Values from a String
+* Temporal3 - Project Temporal Values from other Temporal Values
+* Temporal4 - Store Temporal Values
+* Temporal5 - Access Components of Temporal Values
+* Temporal6 - Render Temporal Values as a String
+* Temporal7 - Compare Temporal Values
+* Temporal8 - Compute Arithmetic Operations on Temporal Values
+* Temporal9 - Truncate Temporal Values
+
+=== Type Conversion
 
 * TypeConversion1 - To Boolean
 * TypeConversion2 - To Integer

--- a/tck/index.adoc
+++ b/tck/index.adoc
@@ -5,70 +5,102 @@ The two main groups are clauses and expressions.
 Each group enumerates its members.
 Within each member, there are additional categories.
 
-There is also an `uncategorized` directory containing uncategorized features.
-
-== Clauses
-
-Each clause has its own directory of Gherkin `.feature` files, or _features_ for short.
-Each feature follows a naming convention of `<clause-name><group-id>.feature`.
-
-=== CREATE
-
-* `Create1`: Creating nodes
-** This group is about the creation of nodes.
-* `Create2`: Creating relationships
-** This group is about the creation of relationships.
-* `Create3`: Interoperation with other clauses
-** This group is about the interplay of the `CREATE` clause with other clauses.
-* `Create4`: Large Create Query
-** This group is about scenarios with that create a larger number of nodes and relationships.
-* `Create5`: Multiple hops create patterns
-** This group is about create patterns larger than a single node or a single relationship.
-* `Create6`: Negative tests
-** This group is about failure cases for the `CREATE` clause; invalid queries.
+There is also an `uncategorized` and `precategorized` directory containing uncategorized features.
 
 
-=== MATCH
+== clauses
 
-* `Match1`: Match nodes
-** This group is about matching nodes.
-* `Match2`: Match relationships
-** This group is about matching relationships.
-* `Match3`: Match fixed length patterns
-** This group is about matching patterns.
-* `Match4`: Match variable length patterns
-** This group is about matching variable length patterns.
-* `Match5`: Match variable length patterns over given graphs
-** This group is about matching patterns over given graphs.
-* `Match6`: Match named paths
-** This group is about matching named paths.
-* `Match7`: Optional match
-** This group is about optional matching with all of the above.
-* `Match8`: Interoperation with other clauses
-** This group is about Interoperation of `MATCH` clause with other clauses.
-* `Match9`: Deprecated features
-** This group is about deprecated `MATCH` clause features.
-* `Match10`: Negative tests
-** This group is about failure for the `MATCH` clause.
 
-=== UNWIND
+=== create
 
-* `Unwind1`: ...
+* Create1 - Creating nodes
+* Create2 - Creating relationships
+* Create3 - Interoperation with other clauses
+* Create4 - Large Create Query
+* Create5 - Multiple hops create patterns
+* Create6 - Negative tests
 
-== Expressions
+=== delete
 
-The expressions are grouped into categories based on their domain.
-Each category consists of a number of features.
+* Delete1 - Deleting nodes
+* Delete2 - Deleting relationships
+* Delete3 - Deleting named paths
+* Delete4 - Delete clause interoperation with other clauses
+* Delete5 - Delete clause interoperation with built-in data types
+* Delete6 - Negative scenarios
 
-=== Aggregations
+=== match
 
-* `Aggregation1`: ...
+* Match1 - Match Nodes scenarios
+* Match10 - Match clause failure scenarios
+* Match2 - Match relationships scenarios
+* Match3 - Match fixed length patterns scenarios
+* Match4 - Match variable length patterns scenarios
+* Match5 - Match variable length patterns over given graphs scenarios
+* Match6 - Match named paths scenarios
+* Match7 - Optional match scenarios
+* Match8 - Match clause Interoperation with other clauses
+* Match9 - Match deprecated scenarios
 
-=== Functions
+=== set
 
-* `Function1`: Type conversion functions
-* `Function2`: Negative tests for functions (invalid arguments etc)
+* Set1 - Set a Property
+* Set2 - Set a Property to Null
+* Set3 - Set a Label
+* Set4 - Set Multiple Properties
+* Set5 - Set Multiple Properties with a Map
 
-=== Literals
+=== union
 
-* `Literal1`: ...
+* Union1 - Union
+* Union2 - Union All
+* Union3 - Union in combination with Union All
+
+=== unwind
+
+* Unwind1
+
+== expressions
+
+
+=== list
+
+* List1 - Dynamic Element Access
+* List11 - List Comprehension
+* List12 - List Operations Failure
+* List2 - List Slicing
+* List3 - List Equality
+* List4 - List Concatenation
+* List5 - List Membership Validation - IN Operator
+* List6 - List Size
+* List9 - List Tail
+
+=== literals
+
+* Literals1 - Boolean and Null
+* Literals2 - Integer
+* Literals3 - Float
+* Literals4 - String
+* Literals5 - List
+* Literals6 - Maps
+* Literals7 - Negative tests
+
+=== map
+
+* Map2 - Dynamic Value Access
+* Map3 - Keys Function
+* Map4 - Negative Tests
+
+=== mathematical
+
+* Addition
+* ArithmeticPrecedence
+* SignedNumbersFunctions
+* SquareRoot
+
+=== typeConversion
+
+* TypeConversion1 - To Boolean
+* TypeConversion2 - To Integer
+* TypeConversion3 - To Float
+* TypeConversion4 - To String

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -36,8 +36,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <propertyName>buildDirectory</propertyName>
-                        <buildDirectory>${project.build.directory}</buildDirectory>
+                        <propertyName>projectRootdir</propertyName>
+                        <projectRootdir>${project.rootdir}</projectRootdir>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -34,6 +34,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <propertyName>buildDirectory</propertyName>
+                        <buildDirectory>${project.build.directory}</buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015-2020 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools
+
+import org.junit.jupiter.api.Test
+import org.opencypher.tools.tck.api.CypherTCK
+import org.opencypher.tools.tck.inspection.collect.Feature
+import org.opencypher.tools.tck.inspection.collect.Group
+import org.opencypher.tools.tck.inspection.collect.GroupCollection
+import org.opencypher.tools.tck.inspection.collect.ScenarioCategory
+import org.opencypher.tools.tck.inspection.collect.Tag
+import org.opencypher.tools.tck.inspection.collect.Total
+
+class GenerateTCKIndexDocTest {
+  @Test
+  def runAsTest(): Unit = GenerateTCKIndexDoc.main(Array())
+}
+
+object GenerateTCKIndexDoc {
+  private val indexDocFile = System.getProperty("buildDirectory") + "/../../../tck/index.adoc"
+
+  def main(args: Array[String]): Unit = {
+    val scenarios = CypherTCK.allTckScenarios
+    val groups = GroupCollection(scenarios).keySet
+
+    val groupsByParent = groups.groupBy(_.parent)
+
+    // print counts to stdout as a count group tree in dept first order
+    def printDepthFirst(currentGroup: Group): List[String] = {
+      val groupHead = currentGroup match {
+        case Total =>
+          """= TCK Index
+            |
+            |The TCK is split into categories based on language constructs.
+            |The two main groups are clauses and expressions.
+            |Each group enumerates its members.
+            |Within each member, there are additional categories.
+            |
+            |There is also an `uncategorized` and `precategorized` directory containing uncategorized features.
+            |""".stripMargin
+        case ScenarioCategory(name, indent, _) =>
+          System.getProperty("line.separator") + s"=${("=" * indent)} $name" + System.getProperty("line.separator")
+        case Feature(name, _, _) =>
+          s"* $name"
+        case _ => ""
+      }
+      // on each level ordered in classes of Total, ScenarioCategories, Features, Tags
+      val groupsByClasses = groupsByParent.getOrElse(Some(currentGroup), Iterable[Group]()).groupBy{
+        case Total => 0
+        case _:Feature => 1
+        case _:ScenarioCategory => 2
+        case _:Tag => 3
+      }
+      // within each group ordered alphabetically by name
+      val groupsOrdered = groupsByClasses.toSeq.sortBy(_._1).flatMap {
+        case (_, countCategories) => countCategories.toSeq.sortBy(_.name)
+      }
+      // filter out tags and uncategorized
+      val groupsOrderedFiltered = groupsOrdered.filter {
+        case ScenarioCategory("precategorized", _, _) => false
+        case ScenarioCategory("uncategorized", _, _) => false
+        case Tag(_) => false
+        case _ => true
+      }
+
+      groupHead :: groupsOrderedFiltered.flatMap(printDepthFirst).toList
+    }
+
+    val indexDoc = printDepthFirst(Total).mkString(System.lineSeparator)
+
+    import java.io._
+    val pw = new PrintWriter(new File(indexDocFile))
+    pw.write(indexDoc)
+    pw.close
+
+    println("Generated " + indexDocFile)
+  }
+}

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
@@ -108,8 +108,10 @@ object GenerateTCKIndexDoc {
             |
             |There is also an `uncategorized` and `precategorized` directory containing uncategorized features.
             |""".stripMargin
-        case ScenarioCategory(name, indent, _) =>
-          System.lineSeparator() + s"=${"=" * indent} $name" + System.lineSeparator()
+        case ScenarioCategory(name, indent, _) => {
+          val prettyName = name.substring(0,1).toUpperCase + name.substring(1).replaceAll("([A-Z])", " $1")
+          System.lineSeparator() + s"=${"=" * indent} $prettyName" + System.lineSeparator()
+        }
         case Feature(name, _, _) =>
           s"* $name"
         case _ => ""

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
@@ -45,10 +45,10 @@ import scala.io.Source
 import scala.sys.process._
 
 class GenerateTCKIndexDocTest {
-  @Test
+  @Test //comment this in/out if index.adoc should/should not be generated during build
   def runAsTest(): Unit = GenerateTCKIndexDoc.main(Array())
 
-  @Test
+  //@Test //comment this in/out if generated index.adoc should/should not be checked against working copy HEAD during build
   def verifyGenerateIndexIsCommitted(): Unit = {
     val tmpFile = Files.createTempFile("tck-", "-index.adoc")
     val gitCmd = Seq("git", "-C", Paths.get(System.getProperty("projectRootdir")).toAbsolutePath.toString,


### PR DESCRIPTION
The [tck/index.adoc](tck/index.adoc) is intended as repository documentation for the feature categories.

This PR adds [GenerateTCKIndexDoc](https://github.com/opencypher/openCypher/compare/master...hvub:create-tck-index-during-build?expand=1#diff-715e7bfab98083a2e2eda02bffafb292R44), which generates the tck/index.adoc based on folder structure and .feature files. It excludes the `uncategorized` and `precategorized` folders. The generation is fairly simple at the moment. However, it keeps tck/index.adoc uptodate, which no categorization step so far did. If it proofs to be useful, it is possible to improve the generation.

The PR also add [GenerateTCKIndexDocTest](https://github.com/opencypher/openCypher/compare/master...hvub:create-tck-index-during-build?expand=1#diff-715e7bfab98083a2e2eda02bffafb292R39), which runs GenerateTCKIndexDoc as a test, so it run during build – without testing anything in particular.

Keeping a generated artifact in the repository is not ideal, of course. It seems reasonable to remove the GenerateTCKIndexDoc from the build ones the categories become stable or even earlier if the generation shows to cause too many merge conflicts or other troubles.