### PR TITLE
Categorize label expression

### DIFF
--- a/tck/features/expressions/graph/Graph10.feature
+++ b/tck/features/expressions/graph/Graph10.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Graph10 - Access all properties as property map
+Feature: Graph10 - Retrieve all properties as a property map
 
   Scenario: [1] `properties()` on a node
     Given an empty graph

--- a/tck/features/expressions/graph/Graph5.feature
+++ b/tck/features/expressions/graph/Graph5.feature
@@ -55,7 +55,7 @@ Feature: Graph5 - Node and edge label expressions
     And no side effects
 
   # This scenario does not work in Cypher. Although that is a little bit odd.
-  @ignore
+  @ignore @skipStyleCheck
   Scenario: [2] Single-labels expression on relationships
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/graph/Graph5.feature
+++ b/tck/features/expressions/graph/Graph5.feature
@@ -54,30 +54,31 @@ Feature: Graph5 - Node and edge label expressions
       | ()       | false  |
     And no side effects
 
-## This scenario does not work in Cypher. Although that is a little bit odd.
-#  Scenario: [2] Single-labels expression on relationships
-#    Given an empty graph
-#    And having executed:
-#      """
-#      CREATE ()-[:T1]->(),
-#             ()-[:T2]->(),
-#             ()-[:t2]->(),
-#             (:T2)-[:T3]->(),
-#             ()-[:T4]->(:T2)
-#      """
-#    When executing query:
-#      """
-#      MATCH ()-[r]->()
-#      RETURN r, r:T2 AS result
-#      """
-#    Then the result should be, in any order:
-#      | r     | result |
-#      | [:T1] | false  |
-#      | [:T2] | true   |
-#      | [:t2] | false  |
-#      | [:T3] | false  |
-#      | [:T4] | false  |
-#    And no side effects
+  # This scenario does not work in Cypher. Although that is a little bit odd.
+  @ignore
+  Scenario: [2] Single-labels expression on relationships
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:T1]->(),
+             ()-[:T2]->(),
+             ()-[:t2]->(),
+             (:T2)-[:T3]->(),
+             ()-[:T4]->(:T2)
+      """
+    When executing query:
+      """
+      MATCH ()-[r]->()
+      RETURN r, r:T2 AS result
+      """
+    Then the result should be, in any order:
+      | r     | result |
+      | [:T1] | false  |
+      | [:T2] | true   |
+      | [:t2] | false  |
+      | [:T3] | false  |
+      | [:T4] | false  |
+    And no side effects
 
   Scenario: [3] Conjunctive labels expression on nodes
     Given an empty graph

--- a/tck/features/expressions/graph/Graph6.feature
+++ b/tck/features/expressions/graph/Graph6.feature
@@ -28,51 +28,5 @@
 
 #encoding: utf-8
 
-Feature: Graph6 - Dynamic property access
-  # Accessing a property of a node or edge by using a dynamically-computed string value as the key; e.g. allowing for the key to be passed in as a parameter
-
-  Scenario: [1] Execute n['name'] in read queries
-    Given any graph
-    And having executed:
-      """
-      CREATE ({name: 'Apa'})
-      """
-    When executing query:
-      """
-      MATCH (n {name: 'Apa'})
-      RETURN n['nam' + 'e'] AS value
-      """
-    Then the result should be, in any order:
-      | value |
-      | 'Apa' |
-    And no side effects
-
-  Scenario: [2] Execute n['name'] in update queries
-    Given any graph
-    When executing query:
-      """
-      CREATE (n {name: 'Apa'})
-      RETURN n['nam' + 'e'] AS value
-      """
-    Then the result should be, in any order:
-      | value |
-      | 'Apa' |
-    And the side effects should be:
-      | +nodes      | 1 |
-      | +properties | 1 |
-
-  Scenario: [3] Use dynamic property lookup based on parameters when there is lhs type information
-    Given any graph
-    And parameters are:
-      | idx | 'name' |
-    When executing query:
-      """
-      CREATE (n {name: 'Apa'})
-      RETURN n[$idx] AS value
-      """
-    Then the result should be, in any order:
-      | value |
-      | 'Apa' |
-    And the side effects should be:
-      | +nodes      | 1 |
-      | +properties | 1 |
+Feature: Graph6 - Static property access
+  # Accessing a property of a node or edge by using a symbolic name as the key.

--- a/tck/features/expressions/graph/Graph7.feature
+++ b/tck/features/expressions/graph/Graph7.feature
@@ -28,125 +28,51 @@
 
 #encoding: utf-8
 
-Feature: Graph7 - Node properties keys
+Feature: Graph7 - Dynamic property access
+  # Accessing a property of a node or edge by using a dynamically-computed string value as the key; e.g. allowing for the key to be passed in as a parameter
 
-  Scenario: [1] Using `keys()` on a single node, non-empty result
-    Given an empty graph
+  Scenario: [1] Execute n['name'] in read queries
+    Given any graph
     And having executed:
       """
-      CREATE ({name: 'Andres', surname: 'Lopez'})
+      CREATE ({name: 'Apa'})
       """
     When executing query:
       """
