### PR TITLE
Browse and Diff TCK PRs by PR number

### DIFF
--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/TckBrowserWeb.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/TckBrowserWeb.scala
@@ -117,14 +117,12 @@ case class MainRoutes()(implicit val log: cask.Logger) extends cask.Routes with 
       form(action:="/diffRepositoryPR", method:="get")(
         table(
           tr(
-            td(),
             td("Repository"),
             td("PR#"),
             td("Subpath"),
             td(),
           ),
           tr(
-            td(CSS.tckCollection)(BeforeCollection.toString),
             td(input(width:=25.em, `type`:="text", name:="repo", value:="https://github.com/openCypher/openCypher")),
             td(input(width:=10.em, `type`:="text", name:="pr", value:="")),
             td(input(width:=15.em, `type`:="text", name:="subPath", value:="tck/features")),

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/util/CallingSystemProcesses.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/util/CallingSystemProcesses.scala
@@ -51,14 +51,26 @@ object CallingSystemProcesses {
   }
 
   def checkoutRepoCommit(repositoryUrl: String, commit: String, localDirectory: String): ProcessReturn = {
-    val gitCloneCmdSeq =  Seq("git", "clone", repositoryUrl, localDirectory)
-    val gitFetchCmdSeq =  Seq("git", "-C", localDirectory, "fetch")
-    val gitCheckoutCmdSeq =  Seq("git", "-C", localDirectory, "checkout", commit)
+    val gitCloneCmdSeq = Seq("git", "clone", repositoryUrl, localDirectory)
+    val gitFetchCmdSeq = Seq("git", "-C", localDirectory, "fetch")
+    val gitCheckoutCmdSeq = Seq("git", "-C", localDirectory, "checkout", commit)
 
+    cloneFetchCheckout(gitCloneCmdSeq, gitFetchCmdSeq, gitCheckoutCmdSeq)
+  }
+
+  def checkoutMergedPR(repositoryUrl: String, pr: String, localDirectory: String): ProcessReturn = {
+    val gitCloneCmdSeq = Seq("git", "clone", repositoryUrl, localDirectory)
+    val gitFetchCmdSeq = Seq("git", "-C", localDirectory, "fetch", "origin", s"+refs/pull/$pr/merge")
+    val gitCheckoutCmdSeq = Seq("git", "-C", localDirectory, "checkout", "-qf", "FETCH_HEAD")
+
+    cloneFetchCheckout(gitCloneCmdSeq, gitFetchCmdSeq, gitCheckoutCmdSeq)
+  }
+
+  private def cloneFetchCheckout(gitCloneCmdSeq: Seq[String], gitFetchCmdSeq: Seq[String], gitCheckoutCmdSeq: Seq[String]): ProcessReturn = {
     val cmd =
       gitCloneCmdSeq #&&
-      gitFetchCmdSeq #&&
-      gitCheckoutCmdSeq
+        gitFetchCmdSeq #&&
+        gitCheckoutCmdSeq
     val out = ArrayBuffer[String]()
     val err = ArrayBuffer[String]()
     val logger = ProcessLogger(line => out += line, line => err += line)
@@ -67,7 +79,7 @@ object CallingSystemProcesses {
 
     ProcessReturn(exitCode, out, err,
       gitCloneCmdSeq.mkString(" ") + "&&" +
-      gitFetchCmdSeq.mkString(" ") + "&&" +
-      gitCheckoutCmdSeq.mkString(" "))
+        gitFetchCmdSeq.mkString(" ") + "&&" +
+        gitCheckoutCmdSeq.mkString(" "))
   }
 }


### PR DESCRIPTION
This PR extends the TCK Browser to so that TCK PR can be directly browsed and diffed by their PR number.

![TCKDiffPR](https://user-images.githubusercontent.com/30618026/95181624-d516f200-07c3-11eb-8cfd-6a61b8d836e6.png)

Browsing a PR, shows PR merged into the repository's HEAD (`+refs/pull/<pr number>/merge`). Diffing a PR, diffs the merged PR against the HEAD. This greatly simplifies PR reviewing, particularly if multiple PR are in flight at the same time.