### PR TITLE
Remove VOID from procedure signatures

### DIFF
--- a/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
+++ b/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
@@ -50,23 +50,23 @@ The details of internal types are out of scope for the purposes of this document
 
 === Types and Type Literal Syntax
 
-The section below presents presents the new Public Type System (PTS) proposed for Cypher.
+The section below presents the new Public Type System (PTS) proposed for Cypher.
 
 ==== Material and nullable types
 
 The type system provides a way to track nullability, i.e. a type may express if a given expression may be `null` or not.
-Tracking (non-)nullability helps an implementation to detect and warn about possible user errors during compile time and  it also enables optimizations that rely on values not being `null`. As an example, an implementation may infer that `MATCH` will never introduce a nullable variable, but `OPTIONAL MATCH` will only introduce nullable variables.
-
-Material types are all types that do not permit `null` as a valid result of evaluating the underlying expression.
-In the sections below, generally only the material variants of each type are given.
+Tracking (non-)nullability helps an implementation to detect and warn about possible user errors during compile time and it also enables optimizations that rely on values not being `null`. As an example, an implementation may infer that `MATCH` will never introduce a nullable variable, but `OPTIONAL MATCH` will only introduce nullable variables.
 
 Nullable types are all types that do permit `null` as a valid result of evaluating the underlying expression.
-Nullable type names are formed by suffixing a material type name with a single question mark (without in-between whitespace).
-Nullable variants of all material types should be supported by any implementation of Cypher.
+In the sections below, generally only the nullable variants of each type are given.
 Note that `null` is not a type but a value that inhabits every nullable type.
 
-Every nullable type is a supertype of its underlying material type, i.e. `T?` is a supertype of `T`.
-By transitivity of subtyping, if `S` is a supertype of `T`, then `S?` is also a supertype of `T`.
+Material types are all types that do not permit `null` as a valid result of evaluating the underlying expression.
+Material type names are formed by suffixing a nullable type name with a single exclamation mark (without in-between whitespace).
+Material variants of all nullable types should be supported by any implementation of Cypher.
+
+Every nullable type is a supertype of its underlying material type, i.e. `T` is a supertype of `T!`.
+By transitivity of subtyping, if `S` is a supertype of `T`, then `S` is also a supertype of `T!`.
 
 ==== Abstract and concrete types
 
@@ -149,10 +149,6 @@ a nullable variant:
 * `PATH`
 ** A path from a node `n1` to a node `ni` - corresponding to a walk in the graph from `n1` to `ni` - is a sequence `n1`, `r1`, `n2`, `r2`, ..., `r(i-1)`, `ni` of alternating nodes and relationships such that for `1 \<= j < i`, any `rj` contained in the path is incident with `nj` and `n(j+1)`. Additionally, a single node path is a path that starts and ends at the same node `n0` and does not contain any relationships.
 
-==== Void type
-
-This CIP also introduces an additional nullable type called `VOID`. `VOID` is intended to be used as the return type of user defined procedures that execute without producing a result value, i.e. the return type of procedures with side effects. `VOID` is a subtype of `ANY?`. In an expression context, `null` is the only value that inhibits the `VOID` type, indicating a missing "real" return value (Note though that Cypher currently does not have any expressions of type `VOID` and this is merely defined here for completeness).
-
 === Type Annotation
 
 To specify the type of a term in future changes to the Cypher grammar, this CIP proposes using the following syntax
@@ -177,15 +173,13 @@ type = nullable core type
      | container type
      ;
 
-nullable core type = material core type, "?"
-                   | void type
-                   ;
-
-material core type = any type
+nullable core type = any type
                    | scalar type
                    | temporal type
                    | graph type
                    ;
+
+material core type = nullable core type, "!" ;
 
 any type = "ANY" ;
 
@@ -213,24 +207,21 @@ container type = material container type
                | nullable container type
                ;
 
-material container type	= "LIST", "OF", type
+nullable container type	= "LIST", "OF", type
                         | "MAP"
                         ;
 
-nullable container type	= "LIST?", "OF", type
-                        | "MAP?"
+material container type	= "LIST!", "OF", type
+                        | "MAP!"
                         ;
 
-void type = "VOID" ;
-
 keywords = type keywords
-         | type keywords, "?"
-         | void type
+         | type keywords, "!"
          | "OF"
          | ...
          ;
 
-type keywords = material core types
+type keywords = nullable core types
               | container type keywords
               ;
 

