### PR TITLE
Categorize triadic selection

### DIFF
--- a/tck/features/useCases/triadicSelection/TriadicSelection1.feature
+++ b/tck/features/useCases/triadicSelection/TriadicSelection1.feature
@@ -28,9 +28,9 @@
 
 #encoding: utf-8
 
-Feature: TriadicSelection
+Feature: TriadicSelection1 - Query three related nodes on binary-tree graphs
 
-  Scenario: Handling triadic friend of a friend
+  Scenario: [1] Handling triadic friend of a friend
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -47,7 +47,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend
+  Scenario: [2] Handling triadic friend of a friend that is not a friend
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -65,7 +65,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with different relationship type
+  Scenario: [3] Handling triadic friend of a friend that is not a friend with different relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -83,7 +83,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with superset of relationship type
+  Scenario: [4] Handling triadic friend of a friend that is not a friend with superset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -100,7 +100,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with implicit subset of relationship type
+  Scenario: [5] Handling triadic friend of a friend that is not a friend with implicit subset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -123,7 +123,7 @@ Feature: TriadicSelection
       | 'c42'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with explicit subset of relationship type
+  Scenario: [6] Handling triadic friend of a friend that is not a friend with explicit subset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -146,7 +146,7 @@ Feature: TriadicSelection
       | 'c42'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with same labels
+  Scenario: [7] Handling triadic friend of a friend that is not a friend with same labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -162,7 +162,7 @@ Feature: TriadicSelection
       | 'c21'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with different labels
+  Scenario: [8] Handling triadic friend of a friend that is not a friend with different labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -177,7 +177,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with implicit subset of labels
+  Scenario: [9] Handling triadic friend of a friend that is not a friend with implicit subset of labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -193,7 +193,7 @@ Feature: TriadicSelection
       | 'c21'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is not a friend with implicit superset of labels
+  Scenario: [10] Handling triadic friend of a friend that is not a friend with implicit superset of labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -211,7 +211,7 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend
+  Scenario: [11] Handling triadic friend of a friend that is a friend
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -225,7 +225,7 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with different relationship type
+  Scenario: [12] Handling triadic friend of a friend that is a friend with different relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -239,7 +239,7 @@ Feature: TriadicSelection
       | 'b3'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with superset of relationship type
+  Scenario: [13] Handling triadic friend of a friend that is a friend with superset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -254,7 +254,7 @@ Feature: TriadicSelection
       | 'b3'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with implicit subset of relationship type
+  Scenario: [14] Handling triadic friend of a friend that is a friend with implicit subset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -269,7 +269,7 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with explicit subset of relationship type
+  Scenario: [15] Handling triadic friend of a friend that is a friend with explicit subset of relationship type
     Given the binary-tree-1 graph
     When executing query:
       """
@@ -284,7 +284,7 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with same labels
+  Scenario: [16] Handling triadic friend of a friend that is a friend with same labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -298,7 +298,7 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with different labels
+  Scenario: [17] Handling triadic friend of a friend that is a friend with different labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -311,7 +311,7 @@ Feature: TriadicSelection
       | c.name |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with implicit subset of labels
+  Scenario: [18] Handling triadic friend of a friend that is a friend with implicit subset of labels
     Given the binary-tree-2 graph
     When executing query:
       """
@@ -325,7 +325,7 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-  Scenario: Handling triadic friend of a friend that is a friend with implicit superset of labels
+  Scenario: [19] Handling triadic friend of a friend that is a friend with implicit superset of labels
     Given the binary-tree-2 graph
     When executing query:
       """


### PR DESCRIPTION
This PR categorizes scenarios from `TriadicSelection.feature`. These scenarios are not primarily language feature motivated, but rather formulated around a use case. It seems worthwhile to have a special category for such scenarios. Hence the scenarios are categorized under `/useCases/triadicSelection/TriadicSelection1.feature`. Otherwise, the change is straighforward.