### PR TITLE
Compatibility testing

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -55,6 +55,7 @@
   <modules>
     <module>grammar</module>
     <module>tck-api</module>
+    <module>tck-compatibility-tests</module>
     <module>tck-inspection</module>
     <module>tck-integrity-tests</module>
     <module>tck-reporting</module>

--- a/tools/tck-compatibility-tests/pom.xml
+++ b/tools/tck-compatibility-tests/pom.xml
@@ -10,7 +10,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tck-compatibility</artifactId>
+    <artifactId>tck-compatibility-tests</artifactId>
     <packaging>pom</packaging>
     <name>TCK compatibility testing</name>
     <url>http://opencypher.org</url>

--- a/tools/tck-compatibility-tests/pom.xml
+++ b/tools/tck-compatibility-tests/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opencypher</groupId>
+        <artifactId>tools</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tck-compatibility</artifactId>
+    <packaging>pom</packaging>
+    <name>TCK compatibility testing</name>
+    <url>http://opencypher.org</url>
+    <description>openCypher TCK compatibility testing</description>
+
+    <properties>
+        <project.rootdir>${project.basedir}/../..</project.rootdir>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <modules>
+        <module>util</module>
+        <module>neo4j</module>
+    </modules>
+
+</project>

--- a/tools/tck-compatibility-tests/pom.xml
+++ b/tools/tck-compatibility-tests/pom.xml
@@ -29,7 +29,6 @@
 
     <modules>
         <module>util</module>
-        <module>neo4j</module>
     </modules>
 
 </project>

--- a/tools/tck-compatibility-tests/util/pom.xml
+++ b/tools/tck-compatibility-tests/util/pom.xml
@@ -6,11 +6,11 @@
 
     <parent>
         <groupId>org.opencypher</groupId>
-        <artifactId>tck-compatibility</artifactId>
+        <artifactId>tck-compatibility-tests</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>util_2.12</artifactId>
+    <artifactId>tck-compatibility-tests-util_2.12</artifactId>
     <name>openCypher TCK Compatibility Tests</name>
     <url>http://opencypher.org</url>
     <description>Tools for running openCypher TCK scenarios on implementations</description>

--- a/tools/tck-compatibility-tests/util/pom.xml
+++ b/tools/tck-compatibility-tests/util/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opencypher</groupId>
+        <artifactId>tck-compatibility</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>util_2.12</artifactId>
+    <name>openCypher TCK Compatibility Tests</name>
+    <url>http://opencypher.org</url>
+    <description>Tools for running openCypher TCK scenarios on implementations</description>
+
+    <properties>
+        <project.rootdir>${project.basedir}/../../..</project.rootdir>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <configuration>
+                    <parallel>true</parallel>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opencypher</groupId>
+            <artifactId>tck-api_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opencypher</groupId>
+            <artifactId>tck</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <!-- Test deps -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>co.helmethair</groupId>
+            <artifactId>scalatest-junit-runner</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
+++ b/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
+++ b/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015-2020 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.compatibility
+
+import org.opencypher.tools.tck.api.Scenario
+import org.opencypher.tools.tck.api.groups.ContainerGroup
+import org.opencypher.tools.tck.api.groups.Group
+import org.opencypher.tools.tck.api.groups.Item
+import org.opencypher.tools.tck.api.groups.Tag
+import org.opencypher.tools.tck.api.groups.TckTree
+import org.opencypher.tools.tck.api.groups.Total
+import org.scalatest.ParallelTestExecution
+import org.scalatest.funspec.AsyncFunSpec
+
+import scala.concurrent.Future
+
+trait AsyncScalaTests extends AsyncFunSpec with ParallelTestExecution {
+
+  def create(scenarios: Seq[Scenario], exec: Scenario => Unit): Unit = {
+    implicit val tck: TckTree = TckTree(scenarios)
+
+    def tagSeq(item: Item): Seq[org.scalatest.Tag] = item.scenario.tags.map(t => org.scalatest.Tag(t)).toSeq
+
+    def spawnTests(currentGroup: Group): Unit = {
+      currentGroup match {
+        case Total =>
+          Total.children.foreach(spawnTests)
+        case _: Tag => Unit // do not execute scenarios via tags, would be redundant
+        case g: ContainerGroup =>
+          describe(g.description) {
+            g.children.foreach(spawnTests)
+          }
+        case i: Item =>
+          /*
+           * use ignore(...) for switching OFF the test
+           * use it(...) for switching ON the test
+           */
+          it(i.description, tagSeq(i): _*) {
+            Future {
+              exec(i.scenario)
+            } map { _ => succeed }
+          }
+        case _ => Unit
+      }
+    }
+
+    spawnTests(Total)
+  }
+}