--- a/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
+++ b/cip/1.accepted/CIP2015-09-16-public-type-system-type-annotation.adoc
@@ -57,16 +57,16 @@ The section below presents the new Public Type System (PTS) proposed for Cypher.
 The type system provides a way to track nullability, i.e. a type may express if a given expression may be `null` or not.
 Tracking (non-)nullability helps an implementation to detect and warn about possible user errors during compile time and it also enables optimizations that rely on values not being `null`. As an example, an implementation may infer that `MATCH` will never introduce a nullable variable, but `OPTIONAL MATCH` will only introduce nullable variables.
 
+Material types are all types that do not permit `null` as a valid result of evaluating the underlying expression.
+In the sections below, generally only the material variants of each type are given.
+
 Nullable types are all types that do permit `null` as a valid result of evaluating the underlying expression.
-In the sections below, generally only the nullable variants of each type are given.
+Nullable type names are formed by suffixing a material type name with a single question mark (without in-between whitespace).
+Nullable variants of all material types should be supported by any implementation of Cypher.
 Note that `null` is not a type but a value that inhabits every nullable type.
 
-Material types are all types that do not permit `null` as a valid result of evaluating the underlying expression.
-Material type names are formed by suffixing a nullable type name with a single exclamation mark (without in-between whitespace).
-Material variants of all nullable types should be supported by any implementation of Cypher.
-
-Every nullable type is a supertype of its underlying material type, i.e. `T` is a supertype of `T!`.
-By transitivity of subtyping, if `S` is a supertype of `T`, then `S` is also a supertype of `T!`.
+Every nullable type is a supertype of its underlying material type, i.e. `T?` is a supertype of `T`.
+By transitivity of subtyping, if `S` is a supertype of `T`, then `S?` is also a supertype of `T`.
 
 ==== Abstract and concrete types
 
@@ -173,13 +173,15 @@ type = nullable core type
      | container type
      ;
 
-nullable core type = any type
+nullable core type = material core type, "?"
+                   | void type
+                   ;
+
+material core type = any type
                    | scalar type
                    | temporal type
                    | graph type
                    ;
-
-material core type = nullable core type, "!" ;
 
 any type = "ANY" ;
 
@@ -207,21 +209,21 @@ container type = material container type
                | nullable container type
                ;
 
-nullable container type	= "LIST", "OF", type
+material container type	= "LIST", "OF", type
                         | "MAP"
                         ;
 
-material container type	= "LIST!", "OF", type
-                        | "MAP!"
+nullable container type	= "LIST?", "OF", type
+                        | "MAP?"
                         ;
 
 keywords = type keywords
-         | type keywords, "!"
+         | type keywords, "?"
          | "OF"
          | ...
          ;
 
-type keywords = nullable core types
+type keywords = material core types
               | container type keywords
               ;
 

--- a/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
+++ b/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc
@@ -369,18 +369,19 @@ We define the following ascending global sort order of disjoint types:
 * `BOOLEAN`
 * `NUMBER`
 ** `NaN` values are treated as the largest numbers in orderability only (i.e. they are put after positive infinity)
-* `VOID` (i.e. the type of `null`)
+
+The value `null` is larger than any other value.
 
 To give a concrete example, under this global sort order all nodes come before all strings.
 
 Between values of the same type in the global sort order, orderability defers to comparability except that equality is overridden by equivalence as described below.
-For example, `[null, 1]` is ordered before `[null, 2]` under orderability.
+For example, `[null, 1]` is ordered after `[1, 2]` and before `[null, 2]` under orderability.
 Additionally, for the container types, elements of the containers use orderability, not comparability, to determine the order between them.
 For example, `[1, 'foo', 3]` is ordered before `[1, 2, 'bar']` since `'foo'` is ordered before `2`.
 
 Furthermore, the values of additional, non-canonical types must not be inserted after `NaN` values in the global sort order.
 
-The accompanying descending global sort order is the same order in reverse (i.e. it runs from `VOID` to `MAP`).
+The accompanying descending global sort order is the same order in reverse.
 
 
 [[equivalence-def,equivalence]]
