### PR TITLE
Get scala tests to run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,8 @@
     <dep.maven.surefire.plugin.version>2.22.2</dep.maven.surefire.plugin.version>
     <dep.scala.maven.plugin.version>3.4.4</dep.scala.maven.plugin.version>
     <dep.scala.version>2.12.10</dep.scala.version>
-    <dep.scalatest.version>3.0.5</dep.scalatest.version>
+    <dep.scalatest.version>3.2.2</dep.scalatest.version>
+    <dep.scalatest.runner.version>0.1.8</dep.scalatest.runner.version>
     <dep.xmlgraphics-commons.version>2.4</dep.xmlgraphics-commons.version>
     <dep.commons-csv.version>1.8</dep.commons-csv.version>
     <dep.commons-cli.version>1.4</dep.commons-cli.version>
@@ -147,6 +148,13 @@
             <artifactId>scala-library</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>co.helmethair</groupId>
+        <artifactId>scalatest-junit-runner</artifactId>
+        <version>${dep.scalatest.runner.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -306,10 +314,10 @@
     </pluginManagement>
 
     <plugins>
-        <plugin>
-          <groupId>org.neo4j.build.plugins</groupId>
-          <artifactId>license-maven-plugin</artifactId>
-        </plugin>
+      <plugin>
+        <groupId>org.neo4j.build.plugins</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4TestUtils.java
@@ -101,7 +101,7 @@ public class Antlr4TestUtils
         {
             Antlr4.write( Fixture.grammarResource( Antlr4.class, resource, options ), out );
             grammarString = out.toString( UTF_8.name() );
-            System.out.println(grammarString);
+            //System.out.println(grammarString);
         }
         catch ( Throwable t )
         {

--- a/tools/tck-api/pom.xml
+++ b/tools/tck-api/pom.xml
@@ -63,14 +63,20 @@
     <!-- Test deps -->
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-engine</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>co.helmethair</groupId>
+      <artifactId>scalatest-junit-runner</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/CypherValueParserTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/CypherValueParserTest.scala
@@ -28,9 +28,10 @@
 package org.opencypher.tools.tck
 
 import org.opencypher.tools.tck.values._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class CypherValueParserTest extends FunSuite with Matchers {
+class CypherValueParserTest extends AnyFunSuite with Matchers {
 
   test("unlabelled node") {
     val string = "()"

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherTCKTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherTCKTest.scala
@@ -27,21 +27,22 @@
  */
 package org.opencypher.tools.tck.api
 
-import org.junit.jupiter.api.Test
-import org.opencypher.tools.tck.api.CypherTCK.{featuresPath, parseClasspathFeatures}
+import org.scalatest.Assertions
+import org.scalatest.funsuite.AnyFunSuite
 
-class CypherTCKTest {
+class CypherTCKTest extends AnyFunSuite with Assertions {
 
-  @Test
-  def callParseClasspathFeaturesRepeatedly() {
-    parseClasspathFeatures(featuresPath)
-    parseClasspathFeatures(featuresPath)
+
+  test("call parseClasspathFeatures repeatedly") {
+    CypherTCK.parseClasspathFeatures(CypherTCK.featuresPath)
+    CypherTCK.parseClasspathFeatures(CypherTCK.featuresPath)
+    succeed
   }
 
-  @Test
-  def parseAllScenarioValues(): Unit = {
+  test("call allTckScenarios") {
     CypherTCK.allTckScenarios
     // does not throw exception
+    succeed
   }
 
 }

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/ScenarioTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/ScenarioTest.scala
@@ -30,10 +30,10 @@ package org.opencypher.tools.tck.api
 import java.net.URI
 import java.util
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ScenarioTest extends FunSuite with Matchers {
+class ScenarioTest extends AnyFunSuite with Matchers {
   val rand = new scala.util.Random(1)
 
   val noPickleSteps = new util.ArrayList[io.cucumber.core.gherkin.Step]()

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
@@ -29,10 +29,10 @@ package org.opencypher.tools.tck.api
 
 import java.net.URI
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class TCKApiTest extends FunSuite with Matchers {
+class TCKApiTest extends AnyFunSuite with Matchers {
   private val fooUri: URI = getClass.getResource("..").toURI
   private val scenarios: Seq[Scenario] = CypherTCK.parseFeatures(fooUri).flatMap(_.scenarios)
 

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/events/TCKEventsTest.scala
@@ -66,7 +66,7 @@ class TCKEventsTest extends AnyFunSuite with Assertions with Matchers {
       "Step 'ExpectResult' finished. Result: | n |" + System.lineSeparator + "| 3 |",
       "Step 'SideEffects -> no side effects' started",
       "Step 'SideEffects' finished. Result: | n |" + System.lineSeparator + "| 3 |"
-    ))
+    )
   }
 
   private object FakeGraph extends Graph with ProcedureSupport {

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/values/CypherValueTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/values/CypherValueTest.scala
@@ -27,9 +27,10 @@
  */
 package org.opencypher.tools.tck.values
 
-import org.scalatest.{FunSuiteLike, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class CypherValueTest extends FunSuiteLike with Matchers {
+class CypherValueTest extends AnyFunSuite with Matchers {
 
   test("list comparisons") {
     val oList1 = CypherOrderedList(List(CypherInteger(1), CypherInteger(2)))

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -71,8 +71,8 @@
         <!-- Test deps -->
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -81,6 +81,13 @@
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>co.helmethair</groupId>
+            <artifactId>scalatest-junit-runner</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
@@ -30,7 +30,6 @@ package org.opencypher.tools
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import org.junit.jupiter.api.Test
 import org.opencypher.tools.tck.api.CypherTCK
 import org.opencypher.tools.tck.inspection.collect.Feature
 import org.opencypher.tools.tck.inspection.collect.Group
@@ -38,18 +37,20 @@ import org.opencypher.tools.tck.inspection.collect.GroupCollection
 import org.opencypher.tools.tck.inspection.collect.ScenarioCategory
 import org.opencypher.tools.tck.inspection.collect.Tag
 import org.opencypher.tools.tck.inspection.collect.Total
-import org.scalatest.Assertions._
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 import scala.sys.process._
 
-class GenerateTCKIndexDocTest {
-  @Test //comment this in/out if index.adoc should/should not be generated during build
-  def runAsTest(): Unit = GenerateTCKIndexDoc.main(Array())
+class GenerateTCKIndexDocTest extends AnyFunSuite {
+  //used test(...)/ignore(...) if index.adoc should/should not be generated during build
+  test("generate index doc") {
+    GenerateTCKIndexDoc.main(Array())
+  }
 
-  //@Test //comment this in/out if generated index.adoc should/should not be checked against working copy HEAD during build
-  def verifyGenerateIndexIsCommitted(): Unit = {
+  //used test(...)/ignore(...) if generated index.adoc should/should not be checked against working copy HEAD during build
+  ignore("generate index doc should be committed") {
     val tmpFile = Files.createTempFile("tck-", "-index.adoc")
     val gitCmd = Seq("git", "-C", Paths.get(System.getProperty("projectRootdir")).toAbsolutePath.toString,
       "show", s"HEAD:${GenerateTCKIndexDoc.indexDocFileRelative}")

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
@@ -40,10 +40,10 @@ import org.opencypher.tools.tck.inspection.collect.GroupCollection
 import org.opencypher.tools.tck.inspection.diff
 import org.opencypher.tools.tck.inspection.diff.GroupCollectionDiff
 import org.opencypher.tools.tck.inspection.diff.GroupDiff
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class CountScenariosTest extends FunSuite with Matchers {
+class CountScenariosTest extends AnyFunSuite with Matchers {
   private val dummyPickle = new io.cucumber.core.gherkin.Pickle() {
     override def getKeyword: String = ""
 

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupCollectionDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupCollectionDiffTest.scala
@@ -42,10 +42,10 @@ import org.opencypher.tools.tck.inspection.collect.Tag
 import org.opencypher.tools.tck.inspection.collect.Total
 import org.opencypher.tools.tck.inspection.diff
 import org.opencypher.tools.tck.inspection.diff.ScenarioDiffTag._
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class GroupCollectionDiffTest extends FunSuite with Matchers {
+class GroupCollectionDiffTest extends AnyFunSuite with Matchers {
   private val dummyPickle = new io.cucumber.core.gherkin.Pickle() {
     override def getKeyword: String = ""
 

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
@@ -35,10 +35,10 @@ import org.opencypher.tools.tck.api.Measure
 import org.opencypher.tools.tck.api.Scenario
 import org.opencypher.tools.tck.api.Step
 import org.opencypher.tools.tck.inspection.diff.ScenarioDiffTag._
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class GroupDiffTest extends FunSuite with Matchers {
+class GroupDiffTest extends AnyFunSuite with Matchers {
   private val dummyPickle = new io.cucumber.core.gherkin.Pickle() {
     override def getKeyword: String = ""
 

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiffTest.scala
@@ -35,10 +35,10 @@ import org.opencypher.tools.tck.api.Measure
 import org.opencypher.tools.tck.api.Scenario
 import org.opencypher.tools.tck.api.Step
 import org.opencypher.tools.tck.inspection.diff.ScenarioDiffTag._
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ScenarioDiffTest extends FunSuite with Matchers {
+class ScenarioDiffTest extends AnyFunSuite with Matchers {
   val rand = new scala.util.Random(1)
 
   val noPickleSteps = new util.ArrayList[io.cucumber.core.gherkin.Step]()

--- a/tools/tck-integrity-tests/pom.xml
+++ b/tools/tck-integrity-tests/pom.xml
@@ -77,10 +77,15 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
+++ b/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
@@ -44,7 +44,7 @@ class FeatureFormatChecker extends TCKCucumberTemplate {
   private var skipStyleCheck: Boolean = false
 
   Before { (scenario: io.cucumber.scala.Scenario) =>
-    //validateDuplicateNames(scenario).map(msg => throw InvalidFeatureFormatException(msg))
+    validateDuplicateNames(scenario).map(msg => throw InvalidFeatureFormatException(msg))
     currentScenarioName = scenario.getName
     skipStyleCheck = scenario.getSourceTagNames.contains(TCKTags.SKIP_STYLE_CHECK)
   }

--- a/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
+++ b/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/FeatureFormatChecker.scala
@@ -44,7 +44,7 @@ class FeatureFormatChecker extends TCKCucumberTemplate {
   private var skipStyleCheck: Boolean = false
 
   Before { (scenario: io.cucumber.scala.Scenario) =>
-    validateDuplicateNames(scenario).map(msg => throw InvalidFeatureFormatException(msg))
+    //validateDuplicateNames(scenario).map(msg => throw InvalidFeatureFormatException(msg))
     currentScenarioName = scenario.getName
     skipStyleCheck = scenario.getSourceTagNames.contains(TCKTags.SKIP_STYLE_CHECK)
   }

--- a/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/validateDuplicateNames.scala
+++ b/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/validateDuplicateNames.scala
@@ -44,7 +44,7 @@ object validateDuplicateNames extends (io.cucumber.scala.Scenario => Option[Stri
     val scenarioNames = scenarioNamesByFeature.getOrElseUpdate(scenario.getUri, scala.collection.mutable.HashMap[String, List[Int]]())
     val lineNumbers = scenarioNames.getOrElseUpdate(scenario.getName, List[Int]())
     // this is not very stable, but this only indicator we currently have for scenario from scenario outlines
-    if (lineNumbers.isEmpty || lineNumbers.exists(lineNumber => Math.abs(scenario.getLine - lineNumber) == 1)) {
+    if (lineNumbers.isEmpty || lineNumbers.exists(lineNumber => Math.abs(scenario.getLine - lineNumber) == 3)) {
       scenarioNames.update(scenario.getName, scenario.getLine :: lineNumbers)
       None
     } else {

--- a/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/validateDuplicateNames.scala
+++ b/tools/tck-integrity-tests/src/main/scala/org/opencypher/tools/tck/validateDuplicateNames.scala
@@ -44,7 +44,7 @@ object validateDuplicateNames extends (io.cucumber.scala.Scenario => Option[Stri
     val scenarioNames = scenarioNamesByFeature.getOrElseUpdate(scenario.getUri, scala.collection.mutable.HashMap[String, List[Int]]())
     val lineNumbers = scenarioNames.getOrElseUpdate(scenario.getName, List[Int]())
     // this is not very stable, but this only indicator we currently have for scenario from scenario outlines
-    if (lineNumbers.isEmpty || lineNumbers.exists(lineNumber => Math.abs(scenario.getLine - lineNumber) == 3)) {
+    if (lineNumbers.isEmpty || lineNumbers.exists(lineNumber => scenario.getLine != lineNumber && Math.abs(scenario.getLine - lineNumber) <= 3)) {
       scenarioNames.update(scenario.getName, scenario.getLine :: lineNumbers)
       None
     } else {

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/TckTestSupport.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/TckTestSupport.scala
@@ -28,14 +28,15 @@
 package org.opencypher.tools.tck
 
 import io.cucumber.datatable.DataTable
-import org.junit.runner.RunWith
 import org.junit.platform.runner.JUnitPlatform
-import org.scalatest.{FunSuiteLike, Matchers}
+import org.junit.runner.RunWith
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.convert.DecorateAsJava
 
 @RunWith(classOf[JUnitPlatform])
-abstract class TckTestSupport extends FunSuiteLike with Matchers with DecorateAsJava {
+abstract class TckTestSupport extends AnyFunSuite with Matchers with DecorateAsJava {
 
   def tableOf(strings: Seq[String]*): DataTable = {
     DataTable.create(strings.map(_.toList.asJava).toList.asJava)


### PR DESCRIPTION
Since the recent update of various dependencies and number of scalatest-based test where not executed during the maven build, which unfortunately went unnoticed for a bit.

This PR fixes this.

With one qualification, though:

The tests in `tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/`, which test the functional components of the `org.opencypher.tools.tck.FeatureFormatChecker` are not executed. The `junit-vintage-engine`, which is required to let the `FeatureFormatChecker` itself be executed as part of the `org.opencypher.tools.VerifyFeaturesTest`, ignore the scalatests with outputs such as:

```
Nov. 06, 2020 8:57:58 VORM. org.junit.vintage.engine.discovery.DefensiveAllDefaultPossibilitiesBuilder$DefensiveAnnotatedBuilder buildRunner
WARNING: Ignoring test class using JUnitPlatform runner: org.opencypher.tools.tck.validateNamedGraphTest
```

After lot of trying and researching, it seems that we get either `FeatureFormatChecker` executed or the tests of the `FeatureFormatChecker` but not both. As the `FeatureFormatChecker` is barely modified while the feature are frequently modified, it is far more important that `FeatureFormatChecker` itself is executed than its tests.

Consideration beyond this PR:

The whole setup of the `FeatureFormatChecker` is somewhat obscure. It uses Cucumber magic to loop through all scenarios instead of our own tck-api. After considerable research and trying, it is still unclear how this can be lifted to use on Cucumber + jUnit5 (to get rid of `junit-vintage-engine`).

The `validateDuplicateNames` component of the `FeatureFormatChecker` needed adoption, too, since the Cucumber API used by the feature format check changed its behavior with regards to line numbers of scenarios created from scenario outline. The current solution is less ideal.

Since the tck-api exposes more information about TCK scenarios, longterm, it seems more appropriate to rewrite the `FeatureFormatChecker` to use the tck-api and being run during build via scalatest (which would also allow to get rid of `junit-vintage-engine`).