### PR TITLE
Scenario fixes for M16

### DIFF
--- a/tck/features/clauses/merge/Merge1.feature
+++ b/tck/features/clauses/merge/Merge1.feature
@@ -306,4 +306,4 @@ Feature: Merge1 - Merge node
       """
       MERGE ({num: null})
       """
-    Then a SemanticError should be raised at compile time: MergeReadOwnWrites
+    Then a SemanticError should be raised at runtime: MergeReadOwnWrites

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -524,4 +524,4 @@ Feature: Merge5 - Merge relationships
       CREATE (a), (b)
       MERGE (a)-[r:X {num: null}]->(b)
       """
-    Then a SemanticError should be raised at compile time: MergeReadOwnWrites
+    Then a SemanticError should be raised at runtime: MergeReadOwnWrites

--- a/tck/features/clauses/set/Set1.feature
+++ b/tck/features/clauses/set/Set1.feature
@@ -186,7 +186,7 @@ Feature: Set1 - Set a Property
       CREATE (a)
       SET a.maplist = [{num: 1}]
       """
-    Then a TypeError should be raised at compile time: InvalidPropertyType
+    Then a TypeError should be raised at runtime: InvalidPropertyType
 
   Scenario: [11] Set multiple node properties
     Given an empty graph

--- a/tck/features/expressions/list/List1.feature
+++ b/tck/features/expressions/list/List1.feature
@@ -121,7 +121,7 @@ Feature: List1 - Dynamic Element Access
       WITH $expr AS expr, $idx AS idx
       RETURN expr[idx]
       """
-    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
+    Then a TypeError should be raised at compile time: ListElementAccessByNonInteger
 
   @NegativeTest
   Scenario: [8] Fail at compile time when attempting to index with a non-integer into a list

--- a/tck/features/expressions/literals/Literals2.feature
+++ b/tck/features/expressions/literals/Literals2.feature
@@ -152,4 +152,4 @@ Feature: Literals2 - Decimal integer
       """
       RETURN 9223372#54775808 AS literal
       """
-    Then a SyntaxError should be raised at compile time: InvalidNumberLiteral
+    Then a SyntaxError should be raised at compile time: UnexpectedSyntax

--- a/tck/features/expressions/literals/Literals8.feature
+++ b/tck/features/expressions/literals/Literals8.feature
@@ -348,7 +348,7 @@ Feature: Literals8 - Maps
       """
       RETURN {1} AS literal
       """
-    Then a SyntaxError should be raised at compile time: MissingParameter
+    Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
   @NegativeTest @skipGrammarCheck
   Scenario: [25] Fail on a map containing a list without key


### PR DESCRIPTION
**This PR builds on #477.**

The PR makes last fixes / adjustments to scenarios revealed necessary by running TCK against Neo4j. 

More specifically, the PR fixes error information of six @NegativeTest scenarios. In two is change a wrong error detail. In four is changes the phase where the error is detected, which is in principle too detailed specification for the TCK and probably needs to be removed in the longer run, anyway.