### PR TITLE
Categorize conditional operations

### DIFF
--- a/tck/features/expressions/conditional/Conditional1.feature
+++ b/tck/features/expressions/conditional/Conditional1.feature
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2015-2020 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Conditional1 - Coalesce Expression
+
+  Scenario: Run coalesce
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({name: 'Emil Eifrem', title: 'CEO'}), ({name: 'Nobody'})
+      """
+    When executing query:
+      """
+      MATCH (a)
+      RETURN coalesce(a.title, a.name)
+      """
+    Then the result should be, in any order:
+      | coalesce(a.title, a.name) |
+      | 'CEO'                     |
+      | 'Nobody'                  |
+    And no side effects

--- a/tck/features/expressions/conditional/Conditional2.feature
+++ b/tck/features/expressions/conditional/Conditional2.feature
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2015-2020 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Conditional2 - Case Expression
+

--- a/tck/features/uncategorized/FunctionsAcceptance.feature
+++ b/tck/features/uncategorized/FunctionsAcceptance.feature
@@ -30,23 +30,6 @@
 
 Feature: FunctionsAcceptance
 
-  Scenario: Run coalesce
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name: 'Emil Eifrem', title: 'CEO'}), ({name: 'Nobody'})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      RETURN coalesce(a.title, a.name)
-      """
-    Then the result should be, in any order:
-      | coalesce(a.title, a.name) |
-      | 'CEO'                     |
-      | 'Nobody'                  |
-    And no side effects
-
   Scenario: Functions should return null if they get path containing unbound
     Given any graph
     When executing query:


### PR DESCRIPTION
This categorizes conditional operations. Where is just one scenario for COALESCE and no for CASE WHEN. Hence, fairly trivial PR.