### PR TITLE
Categorize more negative scenarios

### DIFF
--- a/tck/features/clauses/match/Match1.feature
+++ b/tck/features/clauses/match/Match1.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Match1 - Match Nodes scenarios
+Feature: Match1 - Match nodes
 
   Scenario: [1] Match non-existent nodes returns empty
     Given an empty graph
@@ -119,3 +119,13 @@ Feature: Match1 - Match Nodes scenarios
       | 3 | 1 |
       | 3 | 2 |
     And no side effects
+
+  @NegativeTest
+  Scenario: [6] Fail when using parameter as node predicate in MATCH
+    Given any graph
+    When executing query:
+      """
+      MATCH (n $param)
+      RETURN n
+      """
+    Then a SyntaxError should be raised at compile time: InvalidParameterUse

--- a/tck/features/clauses/match/Match1.feature
+++ b/tck/features/clauses/match/Match1.feature
@@ -129,3 +129,14 @@ Feature: Match1 - Match nodes
       RETURN n
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
+
+  @NegativeTest
+  Scenario: [7] Fail when a relationship is used as a node
+    Given any graph
+    When executing query:
+      """
+      MATCH ()-[r]-()
+      MATCH (r)
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: VariableTypeConflict

--- a/tck/features/clauses/match/Match2.feature
+++ b/tck/features/clauses/match/Match2.feature
@@ -141,3 +141,14 @@ Feature: Match2 - Match relationships
       RETURN r
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
+
+  @NegativeTest
+  Scenario: [8] Fail when a node is used as a relationship
+    Given any graph
+    When executing query:
+      """
+      MATCH (r)
+      MATCH ()-[r]-()
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: VariableTypeConflict

--- a/tck/features/clauses/match/Match2.feature
+++ b/tck/features/clauses/match/Match2.feature
@@ -143,12 +143,33 @@ Feature: Match2 - Match relationships
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: [8] Fail when a node is used as a relationship
+  Scenario Outline: [8] Fail when a node or a path is used as a relationship
     Given any graph
     When executing query:
       """
-      MATCH (r)
+      MATCH <pattern>
       MATCH ()-[r]-()
       RETURN r
       """
     Then a SyntaxError should be raised at compile time: VariableTypeConflict
+
+    Examples:
+      | pattern      |
+      | (r)          |
+      | r = ()-[]-() |
+
+  @NegativeTest
+  Scenario Outline: [9] Fail when a relationship and a node have the same variable
+    Given any graph
+    When executing query:
+      """
+      MATCH <pattern>
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: VariableTypeConflict
+
+    Examples:
+      | pattern     |
+      | (r)-[r]-()  |
+      | ()-[r]-(r)  |
+      | (r)-[r]-(r) |

--- a/tck/features/clauses/match/Match2.feature
+++ b/tck/features/clauses/match/Match2.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Match2 - Match relationships scenarios
+Feature: Match2 - Match relationships
 
   Scenario: [1] Match non-existent relationships returns empty
     Given an empty graph
@@ -131,3 +131,13 @@ Feature: Match2 - Match relationships scenarios
       | [:KNOWS] |
       | [:HATES] |
     And no side effects
+
+  @NegativeTest
+  Scenario: [7] Fail when using parameter as relationship predicate in MATCH
+    Given any graph
+    When executing query:
+      """
+      MATCH ()-[r:FOO $param]->()
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: InvalidParameterUse

--- a/tck/features/clauses/match/Match3.feature
+++ b/tck/features/clauses/match/Match3.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Match3 - Match fixed length patterns scenarios
+Feature: Match3 - Match fixed length patterns
 
   Scenario: [1] Get neighbours
     Given an empty graph
@@ -517,3 +517,13 @@ Feature: Match3 - Match fixed length patterns scenarios
     Then the result should be, in any order:
       | b |
     And no side effects
