### PR TITLE
categorize null operations

### DIFF
--- a/tck/features/expressions/null/Null1.feature
+++ b/tck/features/expressions/null/Null1.feature
@@ -28,9 +28,9 @@
 
 #encoding: utf-8
 
-Feature: NullOperator
+Feature: Null1 - IS NULL validation
 
-  Scenario: Property null check on non-null node
+  Scenario: [1] Property null check on non-null node
     Given an empty graph
     And having executed:
       """
@@ -47,24 +47,7 @@ Feature: NullOperator
       | true              | false            |
     And no side effects
 
-  Scenario: Property not null check on non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      MATCH (n)
-      RETURN n.missing IS NOT NULL,
-             n.exists IS NOT NULL
-      """
-    Then the result should be, in any order:
-      | n.missing IS NOT NULL | n.exists IS NOT NULL |
-      | false                 | true                 |
-    And no side effects
-
-  Scenario: Property null check on optional non-null node
+  Scenario: [2] Property null check on optional non-null node
     Given an empty graph
     And having executed:
       """
@@ -81,24 +64,7 @@ Feature: NullOperator
       | true              | false            |
     And no side effects
 
-  Scenario: Property not null check on optional non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NOT NULL,
-             n.exists IS NOT NULL
-      """
-    Then the result should be, in any order:
-      | n.missing IS NOT NULL | n.exists IS NOT NULL |
-      | false                 | true                 |
-    And no side effects
-
-  Scenario: Property null check on null node
+  Scenario: [3] Property null check on null node
     Given an empty graph
     When executing query:
       """
@@ -110,14 +76,13 @@ Feature: NullOperator
       | true              |
     And no side effects
 
-  Scenario: Property not null check on null node
-    Given an empty graph
+  Scenario: [4] A literal null IS null
+    Given any graph
     When executing query:
       """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NOT NULL
+      RETURN null IS NULL AS value
       """
     Then the result should be, in any order:
-      | n.missing IS NOT NULL |
-      | false                 |
+      | value |
+      | true  |
     And no side effects

--- a/tck/features/expressions/null/Null2.feature
+++ b/tck/features/expressions/null/Null2.feature
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2015-2020 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Null2 - IS NOT NULL validation
+
+  Scenario: [1] Property not null check on non-null node
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({exists: 42})
+      """
+    When executing query:
+      """
+      MATCH (n)
+      RETURN n.missing IS NOT NULL,
+             n.exists IS NOT NULL
+      """
+    Then the result should be, in any order:
+      | n.missing IS NOT NULL | n.exists IS NOT NULL |
+      | false                 | true                 |
+    And no side effects
+
+  Scenario: [2] Property not null check on optional non-null node
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({exists: 42})
+      """
+    When executing query:
+      """
+      OPTIONAL MATCH (n)
+      RETURN n.missing IS NOT NULL,
+             n.exists IS NOT NULL
+      """
+    Then the result should be, in any order:
+      | n.missing IS NOT NULL | n.exists IS NOT NULL |
+      | false                 | true                 |
+    And no side effects
+
+  Scenario: [3] Property not null check on null node
+    Given an empty graph
+    When executing query:
+      """
+      OPTIONAL MATCH (n)
+      RETURN n.missing IS NOT NULL
+      """
+    Then the result should be, in any order:
+      | n.missing IS NOT NULL |
+      | false                 |
+    And no side effects
+
+  Scenario: [4] A literal null is not IS NOT null
+    Given any graph
+    When executing query:
+      """
+      RETURN null IS NOT NULL AS value
+      """
+    Then the result should be, in any order:
+      | value |
+      | false |
+    And no side effects

--- a/tck/features/expressions/null/Null3.feature
+++ b/tck/features/expressions/null/Null3.feature
@@ -28,12 +28,10 @@
 
 #encoding: utf-8
 
-Feature: TernaryLogicAcceptanceTest
+Feature: Null2 - Null evaluation
 
-  Background:
+  Scenario: [1] The inverse of a null is a null
     Given any graph
-
-  Scenario: The inverse of a null is a null
     When executing query:
       """
       RETURN NOT null AS value
@@ -43,27 +41,8 @@ Feature: TernaryLogicAcceptanceTest
       | null  |
     And no side effects
 
-  Scenario: A literal null IS null
-    When executing query:
-      """
-      RETURN null IS NULL AS value
-      """
-    Then the result should be, in any order:
-      | value |
-      | true  |
-    And no side effects
-
-  Scenario: A literal null is not IS NOT null
-    When executing query:
-      """
-      RETURN null IS NOT NULL AS value
-      """
-    Then the result should be, in any order:
-      | value |
-      | false |
-    And no side effects
-
-  Scenario: It is unknown - i.e. null - if a null is equal to a null
+  Scenario: [2] It is unknown - i.e. null - if a null is equal to a null
+    Given any graph
     When executing query:
       """
       RETURN null = null AS value
@@ -73,7 +52,8 @@ Feature: TernaryLogicAcceptanceTest
       | null  |
     And no side effects
 
-  Scenario: It is unknown - i.e. null - if a null is not equal to a null
+  Scenario: [3] It is unknown - i.e. null - if a null is not equal to a null
+    Given any graph
     When executing query:
       """
       RETURN null <> null AS value
@@ -83,7 +63,8 @@ Feature: TernaryLogicAcceptanceTest
       | null  |
     And no side effects
 
-  Scenario Outline: Using null in AND
+  Scenario Outline: [4] Using null in AND
+    Given any graph
     And parameters are:
       | lhs | <lhs> |
       | rhs | <rhs> |
@@ -104,7 +85,8 @@ Feature: TernaryLogicAcceptanceTest
       | null  | false | false  |
       | false | null  | false  |
 
-  Scenario Outline: Using null in OR
+  Scenario Outline: [5] Using null in OR
+    Given any graph
     And parameters are:
       | lhs | <lhs> |
       | rhs | <rhs> |
@@ -125,10 +107,11 @@ Feature: TernaryLogicAcceptanceTest
       | null  | false | null   |
       | false | null  | null   |
 
-  Scenario Outline: Using null in XOR
+  Scenario Outline: [6] Using null in XOR
+    Given any graph
     And parameters are:
-      | lhs    | <lhs>    |
-      | rhs    | <rhs>    |
+      | lhs | <lhs> |
+      | rhs | <rhs> |
     When executing query:
       """
       RETURN $lhs XOR $rhs AS result
@@ -146,10 +129,11 @@ Feature: TernaryLogicAcceptanceTest
       | null  | false | null   |
       | false | null  | null   |
 
-  Scenario Outline: Using null in IN
+  Scenario Outline: [7] Using null in IN
+    Given any graph
     And parameters are:
-      | elt    | <elt>    |
-      | coll   | <coll>   |
+      | elt  | <elt>  |
+      | coll | <coll> |
     When executing query:
       """
       RETURN $elt IN $coll AS result


### PR DESCRIPTION
@hvub 
Null operations categorization:
The scenarios from the feature file `NullOperator.feature` are splitter between `Null1.feature` and `Null2.feature`, according to their appropriate operation. No modifications to the scenario other than numbering.
The scenarios from the feature file `TernaryLogicAcceptance.feature`, in addition to numbering, got the modification of ` given: any graph` as it was the feature file `background` at the origin.
modified scenarios as depicted above:
A literal null IS null
A literal null is not IS NOT null
The inverse of a null is a null
It is unknown - i.e. null - if a null is equal to a null
It is unknown - i.e. null - if a null is not equal to a null
Using null in AND
Using null in OR
Using null in XOR
Using null in IN