--- a/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/DynamicJunitTests.scala
+++ b/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/DynamicJunitTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/DynamicJunitTests.scala
+++ b/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/DynamicJunitTests.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015-2020 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.compatibility
+
+import java.util
+
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.function.Executable
+import org.opencypher.tools.tck.api.Scenario
+import org.opencypher.tools.tck.api.groups.ContainerGroup
+import org.opencypher.tools.tck.api.groups.Group
+import org.opencypher.tools.tck.api.groups.Item
+import org.opencypher.tools.tck.api.groups.Tag
+import org.opencypher.tools.tck.api.groups.TckTree
+import org.opencypher.tools.tck.api.groups.Total
+
+import scala.collection.JavaConverters._
+
+trait DynamicJunitTests {
+
+  def create(scenarios: Seq[Scenario], createTest: Scenario => Executable): util.Collection[DynamicNode] = {
+    implicit val tck: TckTree = TckTree(scenarios)
+
+    def spawnTests(currentGroup: Group): Seq[DynamicNode] = {
+      currentGroup match {
+        case Total =>
+          Total.children.toSeq.sorted.flatMap(g => spawnTests(g))
+        case _: Tag => Seq.empty[DynamicNode]
+        case g: ContainerGroup =>
+          Seq(DynamicContainer.dynamicContainer(
+            g.description,
+            g.children.flatMap(g => spawnTests(g)).asJavaCollection
+          ))
+        case i: Item =>
+          Seq(DynamicTest.dynamicTest(i.description, createTest(i.scenario)))
+      }
+    }
+
+    spawnTests(Total).asJavaCollection
+  }
+}

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
@@ -31,17 +31,9 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import org.opencypher.tools.tck.api.CypherTCK
-<<<<<<< HEAD:tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
 import org.opencypher.tools.tck.api.groups.Feature
 import org.opencypher.tools.tck.api.groups.ScenarioCategory
 import org.opencypher.tools.tck.api.groups.TckTree
-=======
-import org.opencypher.tools.tck.api.groups.CollectGroups
-import org.opencypher.tools.tck.api.groups.Feature
-import org.opencypher.tools.tck.api.groups.OrderGroupsDepthFirst
-import org.opencypher.tools.tck.api.groups.ScenarioCategory
-import org.opencypher.tools.tck.api.groups.Tag
->>>>>>> adjust tck index doc generator:tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
 import org.opencypher.tools.tck.api.groups.Total
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
@@ -31,9 +31,17 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import org.opencypher.tools.tck.api.CypherTCK
+<<<<<<< HEAD:tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/GenerateTCKIndexDoc.scala
 import org.opencypher.tools.tck.api.groups.Feature
 import org.opencypher.tools.tck.api.groups.ScenarioCategory
 import org.opencypher.tools.tck.api.groups.TckTree
+=======
+import org.opencypher.tools.tck.api.groups.CollectGroups
+import org.opencypher.tools.tck.api.groups.Feature
+import org.opencypher.tools.tck.api.groups.OrderGroupsDepthFirst
+import org.opencypher.tools.tck.api.groups.ScenarioCategory
+import org.opencypher.tools.tck.api.groups.Tag
+>>>>>>> adjust tck index doc generator:tools/tck-inspection/src/test/scala/org/opencypher/tools/GenerateTCKIndexDoc.scala
 import org.opencypher.tools.tck.api.groups.Total
 import org.scalatest.funsuite.AnyFunSuite
 


### PR DESCRIPTION
**This PR builds on #468** 

Are very common thing when using the TCK is to run the TCK scenarios against an implementation for testing. 

This PR adds module `tck-compatibility-tests`, which provides support for this.

The submodule `util` provide two traits that spawn hierachical tests with the help of the `TckTree`, which reflect the TCK categories and features in a test tree:

 * `org.opencypher.tools.tck.compatibility.AsyncScalaTests` spawns asynchronic scalatests
 * `org.opencypher.tools.tck.compatibility.DynamicJunitTests` spawns JUnit tests

The intend is, to add one submodule per implementation that should be tested against during build. Such submodules will have to use public artifacts of the implementation they test. Currently, no implementation is ready in this regard. It is expected that implementation become ready with the next milestone release of the TCK.