+
+  @NegativeTest
+  Scenario: [27] Fail when re-using a relationship in the same pattern
+    Given any graph
+    When executing query:
+      """
+      MATCH (a)-[r]->()-[r]->(a)
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: RelationshipUniquenessViolation

--- a/tck/features/clauses/match/Match6.feature
+++ b/tck/features/clauses/match/Match6.feature
@@ -386,3 +386,126 @@ Feature: Match6 - Match named paths scenarios
       | <({name: 'A'})-[:KNOWS]->({name: 'B'})>                         |
       | <({name: 'A'})-[:KNOWS]->({name: 'B'})-[:KNOWS]->({name: 'C'})> |
     And no side effects
+
+  @NegativeTest
+  Scenario Outline: [21] Fail when a node has the same variable in a preceding MATCH
+    Given any graph
+    When executing query:
+      """
+      MATCH <pattern>
+      MATCH p = ()-[]-()
+      RETURN p
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+    Examples:
+      | pattern                               |
+      | (p)-[]-()                             |
+      | (p)-[]->()                            |
+      | (p)<-[]-()                            |
+      | ()-[]-(p)                             |
+      | ()-[]->(p)                            |
+      | ()<-[]-(p)                            |
+      | (p)-[]-(), ()                         |
+      | ()-[]-(p), ()                         |
+      | (p)-[]-()-[]-()                       |
+      | ()-[]-(p)-[]-()                       |
+      | ()-[]-()-[]-(p)                       |
+      | (a)-[r]-(p)-[]->(b), (t), (t)-[*]-(b) |
+      | (a)-[r*]-(s)-[]-(b), (p), (t)-[]-(b)  |
+      | (a)-[r]-(p)<-[*]-(b), (t), (t)-[]-(b) |
+
+  @NegativeTest
+  Scenario Outline: [22] Fail when a relationship has the same variable in a preceding MATCH
+    Given any graph
+    When executing query:
+      """
+      MATCH <pattern>
+      MATCH p = ()-[]-()
+      RETURN p
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+    Examples:
+      | pattern                               |
+      | ()-[p]-()                             |
+      | ()-[p]->()                            |
+      | ()<-[p]-()                            |
+      | ()-[p*]-()                            |
+      | ()-[p*]->()                           |
+      | ()<-[p*]-()                           |
+      | ()-[p]-(), ()                         |
+      | ()-[p*]-(), ()                        |
+      | ()-[p]-()-[]-()                       |
+      | ()-[p*]-()-[]-()                      |
+      | ()-[]-()-[p]-()                       |
+      | ()-[]-()-[p*]-()                      |
+      | (a)-[r]-()-[]->(b), (t), (t)-[p*]-(b) |
+      | (a)-[r*]-(s)-[p]-(b), (t), (t)-[]-(b) |
+      | (a)-[r]-(s)<-[p]-(b), (t), (t)-[]-(b) |
+
+  @NegativeTest
+  Scenario Outline: [23] Fail when a node has the same variable in the same pattern
+    Given any graph
+    When executing query:
+      """
+      MATCH <pattern>
+      RETURN p
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+    Examples:
+      | pattern                                               |
+      | p = (p)-[]-()                                         |
+      | p = (p)-[]->()                                        |
+      | p = (p)<-[]-()                                        |
+      | p = ()-[]-(p)                                         |
+      | p = ()-[]->(p)                                        |
+      | p = ()<-[]-(p)                                        |
+      | (p)-[]-(), p = ()-[]-()                               |
+      | (p)-[]->(), p = ()-[]-()                              |
+      | (p)<-[]-(), p = ()-[]-()                              |
+      | ()-[]-(p), p = ()-[]-()                               |
+      | ()-[]->(p), p = ()-[]-()                              |
+      | ()<-[]-(p), p = ()-[]-()                              |
+      | (p)-[]-(), (), p = ()-[]-()                           |
+      | ()-[p]-(), (), p = ()-[]-()                           |
+      | ()-[]-(p), (), p = ()-[]-()                           |
+      | (p)-[]-()-[]-(), p = ()-[]-()                         |
+      | ()-[]-(p)-[]-(), p = ()-[]-()                         |
+      | ()-[]-()-[]-(p), p = ()-[]-()                         |
+      | (a)-[r]-(p)-[]-(b), p = (s)-[]-(t), (t), (t)-[]-(b)   |
+      | (a)-[r]-(p)<-[*]-(b), p = (s)-[]-(t), (t), (t)-[]-(b) |
+
+  @NegativeTest
+  Scenario Outline: [24] Fail when a relationship has the same variable in the same pattern
+    Given any graph
+    When executing query:
+      """
+      MATCH <pattern>
+      RETURN p
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+    Examples:
+      | pattern                                                |
+      | p = ()-[p]-()                                          |
+      | p = ()-[p]->()                                         |
+      | p = ()<-[p]-()                                         |
+      | p = ()-[p*]-()                                         |
+      | p = ()-[p*]->()                                        |
+      | p = ()<-[p*]-()                                        |
+      | ()-[p]-(), p = ()-[]-()                                |
+      | ()-[p]->(), p = ()-[]-()                               |
+      | ()<-[p]-(), p = ()-[]-()                               |
+      | ()-[p*]-(), p = ()-[]-()                               |
+      | ()-[p*]->(), p = ()-[]-()                              |
+      | ()<-[p*]-(), p = ()-[]-()                              |
+      | ()-[p]-(), (), p = ()-[]-()                            |
+      | ()-[p*]-(), (), p = ()-[]-()                           |
+      | ()-[p]-()-[]-(), p = ()-[]-()                          |
+      | ()-[p*]-()-[]-(), p = ()-[]-()                         |
+      | ()-[]-()-[p]-(), p = ()-[]-()                          |
+      | ()-[]-()-[p*]-(), p = ()-[]-()                         |
+      | (a)-[r]-(s)-[p]-(b), p = (s)-[]-(t), (t), (t)-[]-(b)   |
+      | (a)-[r]-(s)<-[p*]-(b), p = (s)-[]-(t), (t), (t)-[]-(b) |

--- a/tck/features/clauses/merge/Merge1.feature
+++ b/tck/features/clauses/merge/Merge1.feature
@@ -288,3 +288,13 @@ Feature: Merge1 - Merge Node
       MERGE (a)
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  @NegativeTest
+  Scenario: [15] Fail when using parameter as node predicate in MERGE
+    Given any graph
+    When executing query:
+      """
+      MERGE (n $param)
+      RETURN n
+      """
+    Then a SyntaxError should be raised at compile time: InvalidParameterUse

--- a/tck/features/clauses/merge/Merge1.feature
+++ b/tck/features/clauses/merge/Merge1.feature
@@ -278,3 +278,13 @@ Feature: Merge1 - Merge Node
       | +nodes      | 1 |
       | -nodes      | 2 |
       | -properties | 2 |
+
+  @NegativeTest
+  Scenario: [14] Fail when merge a node that is already bound
+    Given any graph
+    When executing query:
+      """
+      MATCH (a)
+      MERGE (a)
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound

