### PR TITLE
Categorize temporal 2

### DIFF
--- a/tck/features/expressions/temporal/Temporal10.feature
+++ b/tck/features/expressions/temporal/Temporal10.feature
@@ -30,7 +30,7 @@
 
 Feature: Temporal10 - Compute Durations Between two Temporal Values
 
-  Scenario Outline: Should split between boundaries correctly
+  Scenario Outline: [1] Should split between boundaries correctly
     Given any graph
     When executing query:
       """
@@ -51,7 +51,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2017-10-28T23:00+02:00[Europe/Stockholm]') | datetime('2017-10-29T04:00+01:00[Europe/Stockholm]') | 'PT6H'             | 0    | 21600   | 0         |
       | datetime('2017-10-29T04:00+01:00[Europe/Stockholm]') | datetime('2017-10-28T23:00+02:00[Europe/Stockholm]') | 'PT-6H'            | 0    | -21600  | 0         |
 
-  Scenario Outline: Should compute duration between two temporals
+  Scenario Outline: [2] Should compute duration between two temporals
     Given any graph
     When executing query:
       """
@@ -90,7 +90,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | localtime('16:30')                       | 'PT-5H-10M-36.143S'       |
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT-4H-10M-36.143S'       |
 
-  Scenario Outline: Should compute duration between two temporals in months
+  Scenario Outline: [3] Should compute duration between two temporals in months
     Given any graph
     When executing query:
       """
@@ -125,7 +125,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | localtime('16:30')                       | 'PT0S'   |
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT0S'   |
 
-  Scenario Outline: Should compute duration between two temporals in days
+  Scenario Outline: [4] Should compute duration between two temporals in days
     Given any graph
     When executing query:
       """
@@ -160,7 +160,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | localtime('16:30')                       | 'PT0S'    |
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT0S'    |
 
-  Scenario Outline: Should compute duration between two temporals in seconds
+  Scenario Outline: [5] Should compute duration between two temporals in seconds
     Given any graph
     When executing query:
       """
@@ -199,7 +199,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | localtime('16:30')                       | 'PT-5H-10M-36.143S'   |
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT-4H-10M-36.143S'   |
 
-  Scenario: Should compute duration between if they differ only by a fraction of a second and the first comes after the second.
+  Scenario: [6] Should compute duration between if they differ only by a fraction of a second and the first comes after the second.
     Given any graph
     When executing query:
       """
@@ -210,7 +210,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | 'PT-0.001S' |
     And no side effects
 
-  Scenario Outline: Should compute negative duration between in big units
+  Scenario Outline: [7] Should compute negative duration between in big units
     Given any graph
     When executing query:
       """
@@ -229,7 +229,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2018-07-21T21:40:36.143+0200') | localdatetime('2016-07-21T21:40:36.143') | 'P-2Y'      |
       | datetime('2018-07-21T21:40:36.143+0500') | datetime('1984-07-21T22:40:36.143+0200') | 'P-33Y-11M' |
 
-  Scenario Outline: Should handle durations at daylight saving time day
+  Scenario Outline: [8] Should handle durations at daylight saving time day
     Given any graph
     When executing query:
       """
@@ -249,7 +249,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | date({year: 2017, month: 10, day: 29})                                            | datetime({year: 2017, month: 10, day: 29, hour: 4, timezone: 'Europe/Stockholm'}) | 'PT5H'  |
       | datetime({year: 2017, month: 10, day: 29, hour: 0, timezone: 'Europe/Stockholm'}) | date({year: 2017, month: 10, day: 30})                                            | 'PT25H' |
 
-  Scenario: Should handle large durations
+  Scenario: [9] Should handle large durations
     Given any graph
     When executing query:
       """
@@ -260,7 +260,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | 'P1999999998Y11M30D' |
     And no side effects
 
-  Scenario: Should handle large durations in seconds
+  Scenario: [10] Should handle large durations in seconds
     Given any graph
     When executing query:
       """
@@ -271,7 +271,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | 'PT17531639991215H59M59S' |
     And no side effects
 
-  Scenario Outline: Should handle when seconds and subseconds have different signs
+  Scenario Outline: [11] Should handle when seconds and subseconds have different signs
     Given any graph
     When executing query:
       """
@@ -295,7 +295,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | '12:34:56.3' | '12:34:54.7' | 'PT-1.6S'     |
       | '12:34:54.7' | '12:34:56.3' | 'PT1.6S'      |
 
-  Scenario Outline: Should compute durations with no difference
+  Scenario Outline: [12] Should compute durations with no difference
     Given any graph
     When executing query:
       """
