### PR TITLE
Scenarios for maps with null values

### DIFF
--- a/tck/features/clauses/set/Set4.feature
+++ b/tck/features/clauses/set/Set4.feature
@@ -67,7 +67,7 @@ Feature: Set4 - Set all properties with a map
       | +properties | 2 |
       | -properties | 2 |
 
-  Scenario: [2] Null values in a property map are removed with SET
+  Scenario: [3] Null values in a property map are removed with SET
     Given an empty graph
     And having executed:
       """
@@ -86,7 +86,7 @@ Feature: Set4 - Set all properties with a map
       | +properties | 2 |
       | -properties | 2 |
 
-  Scenario: [3] All properties are removed if node is set to empty property map
+  Scenario: [4] All properties are removed if node is set to empty property map
     Given an empty graph
     And having executed:
       """

--- a/tck/features/clauses/set/Set4.feature
+++ b/tck/features/clauses/set/Set4.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Set4 - Set All Properties with a Map
+Feature: Set4 - Set all properties with a map
 
   Scenario: [1] Set multiple properties with a property map
     Given an empty graph
@@ -48,7 +48,7 @@ Feature: Set4 - Set All Properties with a Map
     And the side effects should be:
       | +properties | 3 |
 
-  Scenario: [2] Non-existent values in a property map are removed with SET =
+  Scenario: [2] Non-existent values in a property map are removed with SET
     Given an empty graph
     And having executed:
       """
@@ -61,7 +61,26 @@ Feature: Set4 - Set All Properties with a Map
       RETURN n
       """
     Then the result should be, in any order:
-      | n                           |
+      | n                          |
+      | (:X {name: 'B', baz: 'C'}) |
+    And the side effects should be:
+      | +properties | 2 |
+      | -properties | 2 |
+
+  Scenario: [2] Null values in a property map are removed with SET
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:X {name: 'A', name2: 'B'})
+      """
+    When executing query:
+      """
+      MATCH (n:X {name: 'A'})
+      SET n = {name: 'B', name2: null, baz: 'C'}
+      RETURN n
+      """
+    Then the result should be, in any order:
+      | n                          |
       | (:X {name: 'B', baz: 'C'}) |
     And the side effects should be:
       | +properties | 2 |
@@ -85,7 +104,7 @@ Feature: Set4 - Set All Properties with a Map
     And the side effects should be:
       | -properties | 2 |
 
-  Scenario: [4] Ignore null when setting properties using an overriding map
+  Scenario: [5] Ignore null when setting properties using an overriding map
     Given an empty graph
     When executing query:
       """

--- a/tck/features/clauses/set/Set5.feature
+++ b/tck/features/clauses/set/Set5.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Set5 - Set Multiple Properties with a Map
+Feature: Set5 - Set multiple properties with a map
 
   Scenario: [1] Ignore null when setting properties using an appending map
     Given an empty graph
@@ -56,7 +56,7 @@ Feature: Set5 - Set Multiple Properties with a Map
       RETURN n
       """
     Then the result should be, in any order:
-      | n                             |
+      | n                            |
       | (:X {name: 'A', name2: 'C'}) |
     And the side effects should be:
       | +properties | 1 |
@@ -75,7 +75,7 @@ Feature: Set5 - Set Multiple Properties with a Map
       RETURN n
       """
     Then the result should be, in any order:
-      | n                             |
+      | n                            |
       | (:X {name: 'A', name2: 'B'}) |
     And the side effects should be:
       | +properties | 1 |

--- a/tck/features/expressions/comparison/Comparison1.feature
+++ b/tck/features/expressions/comparison/Comparison1.feature
@@ -143,7 +143,37 @@ Feature: Comparison1 - Equality
       | [[1], [2]]    | [[1], [null]] | null   |
       | [[1], [2, 3]] | [[1], [null]] | false  |
 
-  Scenario Outline: [7] Equality and inequality of NaN
+  Scenario Outline: [7] Comparing maps to maps
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <lhs> = <rhs> AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | lhs             | rhs                | result |
+      | {}              | {}                 | true   |
+      | {k: true}       | {k: true}          | true   |
+      | {k: 1}          | {k: 1}             | true   |
+      | {k: 1.0}        | {k: 1.0}           | true   |
+      | {k: 'abc'}      | {k: 'abc'}         | true   |
+      | {k: 'a', l: 2}  | {k: 'a', l: 2}     | true   |
+      | {}              | {k: null}          | false  |
+      | {k: null}       | {}                 | false  |
+      | {k: 1}          | {k: 1, l: null}    | false  |
+      | {k: null, l: 1} | {l: 1}             | false  |
+      | {k: null}       | {k: null, l: null} | false  |
+      | {k: null}       | {k: null}          | null   |
+      | {k: 1}          | {k: null}          | null   |
+      | {k: 1, l: null} | {k: null, l: null} | null   |
+      | {k: 1, l: null} | {k: null, l: 1}    | null   |
+      | {k: 1, l: null} | {k: 1, l: 1}       | null   |
+
+  Scenario Outline: [8] Equality and inequality of NaN
     Given any graph
     When executing query:
       """
@@ -161,7 +191,7 @@ Feature: Comparison1 - Equality
       | 0.0 / 0.0 | 0.0 / 0.0 |
       | 0.0 / 0.0 | 'a'       |
 
-  Scenario Outline: [8] Equality between strings and numbers
+  Scenario Outline: [9] Equality between strings and numbers
     Given any graph
     When executing query:
       """