--- a/tck/features/clauses/merge/Merge2.feature
+++ b/tck/features/clauses/merge/Merge2.feature
@@ -112,3 +112,13 @@ Feature: Merge2 - Merge Node - On Create
       | +nodes      | 1 |
       | +labels     | 1 |
       | +properties | 1 |
+
+  @NegativeTest
+  Scenario: [6] Fail when using undefined variable in ON CREATE
+    Given any graph
+    When executing query:
+      """
+      MERGE (n)
+        ON CREATE SET x.num = 1
+      """
+    Then a SyntaxError should be raised at compile time: UndefinedVariable

--- a/tck/features/clauses/merge/Merge3.feature
+++ b/tck/features/clauses/merge/Merge3.feature
@@ -103,3 +103,13 @@ Feature: Merge3 - Merge Node - On Match
       | +nodes      | 1 |
       | +labels     | 1 |
       | +properties | 1 |
+
+  @NegativeTest
+  Scenario: [5] Fail when using undefined variable in ON MATCH
+    Given any graph
+    When executing query:
+      """
+      MERGE (n)
+        ON MATCH SET x.num = 1
+      """
+    Then a SyntaxError should be raised at compile time: UndefinedVariable

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -482,3 +482,13 @@ Feature: Merge5 - Merge relationships
       MERGE (a)-[:A|:B]->(b)
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
+
+  @NegativeTest
+  Scenario: [26] Fail when merging relationship that is already bound
+    Given any graph
+    When executing query:
+      """
+      MATCH (a)-[r]->(b)
+      MERGE (a)-[r]->(b)
+      """
+    Then a SyntaxError should be raised at compile time: VariableAlreadyBound

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -504,3 +504,14 @@ Feature: Merge5 - Merge relationships
       RETURN r
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
+
+  @NegativeTest
+  Scenario: [28] Fail when using variable length relationship in MERGE
+    Given any graph
+    When executing query:
+      """
+      MERGE (a)
+      MERGE (b)
+      MERGE (a)-[:FOO*2]->(b)
+      """
+    Then a SyntaxError should be raised at compile time: CreatingVarLength

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -494,7 +494,7 @@ Feature: Merge5 - Merge relationships
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   @NegativeTest
-  Scenario: Failing when using parameter as relationship predicate in MERGE
+  Scenario: [27] Fail when using parameter as relationship predicate in MERGE
     Given any graph
     When executing query:
       """

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Merge5 - Merge Relationships
+Feature: Merge5 - Merge relationships
 
   Scenario: [1] Creating a relationship
     Given an empty graph
@@ -452,3 +452,33 @@ Feature: Merge5 - Merge Relationships
       MERGE (a)-[r:KNOWS]->(a:Bar)
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  @NegativeTest
+  Scenario: [23] Fail when merging relationship without type
+    Given any graph
+    When executing query:
+      """
+      CREATE (a), (b)
+      MERGE (a)-->(b)
+      """
+    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
+
+  @NegativeTest
+  Scenario: [24] Fail when merging relationship without type, no colon
+    Given any graph
+    When executing query:
+      """
+      MATCH (a), (b)
+      MERGE (a)-[NO_COLON]->(b)
+      """
+    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
+
+  @NegativeTest
+  Scenario: [25] Fail when merging relationship with more than one type
+    Given any graph
+    When executing query:
+      """
+      CREATE (a), (b)
+      MERGE (a)-[:A|:B]->(b)
+      """
+    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -492,3 +492,15 @@ Feature: Merge5 - Merge relationships
       MERGE (a)-[r]->(b)
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  @NegativeTest
+  Scenario: Failing when using parameter as relationship predicate in MERGE
+    Given any graph
+    When executing query:
+      """
+      MERGE (a)
+      MERGE (b)
+      MERGE (a)-[r:FOO $param]->(b)
+      RETURN r
+      """
+    Then a SyntaxError should be raised at compile time: InvalidParameterUse

--- a/tck/features/expressions/boolean/Boolean4.feature
+++ b/tck/features/expressions/boolean/Boolean4.feature
@@ -46,3 +46,20 @@ Feature: Boolean4 - NOT logical operations
       | n             |
       | ({name: 'a'}) |
     And no side effects
+
+  @NegativeTest
+  Scenario Outline: [2] Fail when using NOT on a non-boolean literal
+    Given any graph
+    When executing query:
+      """
+      RETURN NOT <literal>
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | literal       |
+      | 123           |
+      | 123.4         |
+      | 'foo'         |
+    # | [true, false] | current Neo4j return true on an empty list and false on any other list
+      | {bool: true}  |

