### PR TITLE
Scenario count in percentage in tck browser

### DIFF
--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/TckBrowserWeb.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/TckBrowserWeb.scala
@@ -64,7 +64,7 @@ case class MainRoutes()(implicit val log: cask.Logger) extends cask.Routes with 
       form(action:="/browserPath", method:="get")(
         table(
           tr(
-            td(input(width:=50.em, `type`:="text", name:="path")),
+            td(input(width:=50.em, `type`:="text", name:="path", value:="tck/features")),
             td(input(`type`:="submit", value:="Show")),
           )
         )


### PR DESCRIPTION
This PR has two tiny usability tweaks to the TCK browser 

- In the browse view, it show the percentage of total number of scenario for each category
- On the main page, the path field is prefilled value with the relative path pointing to the TCK of the oC repo the browser was started from