@@ -527,19 +528,18 @@ Any other comparison will always yield a `null` value (except when comparing `Na
 .Comparability of values of different types (`X` means the result of comparison will always return `true` or `false`)
 [frame="topbot",options="header,footer"]
 |================================================================================================================================
-|Type           | `NODE` | `RELATIONSHIP` | `PATH` | `MAP` | `LIST OF ANY?` | Temporal | `DURATION` | `STRING` | `BOOLEAN` | `INTEGER` | `FLOAT` | `VOID`
-|`NODE`         | X      |                |        |       |                |          |            |          |           |           |         |
-|`RELATIONSHIP` |        | X              |        |       |                |          |            |          |           |           |         |
-|`PATH`         |        |                | X      |       |                |          |            |          |           |           |         |
-|`MAP`          |        |                |        | X     |                |          |            |          |           |           |         |
-|`LIST OF ANY?` |        |                |        |       | X              |          |            |          |           |           |         |
-|Temporal       |        |                |        |       |                | X^†^     |            |          |           |           |         |
-|`DURATION`     |        |                |        |       |                |          |            |          |           |           |         |
-|`STRING`       |        |                |        |       |                |          |            | X        |           |           |         |
-|`BOOLEAN`      |        |                |        |       |                |          |            |          | X         |           |         |
-|`INTEGER`      |        |                |        |       |                |          |            |          |           | X         | X       |
-|`FLOAT`        |        |                |        |       |                |          |            |          |           | X         | X       |
-|`VOID`         |        |                |        |       |                |          |            |          |           |           |         |
+|Type           | `NODE` | `RELATIONSHIP` | `PATH` | `MAP` | `LIST OF ANY?` | Temporal | `DURATION` | `STRING` | `BOOLEAN` | `INTEGER` | `FLOAT`
+|`NODE`         | X      |                |        |       |                |          |            |          |           |           |
+|`RELATIONSHIP` |        | X              |        |       |                |          |            |          |           |           |
+|`PATH`         |        |                | X      |       |                |          |            |          |           |           |
+|`MAP`          |        |                |        | X     |                |          |            |          |           |           |
+|`LIST OF ANY?` |        |                |        |       | X              |          |            |          |           |           |
+|Temporal       |        |                |        |       |                | X^†^     |            |          |           |           |
+|`DURATION`     |        |                |        |       |                |          |            |          |           |           |
+|`STRING`       |        |                |        |       |                |          |            | X        |           |           |
+|`BOOLEAN`      |        |                |        |       |                |          |            |          | X         |           |
+|`INTEGER`      |        |                |        |       |                |          |            |          |           | X         | X
+|`FLOAT`        |        |                |        |       |                |          |            |          |           | X         | X
 |================================================================================================================================
 
 † Comparisons between _the same_ Temporal instant type will always return `true` or `false`, comparisons between _different_ temporal instant types will not.

--- a/tck/features/clauses/call/Call1.feature
+++ b/tck/features/clauses/call/Call1.feature
@@ -30,9 +30,9 @@
 
 Feature: Call1 - Basic procedure calling
 
-  Scenario: [1] Standalone call to VOID procedure that takes no arguments
+  Scenario: [1] Standalone call to procedure that takes no arguments and yields no results
     Given an empty graph
-    And there exists a procedure test.doNothing() :: VOID:
+    And there exists a procedure test.doNothing() :: ():
       |
     When executing query:
       """
@@ -41,9 +41,9 @@ Feature: Call1 - Basic procedure calling
     Then the result should be empty
     And no side effects
 
-  Scenario: [2] Standalone call to VOID procedure that takes no arguments, called with implicit arguments
+  Scenario: [2] Standalone call to procedure that takes no arguments and yields no results, called with implicit arguments
     Given an empty graph
-    And there exists a procedure test.doNothing() :: VOID:
+    And there exists a procedure test.doNothing() :: ():
       |
     When executing query:
       """
@@ -52,9 +52,9 @@ Feature: Call1 - Basic procedure calling
     Then the result should be empty
     And no side effects
 
-  Scenario: [3] In-query call to VOID procedure that takes no arguments
+  Scenario: [3] In-query call to procedure that takes no arguments and yields no results
     Given an empty graph
-    And there exists a procedure test.doNothing() :: VOID:
+    And there exists a procedure test.doNothing() :: ():
       |
     When executing query:
       """
@@ -66,9 +66,9 @@ Feature: Call1 - Basic procedure calling
       | n |
     And no side effects
 
-  Scenario: [4] In-query call to VOID procedure does not consume rows
+  Scenario: [4] In-query call to procedure that takes no arguments and yields no results and consumes no rows
     Given an empty graph
-    And there exists a procedure test.doNothing() :: VOID:
+    And there exists a procedure test.doNothing() :: ():
       |
     And having executed:
       """
@@ -89,29 +89,7 @@ Feature: Call1 - Basic procedure calling
       | 'c'  |
     And no side effects
 
-  Scenario: [5] Standalone call to procedure that takes no arguments and yields no results
-    Given an empty graph
-    And there exists a procedure test.doNothing() :: ():
-      |
-    When executing query:
-      """
-      CALL test.doNothing()
-      """
-    Then the result should be empty
-    And no side effects
-
-  Scenario: [6] Standalone call to procedure that takes no arguments and yields no results, called with implicit arguments
-    Given an empty graph
-    And there exists a procedure test.doNothing() :: ():
-      |
-    When executing query:
-      """
-      CALL test.doNothing
-      """
-    Then the result should be empty
-    And no side effects
-
-  Scenario: [7] Standalone call to STRING procedure that takes no arguments
+  Scenario: [5] Standalone call to STRING procedure that takes no arguments
     Given an empty graph
     And there exists a procedure test.labels() :: (label :: STRING?):
       | label |
@@ -129,7 +107,7 @@ Feature: Call1 - Basic procedure calling
       | 'C'   |
     And no side effects
 
-  Scenario: [8] In-query call to STRING procedure that takes no arguments
+  Scenario: [6] In-query call to STRING procedure that takes no arguments
     Given an empty graph
     And there exists a procedure test.labels() :: (label :: STRING?):
       | label |
@@ -149,7 +127,7 @@ Feature: Call1 - Basic procedure calling
     And no side effects
 
   @NegativeTest
-  Scenario: [9] Standalone call to procedure should fail if explicit argument is missing
+  Scenario: [7] Standalone call to procedure should fail if explicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
       | name | in | out |
@@ -160,7 +138,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
   @NegativeTest
-  Scenario: [10] In-query call to procedure should fail if explicit argument is missing
+  Scenario: [8] In-query call to procedure should fail if explicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
       | name | in | out |
@@ -172,7 +150,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
   @NegativeTest
-  Scenario: [11] Standalone call to procedure should fail if too many explicit argument are given
+  Scenario: [9] Standalone call to procedure should fail if too many explicit argument are given
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
       | in | out |
@@ -183,7 +161,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
   @NegativeTest
-  Scenario: [12] In-query call to procedure should fail if too many explicit argument are given
+  Scenario: [10] In-query call to procedure should fail if too many explicit argument are given
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
       | in | out |
@@ -195,7 +173,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
   @NegativeTest
-  Scenario: [13] Standalone call to procedure should fail if implicit argument is missing
+  Scenario: [11] Standalone call to procedure should fail if implicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
       | name | in | out |
@@ -208,7 +186,7 @@ Feature: Call1 - Basic procedure calling
     Then a ParameterMissing should be raised at compile time: MissingParameter
 
   @NegativeTest
-  Scenario: [14] In-query call to procedure that has outputs fails if no outputs are yielded
+  Scenario: [12] In-query call to procedure that has outputs fails if no outputs are yielded
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
       | in | out |
@@ -220,7 +198,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   @NegativeTest
-  Scenario: [15] Standalone call to unknown procedure should fail
+  Scenario: [13] Standalone call to unknown procedure should fail
     Given an empty graph
     When executing query:
       """
@@ -229,7 +207,7 @@ Feature: Call1 - Basic procedure calling
     Then a ProcedureError should be raised at compile time: ProcedureNotFound
 
   @NegativeTest
-  Scenario: [16] In-query call to unknown procedure should fail
+  Scenario: [14] In-query call to unknown procedure should fail
     Given an empty graph
     When executing query:
       """
@@ -239,7 +217,7 @@ Feature: Call1 - Basic procedure calling
     Then a ProcedureError should be raised at compile time: ProcedureNotFound
 
   @NegativeTest
-  Scenario: [17] In-query procedure call should fail if shadowing an already bound variable
+  Scenario: [15] In-query procedure call should fail if shadowing an already bound variable
     Given an empty graph
     And there exists a procedure test.labels() :: (label :: STRING?):
       | label |
@@ -255,7 +233,7 @@ Feature: Call1 - Basic procedure calling
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   @NegativeTest
-  Scenario: [18] In-query procedure call should fail if one of the argument expressions uses an aggregation function
+  Scenario: [16] In-query procedure call should fail if one of the argument expressions uses an aggregation function
     Given an empty graph
     And there exists a procedure test.labels(in :: INTEGER?) :: (label :: STRING?):
       | in | label |


### PR DESCRIPTION
The PR 

 * changes procedure signatures in TCK scenarios that have return type `VOID` to return type `()` and 
 * removes duplicate scenarios that result from this change.

Return type `VOID` to return type `()` do not have a semantics difference in openCypher at the moment. The [Call CIP](https://github.com/openCypher/openCypher/blob/master/cip/1.accepted/CIP2015-06-24-call-procedures.adoc) does not allow `VOID` as output signature. Hence, there is no point in keeping such scenarios.