--- a/tck/features/expressions/graph/Graph4.feature
+++ b/tck/features/expressions/graph/Graph4.feature
@@ -135,3 +135,13 @@ Feature: Graph4 - Edge relationship type
       | true    |
       | ''      |
       | []      |
+
+  @NegativeTest
+  Scenario: Failing when using `type()` on a node
+    Given any graph
+    When executing query:
+      """
+      MATCH (r)
+      RETURN type(r)
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/expressions/graph/Graph6.feature
+++ b/tck/features/expressions/graph/Graph6.feature
@@ -30,3 +30,14 @@
 
 Feature: Graph6 - Static property access
   # Accessing a property of a node or edge by using a symbolic name as the key.
+
+  @NegativeTest
+  Scenario: [1] Fail when performing property access on a non-graph element
+    Given any graph
+    When executing query:
+      """
+      CREATE (n {name: 'foo'})
+      WITH n.name AS n2
+      RETURN n2.name
+      """
+    Then a TypeError should be raised at runtime: PropertyAccessOnNonMap

--- a/tck/features/expressions/graph/Graph9.feature
+++ b/tck/features/expressions/graph/Graph9.feature
@@ -110,3 +110,13 @@ Feature: Graph9 - Property existence check
       | exists(n.missing) |
       | null              |
     And no side effects
+
+  @NegativeTest
+  Scenario: [6] Fail when checking existence of a non-property and non-pattern
+    Given any graph
+    When executing query:
+      """
+      MATCH (n)
+      RETURN exists(n.num + 1)
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentExpression

--- a/tck/features/expressions/list/List11.feature
+++ b/tck/features/expressions/list/List11.feature
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2015-2020 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: List11 - Create a list for a range - `range()` function
+
+  @NegativeTest
+  Scenario: [1] Bad arguments for `range()`
+    Given any graph
+    When executing query:
+      """
+      RETURN range(2, 8, 0)
+      """
+    Then a ArgumentError should be raised at runtime: NumberOutOfRange