@@ -179,7 +209,7 @@ Feature: Comparison1 - Equality
       | '1.0' | 1.0 | false   |
       | '1'   | 1   | false   |
 
-  Scenario: [9] Handling inlined equality of large integer
+  Scenario: [10] Handling inlined equality of large integer
     Given an empty graph
     And having executed:
       """
@@ -195,7 +225,7 @@ Feature: Comparison1 - Equality
       | 4611686018427387905 |
     And no side effects
 
-  Scenario: [10] Handling explicit equality of large integer
+  Scenario: [11] Handling explicit equality of large integer
     Given an empty graph
     And having executed:
       """
@@ -212,7 +242,7 @@ Feature: Comparison1 - Equality
       | 4611686018427387905 |
     And no side effects
 
-  Scenario: [11] Handling inlined equality of large integer, non-equal values
+  Scenario: [12] Handling inlined equality of large integer, non-equal values
     Given an empty graph
     And having executed:
       """
@@ -227,7 +257,7 @@ Feature: Comparison1 - Equality
       | p.id |
     And no side effects
 
-  Scenario: [12] Handling explicit equality of large integer, non-equal values
+  Scenario: [13] Handling explicit equality of large integer, non-equal values
     Given an empty graph
     And having executed:
       """
@@ -243,7 +273,7 @@ Feature: Comparison1 - Equality
       | p.id |
     And no side effects
 
-  Scenario: [13] Direction of traversed relationship is not significant for path equality, simple
+  Scenario: [14] Direction of traversed relationship is not significant for path equality, simple
     Given an empty graph
     And having executed:
       """
@@ -260,7 +290,7 @@ Feature: Comparison1 - Equality
       | true    |
     And no side effects
 
-  Scenario: [14] It is unknown - i.e. null - if a null is equal to a null
+  Scenario: [15] It is unknown - i.e. null - if a null is equal to a null
     Given any graph
     When executing query:
       """
@@ -271,7 +301,7 @@ Feature: Comparison1 - Equality
       | null  |
     And no side effects
 
-  Scenario: [15] It is unknown - i.e. null - if a null is not equal to a null
+  Scenario: [16] It is unknown - i.e. null - if a null is not equal to a null
     Given any graph
     When executing query:
       """
@@ -283,7 +313,7 @@ Feature: Comparison1 - Equality
     And no side effects
 
   @NegativeTest
-  Scenario: [16] Failing when comparing to an undefined variable
+  Scenario: [17] Failing when comparing to an undefined variable
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -65,3 +65,25 @@ Feature: Map3 - Keys function
       | keys(m) | keys(null) |
       | null    | null       |
     And no side effects
+
+  Scenario Outline: [4] Using `keys()` on map with null values
+    Given any graph
+    When executing query:
+      """
+      RETURN keys(<map>) as keys
+      """
+    Then the result should be (ignoring element order for lists):
+      | keys     |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | keys                  | result    |
+      | {}                    | []        |
+      | {k: 1}                | [k]       |
+      | {k: null}             | [k]       |
+      | {null: null}          | [null]    |
+      | {k: null, l: 1}       | [k, l]    |
+      | {k: 1, l: null}       | [k, l]    |
+      | {k: null, l: null}    | [k, l]    |
+      | {k: 1, l: null, m: 1} | [k, l, m] |

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -78,12 +78,12 @@ Feature: Map3 - Keys function
     And no side effects
 
     Examples:
-      | keys                  | result    |
-      | {}                    | []        |
-      | {k: 1}                | [k]       |
-      | {k: null}             | [k]       |
-      | {null: null}          | [null]    |
-      | {k: null, l: 1}       | [k, l]    |
-      | {k: 1, l: null}       | [k, l]    |
-      | {k: null, l: null}    | [k, l]    |
-      | {k: 1, l: null, m: 1} | [k, l, m] |
+      | keys                  | result          |
+      | {}                    | []              |
+      | {k: 1}                | ['k']           |
+      | {k: null}             | ['k']           |
+      | {null: null}          | ['null']        |
+      | {k: null, l: 1}       | ['k', 'l']      |
+      | {k: 1, l: null}       | ['k', 'l']      |
+      | {k: null, l: null}    | ['k', 'l']      |
+      | {k: 1, l: null, m: 1} | ['k', 'l', 'm'] |

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -82,7 +82,6 @@ Feature: Map3 - Keys function
       | {}                    | []              |
       | {k: 1}                | ['k']           |
       | {k: null}             | ['k']           |
-      | {null: null}          | ['null']        |
       | {k: null, l: 1}       | ['k', 'l']      |
       | {k: 1, l: null}       | ['k', 'l']      |
       | {k: null, l: null}    | ['k', 'l']      |

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -70,7 +70,7 @@ Feature: Map3 - Keys function
     Given any graph
     When executing query:
       """