-      MATCH (n)
-      UNWIND keys(n) AS x
-      RETURN DISTINCT x AS theProps
+      MATCH (n {name: 'Apa'})
+      RETURN n['nam' + 'e'] AS value
       """
     Then the result should be, in any order:
-      | theProps  |
-      | 'name'    |
-      | 'surname' |
+      | value |
+      | 'Apa' |
     And no side effects
 
-  Scenario: [2] Using `keys()` on multiple nodes, non-empty result
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name: 'Andres', surname: 'Lopez'}),
-             ({otherName: 'Andres', otherSurname: 'Lopez'})
-      """
+  Scenario: [2] Execute n['name'] in update queries
+    Given any graph
     When executing query:
       """
-      MATCH (n)
-      UNWIND keys(n) AS x
-      RETURN DISTINCT x AS theProps
+      CREATE (n {name: 'Apa'})
+      RETURN n['nam' + 'e'] AS value
       """
     Then the result should be, in any order:
-      | theProps       |
-      | 'name'         |
-      | 'surname'      |
-      | 'otherName'    |
-      | 'otherSurname' |
-    And no side effects
+      | value |
+      | 'Apa' |
+    And the side effects should be:
+      | +nodes      | 1 |
+      | +properties | 1 |
 
-  Scenario: [3] Using `keys()` on a single node, empty result
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()
-      """
+  Scenario: [3] Use dynamic property lookup based on parameters when there is lhs type information
+    Given any graph
+    And parameters are:
+      | idx | 'name' |
     When executing query:
       """
-      MATCH (n)
-      UNWIND keys(n) AS x
-      RETURN DISTINCT x AS theProps
+      CREATE (n {name: 'Apa'})
+      RETURN n[$idx] AS value
       """
     Then the result should be, in any order:
-      | theProps |
-    And no side effects
-
-  Scenario: [4] Using `keys()` on an optionally matched node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()
-      """
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      UNWIND keys(n) AS x
-      RETURN DISTINCT x AS theProps
-      """
-    Then the result should be, in any order:
-      | theProps |
-    And no side effects
-
-  Scenario: [5] Using `keys()` on a relationship, non-empty result
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()-[:KNOWS {status: 'bad', year: '2015'}]->()
-      """
-    When executing query:
-      """
-      MATCH ()-[r:KNOWS]-()
-      UNWIND keys(r) AS x
-      RETURN DISTINCT x AS theProps
-      """
-    Then the result should be, in any order:
-      | theProps |
-      | 'status' |
-      | 'year'   |
-    And no side effects
-
-  Scenario: [6] Using `keys()` on a relationship, empty result
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()-[:KNOWS]->()
-      """
-    When executing query:
-      """
-      MATCH ()-[r:KNOWS]-()
-      UNWIND keys(r) AS x
-      RETURN DISTINCT x AS theProps
-      """
-    Then the result should be, in any order:
-      | theProps |
-    And no side effects
-
-  Scenario: [7] Using `keys()` on an optionally matched relationship
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ()-[:KNOWS]->()
-      """
-    When executing query:
-      """
-      OPTIONAL MATCH ()-[r:KNOWS]-()
-      UNWIND keys(r) AS x
-      RETURN DISTINCT x AS theProps
-      """
-    Then the result should be, in any order:
-      | theProps |
-    And no side effects
+      | value |
+      | 'Apa' |
+    And the side effects should be:
+      | +nodes      | 1 |
+      | +properties | 1 |

--- a/tck/features/expressions/graph/Graph8.feature
+++ b/tck/features/expressions/graph/Graph8.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Graph8 - Properties keys function
+Feature: Graph8 - Property keys function
 
   Scenario: [1] Using `keys()` on a single node, non-empty result
     Given an empty graph

--- a/tck/features/expressions/graph/Graph8.feature
+++ b/tck/features/expressions/graph/Graph8.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Graph8 - Node properties keys
+Feature: Graph8 - Properties keys function
 
   Scenario: [1] Using `keys()` on a single node, non-empty result
     Given an empty graph

--- a/tck/features/expressions/graph/Graph9.feature
+++ b/tck/features/expressions/graph/Graph9.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Graph9 - Check if a property exists on a node or an edge
+Feature: Graph9 - Property existence check
 
   Scenario: [1] `exists()` with dynamic property lookup
     Given an empty graph

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Map3 - Keys Function
+Feature: Map3 - Keys function
 
   Scenario: [1] Using `keys()` on a literal map
     Given any graph

--- a/tck/features/expressions/map/Map4.feature
+++ b/tck/features/expressions/map/Map4.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Map4 - Check if a field exists on a map
+Feature: Map4 - Field existence check
 
   Scenario Outline: [1] `exists()` with literal maps
     Given any graph


### PR DESCRIPTION
This PR is based on [PR444](https://github.com/opencypher/openCypher/pull/444) and should be merged after it.

The actual changes of this PR over 444 start with commit 4bcced6 and concern the addition of [Graph5.feature](tck/features/expressions/graph/Graph5.feature) with a few scenarios for label expressions on node and edge variables, i.e. expression of the form `n:Label`.

Note that scenario [Graph5.[2]](https://github.com/opencypher/openCypher/compare/master...hvub:categorize-label-expression?expand=1#diff-ed21ee603c458138d3adb56e7f63853bR57) is currently not valid in Cypher, hence, the `@ignore` tag. It may be activated by removing the tag, in case Cypher adopts label expressions for relationship variables in some future.