--- a/tck/features/expressions/list/List11.feature
+++ b/tck/features/expressions/list/List11.feature
@@ -142,3 +142,13 @@ Feature: List11 - List Comprehension
       | b    |
       | (:C) |
     And no side effects
+
+  @NegativeTest
+  Scenario: [7] Fail when using aggregation in list comprehension
+    Given any graph
+    When executing query:
+      """
+      MATCH (n)
+      RETURN [x IN [1, 2, 3, 4, 5] | count(*)]
+      """
+    Then a SyntaxError should be raised at compile time: InvalidAggregation

--- a/tck/features/expressions/list/List12.feature
+++ b/tck/features/expressions/list/List12.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: List11 - List Comprehension
+Feature: List12 - List Comprehension
 
   Scenario: [1] Collect and extract using a list comprehension
     Given an empty graph

--- a/tck/features/expressions/list/List5.feature
+++ b/tck/features/expressions/list/List5.feature
@@ -486,3 +486,20 @@ Feature: List5 - List Membership Validation - IN Operator
       | res  |
       | true |
     And no side effects
+
+  @NegativeTest
+  Scenario Outline: [42] Failing when using IN on a non-list literal
+    Given any graph
+    When executing query:
+      """
+      RETURN 1 IN <invalid>
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | invalid |
+      | true    |
+      | 123     |
+      | 123.4   |
+      | 'foo'   |
+      | {x: []} |

--- a/tck/features/expressions/list/List6.feature
+++ b/tck/features/expressions/list/List6.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: List6 - List Size
+Feature: List6 - List size
 
   Scenario: [1] Return list size
     Given any graph

--- a/tck/features/expressions/list/List6.feature
+++ b/tck/features/expressions/list/List6.feature
@@ -81,3 +81,13 @@ Feature: List6 - List Size
       | size(l) | size(null) |
       | null    | null       |
     And no side effects
+
+  @NegativeTest
+  Scenario: [5] Fail for `size()` on paths
+    Given any graph
+    When executing query:
+      """
+      MATCH p = (a)-[*]->(b)
+      RETURN size(p)
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/expressions/literals/Literals5.feature
+++ b/tck/features/expressions/literals/Literals5.feature
@@ -315,3 +315,12 @@ Feature: Literals5 - Float
       | literal        |
       | 1.23456789e308 |
     And no side effects
+
+  @NegativeTest
+  Scenario: [27] Fail when float value is too large
+    Given any graph
+    When executing query:
+      """
+      RETURN 1.34E999
+      """
+    Then a SyntaxError should be raised at compile time: FloatingPointOverflow

--- a/tck/features/expressions/map/Map1.feature
+++ b/tck/features/expressions/map/Map1.feature
@@ -28,5 +28,15 @@
 
 #encoding: utf-8
 
-Feature: Map1 - Static Value Access
-# Static value access refers to the dot-operator – <expression resulting in a map>.<identify> – which does not allow any dynamic computation of the map key – i.e. <identify>.
+Feature: Map1 - Static value access
+# Static value access refers to the dot-operator – <expression resulting in a map>.<identify> – which does not allow any dynamic computation of the map key – i.e. <identify>.
+
+  @NegativeTest
+  Scenario: [1] Fail when performing property access on a non-map
+    Given any graph
+    When executing query:
+      """
+      WITH [{num: 0}, 1] AS list
+      RETURN (list[1]).num
+      """
+    Then a TypeError should be raised at runtime: PropertyAccessOnNonMap

--- a/tck/features/expressions/map/Map1.feature
+++ b/tck/features/expressions/map/Map1.feature
@@ -31,8 +31,20 @@
 Feature: Map1 - Static value access
 # Static value access refers to the dot-operator – <expression resulting in a map>.<identify> – which does not allow any dynamic computation of the map key – i.e. <identify>.
 
+  Scenario: [1] Statically access field of a map resulting from an expression
+    Given any graph
+    When executing query:
+      """
+      WITH [{num: 0}, 1] AS list
+      RETURN (list[0]).num
+      """
+    Then the result should be, in any order:
+      | (list[0]).num |
+      | 0             |
+    And no side effects
+
   @NegativeTest