-      RETURN keys(<map>) as keys
+      RETURN keys(<map>) AS keys
       """
     Then the result should be (ignoring element order for lists):
       | keys     |

--- a/tck/features/expressions/map/Map3.feature
+++ b/tck/features/expressions/map/Map3.feature
@@ -78,7 +78,7 @@ Feature: Map3 - Keys function
     And no side effects
 
     Examples:
-      | keys                  | result          |
+      | map                   | result          |
       | {}                    | []              |
       | {k: 1}                | ['k']           |
       | {k: null}             | ['k']           |

--- a/tck/features/expressions/map/Map4.feature
+++ b/tck/features/expressions/map/Map4.feature
@@ -35,7 +35,7 @@ Feature: Map4 - Field existence check
     When executing query:
       """
       WITH <map> AS map
-      RETURN exists(map.name) AS result
+      RETURN exists(map.<key>) AS result
       """
     Then the result should be, in any order:
       | result   |
@@ -43,10 +43,20 @@ Feature: Map4 - Field existence check
     And no side effects
 
     Examples:
-      | map                             | result |
-      | {name: 'Mats', name2: 'Pontus'} | true   |
-      | {name: null}                    | false  |
-      | {notName: 0, notName2: null}    | false  |
+      | map                                 | key     | result |
+      | {name: 'Mats', name2: 'Pontus'}     | name    | true   |
+      | {name: 'Mats', name2: 'Pontus'}     | name2   | true   |
+      | {name: null}                        | name    | true   |
+      | {name: null, name2: 'Pontus'}       | name    | true   |
+      | {name: null, name2: null}           | name    | true   |
+      | {name: null, name2: null}           | name2   | true   |
+      | {name: 'Pontus', name2: null}       | name2   | true   |
+      | {name: 'Pontus', notName2: null}    | name    | true   |
+      | {notName: 'Pontus', notName2: null} | notName | true   |
+      | {notName: null, notName2: null}     | notName | true   |
+      | {notName: null, notName2: null}     | name    | false  |
+      | {notName: 0, notName2: null}        | name    | false  |
+      | {notName: 0}                        | name    | false  |
 
   Scenario: [2] Using `exists()` on null map
     Given any graph

--- a/tck/features/expressions/map/Map4.feature
+++ b/tck/features/expressions/map/Map4.feature
@@ -52,11 +52,10 @@ Feature: Map4 - Field existence check
       | {name: null, name2: null}           | name2   | true   |
       | {name: 'Pontus', name2: null}       | name2   | true   |
       | {name: 'Pontus', notName2: null}    | name    | true   |
-      | {notName: 'Pontus', notName2: null} | notName | true   |
-      | {notName: null, notName2: null}     | notName | true   |
       | {notName: null, notName2: null}     | name    | false  |
       | {notName: 0, notName2: null}        | name    | false  |
       | {notName: 0}                        | name    | false  |
+      | {}                                  | name    | false  |
 
   Scenario: [2] Using `exists()` on null map
     Given any graph

--- a/tck/features/expressions/null/Null3.feature
+++ b/tck/features/expressions/null/Null3.feature
@@ -28,7 +28,8 @@
 
 #encoding: utf-8
 
-Feature: Null2 - Null evaluation
+Feature: Null3 - Null evaluation
+# the scenarios of this feature should be redistributed to the features of respective operations
 
   Scenario: [1] The inverse of a null is a null
     Given any graph


### PR DESCRIPTION
This PR follows up #464 with changing and augmenting TCK scenarios to reflect the behavior now clarified in the [CIP](https://github.com/sherfert/openCypher/blob/71f865baba103b54ad7bda72c360917c9c4ccc17/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc).
