### PR TITLE
Include invalid value in generated scenario name

### DIFF
--- a/tck/features/expressions/typeConversion/TypeConversion1.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion1.feature
@@ -83,7 +83,7 @@ Feature: TypeConversion1 - To Boolean
     And no side effects
 
   @NegativeTest
-  Scenario Outline: [5] `toBoolean()` on invalid types
+  Scenario Outline: [5] `toBoolean()` on invalid types '<invalid>'
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -122,7 +122,7 @@ Feature: TypeConversion2 - To Integer
     And no side effects
 
   @NegativeTest
-  Scenario Outline: [8] `toInteger()` failing on invalid arguments
+  Scenario Outline: [8] `toInteger()` failing on invalid arguments '<invalid>'
     Given an empty graph
     And having executed:
       """

--- a/tck/features/expressions/typeConversion/TypeConversion3.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion3.feature
@@ -97,7 +97,7 @@ Feature: TypeConversion3 - To Float
     And no side effects
 
   @NegativeTest
-  Scenario Outline: [6] `toFloat()` failing on invalid arguments
+  Scenario Outline: [6] `toFloat()` failing on invalid arguments '<invalid>'
     Given an empty graph
     And having executed:
       """

--- a/tck/features/expressions/typeConversion/TypeConversion4.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion4.feature
@@ -149,7 +149,7 @@ Feature: TypeConversion4 - To String
     And no side effects
 
   @NegativeTest
-  Scenario Outline: `toString()` failing on invalid arguments
+  Scenario Outline: `toString()` failing on invalid arguments '<invalid>'
     Given an empty graph
     And having executed:
       """


### PR DESCRIPTION
Include invalid value in generated scenario name to allow these scenarios to be individually deny listed, if necessary