-  Scenario: [1] Fail when performing property access on a non-map
+  Scenario: [2] Fail when performing property access on a non-map
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/mathematical/Mathematical3.feature
+++ b/tck/features/expressions/mathematical/Mathematical3.feature
@@ -29,3 +29,12 @@
 #encoding: utf-8
 
 Feature: Mathematical3 - Subtraction
+
+  @NegativeTest
+  Scenario: [1] Fail for invalid Unicode hyphen in subtraction
+    Given any graph
+    When executing query:
+      """
+      RETURN 42 — 41
+      """
+    Then a SyntaxError should be raised at compile time: InvalidUnicodeCharacter

--- a/tck/features/expressions/path/Path3.feature
+++ b/tck/features/expressions/path/Path3.feature
@@ -47,3 +47,23 @@ Feature: Path3 - Length of a path
       | (:B) | (:B) | 0 |
       | (:A) | (:B) | 1 |
     And no side effects
+
+  @NegativeTest
+  Scenario: Failing when using `length()` on a node
+    Given any graph
+    When executing query:
+      """
+      MATCH (n)
+      RETURN length(n)
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+  @NegativeTest
+  Scenario: Failing when using `length()` on a relationship
+    Given any graph
+    When executing query:
+      """
+      MATCH ()-[r]->()
+      RETURN length(r)
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -41,16 +41,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   @NegativeTest
-  Scenario: Failing when a relationship is used as a node
-    Given any graph
-    When executing query:
-      """
-      MATCH ()-[r]-(r)
-      RETURN r
-      """
-    Then a SyntaxError should be raised at compile time: VariableTypeConflict
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -166,16 +166,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: Failing when using parameter as relationship predicate in MATCH
-    Given any graph
-    When executing query:
-      """
-      MATCH ()-[r:FOO $param]->()
-      RETURN r
-      """
-    Then a SyntaxError should be raised at compile time: InvalidParameterUse
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -41,50 +41,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   @NegativeTest
-  Scenario: Failing when using IN on a string literal
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      WHERE n.id IN ''
-      RETURN 1
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
-  Scenario: Failing when using IN on an integer literal
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      WHERE n.id IN 1
-      RETURN 1
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
-  Scenario: Failing when using IN on a float literal
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      WHERE n.id IN 1.0
-      RETURN 1
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
-  Scenario: Failing when using IN on a boolean literal
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      WHERE n.id IN true
-      RETURN 1
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
   Scenario: Failing when a node is used as a relationship
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -176,16 +176,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: Failing when using parameter as node predicate in MERGE
-    Given any graph
-    When executing query:
-      """
-      MERGE (n $param)
-      RETURN n
-      """
-    Then a SyntaxError should be raised at compile time: InvalidParameterUse
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -260,27 +260,6 @@ Feature: SemanticErrorAcceptance
     And no side effects
 
   @NegativeTest
-  Scenario: Failing when performing property access on a non-map 1
-    Given any graph
-    When executing query:
-      """
-      WITH [{num: 0}, 1] AS list
-      RETURN (list[1]).num
-      """
-    Then a TypeError should be raised at runtime: PropertyAccessOnNonMap
-
-  @NegativeTest
-  Scenario: Failing when performing property access on a non-map 2
-    Given any graph
-    When executing query:
-      """
-      CREATE (n {name: 'foo'})
-      WITH n.name AS n2
-      RETURN n2.name
-      """
-    Then a TypeError should be raised at runtime: PropertyAccessOnNonMap
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -41,15 +41,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   @NegativeTest
-  Scenario: Bad arguments for `range()`
-    Given any graph
-    When executing query:
-      """
-      RETURN range(2, 8, 0)
-      """
-    Then a ArgumentError should be raised at runtime: NumberOutOfRange
-
-  @NegativeTest
   Scenario: Failing when using non-constants in SKIP
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -41,17 +41,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   @NegativeTest
-  Scenario: Failing when a node is used as a relationship
-    Given any graph
-    When executing query:
-      """
-      MATCH (r)
-      MATCH ()-[r]-()
-      RETURN r
-      """
-    Then a SyntaxError should be raised at compile time: VariableTypeConflict
-
-  @NegativeTest
   Scenario: Failing when a relationship is used as a node
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -116,16 +116,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
   @NegativeTest
