### PR TITLE
Remove invalid construct YIELD *

### DIFF
--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -274,13 +274,10 @@
 
   <production name="YieldItems" rr:inline="true">
     <seq>
-      <alt>
-        *
-        <seq>
-          <non-terminal ref="YieldItem"/>
-          <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat>
-        </seq>
-      </alt>
+      <seq>
+        <non-terminal ref="YieldItem"/>
+        <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat>
+      </seq>
       <opt>&WS; <non-terminal ref="Where"/></opt>
     </seq>
   </production>

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -308,7 +308,4 @@ RETURN count(label) AS numLabels§
 CALL db.labels() YIELD label, foo, bar
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
-CALL db.labels() YIELD *
-WHERE label CONTAINS 'User' AND foo + bar = foo
-RETURN count(label) AS numLabels§
 CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§


### PR DESCRIPTION
This PR modifies the grammar rule that allows the `YIELD *` construct, which is not recognized by Neo4j as valid syntax:
```
neo4j@neo4j> CALL db.labels() YIELD *;
Invalid input '*': expected whitespace, comment, aliased procedure result field or simple procedure result field (line 1, column 24 (offset: 23))
"CALL db.labels() YIELD *;"
```