@@ -314,7 +314,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | localdatetime() |
       | datetime()      |
 
-  Scenario Outline: Should propagate null
+  Scenario Outline: [13] Should propagate null
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/temporal/Temporal10.feature
+++ b/tck/features/expressions/temporal/Temporal10.feature
@@ -30,10 +30,8 @@
 
 Feature: Temporal10 - Compute Durations Between two Temporal Values
 
-  Background:
-    Given any graph
-
   Scenario Outline: Should split between boundaries correctly
+    Given any graph
     When executing query:
       """
       WITH duration.between(<d1>, <d2>) AS dur
@@ -54,6 +52,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2017-10-29T04:00+01:00[Europe/Stockholm]') | datetime('2017-10-28T23:00+02:00[Europe/Stockholm]') | 'PT-6H'            | 0    | -21600  | 0         |
 
   Scenario Outline: Should compute duration between two temporals
+    Given any graph
     When executing query:
       """
       RETURN duration.between(<lhs>, <rhs>) AS duration
@@ -92,6 +91,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT-4H-10M-36.143S'       |
 
   Scenario Outline: Should compute duration between two temporals in months
+    Given any graph
     When executing query:
       """
       RETURN duration.inMonths(<lhs>, <rhs>) AS duration
@@ -126,6 +126,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT0S'   |
 
   Scenario Outline: Should compute duration between two temporals in days
+    Given any graph
     When executing query:
       """
       RETURN duration.inDays(<lhs>, <rhs>) AS duration
@@ -160,6 +161,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT0S'    |
 
   Scenario Outline: Should compute duration between two temporals in seconds
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(<lhs>, <rhs>) AS duration
@@ -198,6 +200,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2014-07-21T21:40:36.143+0200') | time('16:30+0100')                       | 'PT-4H-10M-36.143S'   |
 
   Scenario: Should compute duration between if they differ only by a fraction of a second and the first comes after the second.
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(localdatetime('2014-07-21T21:40:36.143'), localdatetime('2014-07-21T21:40:36.142')) AS d
@@ -208,6 +211,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
     And no side effects
 
   Scenario Outline: Should compute negative duration between in big units
+    Given any graph
     When executing query:
       """
       RETURN duration.inMonths(<lhs>, <rhs>) AS duration
@@ -226,6 +230,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime('2018-07-21T21:40:36.143+0500') | datetime('1984-07-21T22:40:36.143+0200') | 'P-33Y-11M' |
 
   Scenario Outline: Should handle durations at daylight saving time day
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(<lhs>, <rhs>) AS duration
@@ -245,6 +250,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime({year: 2017, month: 10, day: 29, hour: 0, timezone: 'Europe/Stockholm'}) | date({year: 2017, month: 10, day: 30})                                            | 'PT25H' |
 
   Scenario: Should handle large durations
+    Given any graph
     When executing query:
       """
       RETURN duration.between(date('-999999999-01-01'), date('+999999999-12-31')) AS duration
@@ -255,6 +261,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
     And no side effects
 
   Scenario: Should handle large durations in seconds
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(localdatetime('-999999999-01-01'), localdatetime('+999999999-12-31T23:59:59')) AS duration
@@ -265,6 +272,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
     And no side effects
 
   Scenario Outline: Should handle when seconds and subseconds have different signs
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(localtime(<lhs>), localtime(<rhs>)) AS duration
@@ -288,6 +296,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | '12:34:54.7' | '12:34:56.3' | 'PT1.6S'      |
 
   Scenario Outline: Should compute durations with no difference
+    Given any graph
     When executing query:
       """
       RETURN duration.inSeconds(<value>, <value>) AS duration
@@ -306,6 +315,7 @@ Feature: Temporal10 - Compute Durations Between two Temporal Values
       | datetime()      |
 
   Scenario Outline: Should propagate null
+    Given any graph
     When executing query:
       """
       RETURN <func>(null, null) AS t

--- a/tck/features/expressions/temporal/Temporal10.feature
+++ b/tck/features/expressions/temporal/Temporal10.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: DurationBetweenAcceptance
+Feature: Temporal10 - Compute Durations Between two Temporal Values
 
   Background:
     Given any graph


### PR DESCRIPTION
One feature file with scenarios on computing durations from temporal values was overlooked when temporal was categorized. This PR fixes this and adds these scenarios to the temporal category as an additional feature. The PR also rolls the background of the original feature file into the scenarios.