-  Scenario: Failing when using `length()` on a node
-    Given any graph
-    When executing query:
-      """
-      MATCH (r)
-      RETURN length(r)
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -218,16 +218,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   @NegativeTest
-  Scenario: Failing when using undefined variable in ON MATCH
-    Given any graph
-    When executing query:
-      """
-      MERGE (n)
-        ON MATCH SET x.num = 1
-      """
-    Then a SyntaxError should be raised at compile time: UndefinedVariable
-
-  @NegativeTest
   Scenario: Failing when float value is too large
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -145,17 +145,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
   @NegativeTest
-  Scenario: Failing when using variable length relationship in MERGE
-    Given any graph
-    When executing query:
-      """
-      MERGE (a)
-      MERGE (b)
-      MERGE (a)-[:FOO*2]->(b)
-      """
-    Then a SyntaxError should be raised at compile time: CreatingVarLength
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -136,15 +136,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: RelationshipUniquenessViolation
 
   @NegativeTest
-  Scenario: Failing when using NOT on string literal
-    Given any graph
-    When executing query:
-      """
-      RETURN NOT 'foo'
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -208,16 +208,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   @NegativeTest
-  Scenario: Failing when using MERGE on a relationship that is already bound
-    Given any graph
-    When executing query:
-      """
-      MATCH (a)-[r]->(b)
-      MERGE (a)-[r]->(b)
-      """
-    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
-
-  @NegativeTest
   Scenario: Failing when float value is too large
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -106,16 +106,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: VariableTypeConflict
 
   @NegativeTest
-  Scenario: Failing when using `type()` on a node
-    Given any graph
-    When executing query:
-      """
-      MATCH (r)
-      RETURN type(r)
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -126,16 +126,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
   @NegativeTest
-  Scenario: Failing when re-using a relationship in the same pattern
-    Given any graph
-    When executing query:
-      """
-      MATCH (a)-[r]->()-[r]->(a)
-      RETURN r
-      """
-    Then a SyntaxError should be raised at compile time: RelationshipUniquenessViolation
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -281,16 +281,6 @@ Feature: SemanticErrorAcceptance
     Then a TypeError should be raised at runtime: PropertyAccessOnNonMap
 
   @NegativeTest
-  Scenario: Failing when checking existence of a non-property and non-pattern
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      RETURN exists(n.num + 1)
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentExpression
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -218,16 +218,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   @NegativeTest
-  Scenario: Failing when using undefined variable in ON CREATE
-    Given any graph
-    When executing query:
-      """
-      MERGE (n)
-        ON CREATE SET x.num = 1
-      """
-    Then a SyntaxError should be raised at compile time: UndefinedVariable
-
-  @NegativeTest
   Scenario: Failing when using undefined variable in ON MATCH
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -198,15 +198,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: Failing when float value is too large
-    Given any graph
-    When executing query:
-      """
-      RETURN 1.34E999
-      """
-    Then a SyntaxError should be raised at compile time: FloatingPointOverflow
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -309,16 +309,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidUnicodeCharacter
 
   @NegativeTest
-  Scenario: Failing for `size()` on paths
-    Given any graph
-    When executing query:
-      """
-      MATCH p = (a)-[*]->(b)
-      RETURN size(p)
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
   Scenario: Failing when using aggregation in list comprehension
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -300,15 +300,6 @@ Feature: SemanticErrorAcceptance
     Then a ArgumentError should be raised at runtime: NumberOutOfRange
 
   @NegativeTest
-  Scenario: Fail for invalid Unicode hyphen in subtraction
-    Given any graph
-    When executing query:
-      """
-      RETURN 42 — 41
-      """
-    Then a SyntaxError should be raised at compile time: InvalidUnicodeCharacter
-
-  @NegativeTest
   Scenario: Failing when using aggregation in list comprehension
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -71,16 +71,6 @@ Feature: SemanticErrorAcceptance
     Then a ArgumentError should be raised at runtime: NumberOutOfRange
 
   @NegativeTest
-  Scenario: Failing when using aggregation in list comprehension
-    Given any graph
-    When executing query:
-      """
-      MATCH (n)
-      RETURN [x IN [1, 2, 3, 4, 5] | count(*)]
-      """
-    Then a SyntaxError should be raised at compile time: InvalidAggregation
-
-  @NegativeTest
   Scenario: Failing when using non-constants in SKIP
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -156,16 +156,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: CreatingVarLength
 
   @NegativeTest
-  Scenario: Failing when using parameter as node predicate in MATCH
-    Given any graph
-    When executing query:
-      """
-      MATCH (n $param)
-      RETURN n
-      """
-    Then a SyntaxError should be raised at compile time: InvalidParameterUse
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -247,19 +247,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: FloatingPointOverflow
 
   @NegativeTest
-  Scenario: Handling property access on the Any type
-    Given any graph
-    When executing query:
-      """
-      WITH [{num: 0}, 1] AS list
-      RETURN (list[0]).num
-      """
-    Then the result should be, in any order:
-      | (list[0]).num |
-      | 0             |
-    And no side effects
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -186,18 +186,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: Failing when using parameter as relationship predicate in MERGE
-    Given any graph
-    When executing query:
-      """
-      MERGE (a)
-      MERGE (b)
-      MERGE (a)-[r:FOO $param]->(b)
-      RETURN r
-      """
-    Then a SyntaxError should be raised at compile time: InvalidParameterUse
-
-  @NegativeTest
   Scenario: Bad arguments for `range()`
     Given any graph
     When executing query:

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -372,33 +372,3 @@ Feature: SemanticErrorAcceptance
         LIMIT 1.7
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
-
-  @NegativeTest
-  Scenario: Failing when merging relationship without type
-    Given any graph
-    When executing query:
-      """
-      CREATE (a), (b)
-      MERGE (a)-->(b)
-      """
-    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
-
-  @NegativeTest
-  Scenario: Failing when merging relationship without type, no colon
-    Given any graph
-    When executing query:
-      """
-      MATCH (a), (b)
-      MERGE (a)-[NO_COLON]->(b)
-      """
-    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
-
-  @NegativeTest
-  Scenario: Failing when merging relationship with more than one type
-    Given any graph
-    When executing query:
-      """
-      CREATE (a), (b)
-      MERGE (a)-[:A|:B]->(b)
-      """
-    Then a SyntaxError should be raised at compile time: NoSingleRelationshipType

--- a/tck/features/uncategorized/SemanticErrorAcceptance.feature
+++ b/tck/features/uncategorized/SemanticErrorAcceptance.feature
@@ -198,16 +198,6 @@ Feature: SemanticErrorAcceptance
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
   @NegativeTest
-  Scenario: Failing when using MERGE on a node that is already bound
-    Given any graph
-    When executing query:
-      """
-      MATCH (a)
-      MERGE (a)
-      """
-    Then a SyntaxError should be raised at compile time: VariableAlreadyBound
-
-  @NegativeTest
   Scenario: Failing when float value is too large
     Given any graph
     When executing query:

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -44,7 +44,7 @@ object TCKEventsTest {
   @BeforeAll
   def subscribe(): Unit = {
     TCKEvents.feature.subscribe(
-      f => { if (f.name == "List6 - List Size") { events += s"Feature '${f.name}' read" } })
+      f => { if (f.name == "List6 - List size") { events += s"Feature '${f.name}' read" } })
     TCKEvents.scenario.subscribe(s => events += s"Scenario '${s.name}' started")
     TCKEvents.stepStarted.subscribe(s =>
       events += s"Step '${s.step.getClass.getSimpleName} -> ${s.step.source.getText}' started")
@@ -56,7 +56,7 @@ object TCKEventsTest {
   def assertEvents(): Unit = {
     TCKEvents.reset()
     val expected = List[String](
-      "Feature 'List6 - List Size' read",
+      "Feature 'List6 - List size' read",
       "Scenario '[1] Return list size' started",
       "Step 'Execute -> any graph' started",
       "Step 'Execute' finished. Result: <empty result>",


### PR DESCRIPTION
~This PR builds on #457 and should be merge subsequently.~

This PR focuses on categorizing scenarios of `SemanticErrorAcceptance.feature`.

On the side is adjust the feature names and scenarios name of the feature and scenarios touched anyway to improve the naming consistency. More alignment is necessary and to be done in subsequent PRs. This one does not aim at provide a completely consistent naming scheme.

A number of negative test have been generalized and extended. There is a net addition of 232 scnearios, which stem mostly from a few added scenario outlines, each with a long list of examples, cf. for instance [here](https://github.com/opencypher/openCypher/pull/458/files#diff-0c1d84990dd3a9b66b4ba24337f636a23f9dd70216475b26751ab18423b9a530R133-R257).

