### PR TITLE
Facilitate named examples in scenario outlines

### DIFF
--- a/tck/features/expressions/typeConversion/TypeConversion1.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion1.feature
@@ -83,7 +83,7 @@ Feature: TypeConversion1 - To Boolean
     And no side effects
 
   @NegativeTest
-  Scenario Outline: [5] `toBoolean()` on invalid types
+  Scenario Outline: [5] `toBoolean()` on invalid types #Example: <exampleName>
     Given any graph
     When executing query:
       """
@@ -93,8 +93,8 @@ Feature: TypeConversion1 - To Boolean
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid |
-      | []      |
-      | {}      |
-      | 1       |
-      | 1.0     |
+      | invalid | exampleName |
+      | []      | list        |
+      | {}      | map         |
+      | 1       | integer     |
+      | 1.0     | float       |

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -45,20 +45,21 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-case class Scenario(categories: List[String], featureName: String, number: Option[Int], name: String, exampleIndex: Option[Int], tags: Set[String], steps: List[Step], source: io.cucumber.core.gherkin.Pickle, sourceFile: Path) {
+case class Scenario(categories: List[String], featureName: String, number: Option[Int], name: String, exampleIndex: Option[Int], exampleName: Option[String], tags: Set[String], steps: List[Step], source: io.cucumber.core.gherkin.Pickle, sourceFile: Path) {
 
   self =>
 
-  override def toString = s"""${ categories.mkString("/") } :: "$featureName" ::${number.map(ix => " ["+ix+"]").getOrElse("")} "$name" ${exampleIndex.map(ix => "#"+ix).getOrElse("")} ${ if (tags.nonEmpty) tags.mkString(" (", " ", ")") else "" }"""
+  override def toString = s"""${ categories.mkString("/") } :: "$featureName" ::${number.map(ix => " ["+ix+"]").getOrElse("")} "$name" ${exampleIndex.map(ix => "#"+ix).getOrElse("")}${exampleName.map(n => " ("+n+")").getOrElse("")}${ if (tags.nonEmpty) tags.mkString(" (", " ", ")") else "" }"""
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case Scenario(thatCategories, thatFeatureName, thatNumber, thatName, thatExampleIndex, thatTags, thatSteps, thatSource, _) =>
+      case Scenario(thatCategories, thatFeatureName, thatNumber, thatName, thatExampleIndex, thatExampleName, thatTags, thatSteps, thatSource, _) =>
         thatCategories == categories &&
         thatFeatureName == featureName &&
         thatNumber == number &&
         thatName == name &&
         thatExampleIndex == exampleIndex &&
+        thatExampleName == exampleName &&
         thatTags == tags &&
         thatSteps == steps &&
         Pickle(thatSource) == Pickle(source)

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/groups/Group.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/groups/Group.scala
@@ -128,9 +128,9 @@ case class ScenarioItem(override val scenario: Scenario, override val parentGrou
   override def name: String = scenario.name
 }
 
-case class ExampleItem(index: Int, override val scenario: Scenario, override val parentGroup: ScenarioOutline) extends Item {
-  override def description = s"#$index"
-  override def name: String = s"#$index"
+case class ExampleItem(index: Int, exampleName: Option[String], override val scenario: Scenario, override val parentGroup: ScenarioOutline) extends Item {
+  override def description = s"#$index${exampleName.map(n => " ("+n+")").getOrElse("")}"
+  override def name: String = s"#$index${exampleName.map(n => " ("+n+")").getOrElse("")}"
 }
 
 object ExampleItem {

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/groups/TckTree.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/groups/TckTree.scala
@@ -57,7 +57,7 @@ case class TckTree(scenarios: Seq[Scenario]) extends GroupTreeBasics {
       scenario.exampleIndex.
         map(i => {
           val o = ScenarioOutline(scenario.number, scenario.name, parent)
-          val e = ExampleItem(i, scenario, o)
+          val e = ExampleItem(i, scenario.exampleName, scenario, o)
           Seq[Group](o, e)
         }).getOrElse(Seq[Group](ScenarioItem(scenario, parent)))
     )

--- a/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Outline.feature
+++ b/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Outline.feature
@@ -45,3 +45,56 @@ Feature: Outline
       | 1      | 1      | 1      |
       | 2      | 2      | 2      |
       | 3      | 3      | 3      |
+
+  @numbered
+  Scenario Outline: [2] Outline Test with some and overlapping example name #Example: <exampleName>
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <sample>
+      """
+    Then the result should be, in any order:
+      | <column> |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | sample | column | result | exampleName |
+      | 1      | 1      | 1      | one         |
+      | 2      | 2      | 2      |             |
+      | 3      | 3      | 3      | threeFour   |
+      | 4      | 4      | 4      | threeFour   |
+
+  @numbered @fullyNamed
+  Scenario Outline: [3] Outline Test with all example name #Example: <exampleName>
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <sample>
+      """
+    Then the result should be, in any order:
+      | <column> |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | sample | column | result | exampleName |
+      | 1      | 1      | 1      | one         |
+      | 2      | 2      | 2      | two         |
+      | 3      | 3      | 3      | three       |
+
+  @numbered @fullyNamed
+  Scenario Outline: [4] Outline Test with a single example #Example: <exampleName>
+    Given an empty graph
+    When executing query:
+      """
+      RETURN <sample>
+      """
+    Then the result should be, in any order:
+      | <column> |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | sample | column | result | exampleName |
+      | 1      | 1      | 1      | one         |

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/ScenarioTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/ScenarioTest.scala
@@ -110,12 +110,12 @@ class ScenarioTest extends AnyFunSuite with Matchers {
 
   test("Check equality of equal scenarios differing in source") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(2), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(2), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("2", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(2), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(2), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 2).getSteps.get(0)), Measure(pickle("3", "s", 2).getSteps.get(1))),
       pickle("1", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -125,12 +125,12 @@ class ScenarioTest extends AnyFunSuite with Matchers {
 
   test("Check equality of equal scenarios not differing in source") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(2), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(2), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("2", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(2), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(2), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("2", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
@@ -47,7 +47,7 @@ class TCKApiTest extends AnyFunSuite with Matchers {
   }
 
   test("example index of non-outline scenarios") {
-    val nonOutlineScenarios = scenarios.filterNot(s => s.featureName == "Outline" && s.name == "Outline Test")
+    val nonOutlineScenarios = scenarios.filterNot(s => s.featureName == "Outline" && s.name.startsWith("Outline Test"))
     all (nonOutlineScenarios) should have ('exampleIndex (None))
   }
 
@@ -59,6 +59,21 @@ class TCKApiTest extends AnyFunSuite with Matchers {
         s2.source.getLocation.getLine > s.source.getLocation.getLine
       })
     })
+  }
+
+  test("example name of non-outline scenarios should have not an example name") {
+    val nonOutlineScenarios = scenarios.filterNot(s => s.featureName == "Outline" && s.name.startsWith("Outline Test"))
+    nonOutlineScenarios.foreach(s => s.exampleName should be (None))
+  }
+
+  test("example name of outline scenarios with named examples should have an example name") {
+    val namedOutlineScenarios = scenarios.filter(s => s.featureName == "Outline" && s.name.startsWith("Outline Test") && s.tags.contains("@fullyNamed"))
+    namedOutlineScenarios.foreach(s => s.exampleName should not be None)
+  }
+
+  test("scenarios with an example name should have an example index") {
+    val scenariosWithExampleName = scenarios.filter(_.exampleName.nonEmpty)
+    scenariosWithExampleName.foreach(s => s.exampleIndex should not be None)
   }
 
   test("numbered scenarios have a number") {

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/GroupCanonicalOrderingTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/GroupCanonicalOrderingTest.scala
@@ -77,17 +77,17 @@ class GroupCanonicalOrderingTest extends AnyFunSpec with GroupTest {
     val ftr = Feature("ftr", Total)
 
     val expected = Seq(
-      ScenarioItem(createScenario(List(), ftr.name, Some(1), "alpha", None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, Some(1), "alpha", None, None, Set()), ftr),
       ScenarioOutline(Some(1), "gamma", ftr),
-      ScenarioItem(createScenario(List(), ftr.name, Some(2), "alpha", None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, Some(2), "alpha", None, None, Set()), ftr),
       ScenarioOutline(Some(2), "beta", ftr),
-      ScenarioItem(createScenario(List(), ftr.name, Some(2), "gamma", None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, Some(2), "gamma", None, None, Set()), ftr),
       ScenarioOutline(Some(3), "gamma", ftr),
-      ScenarioItem(createScenario(List(), ftr.name, Some(23), "alpha", None, Set()), ftr),
-      ScenarioItem(createScenario(List(), ftr.name, Some(23), "delta", None, Set()), ftr),
-      ScenarioItem(createScenario(List(), ftr.name, None, "aaa", None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, Some(23), "alpha", None, None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, Some(23), "delta", None, None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, None, "aaa", None, None, Set()), ftr),
       ScenarioOutline(None, "ac", ftr),
-      ScenarioItem(createScenario(List(), ftr.name, None, "uwvxyz", None, Set()), ftr),
+      ScenarioItem(createScenario(List(), ftr.name, None, "uwvxyz", None, None, Set()), ftr),
     )
 
     testOrderingOfSortedShuffles(expected, (s: Seq[Numbered]) => s.sorted)
@@ -95,14 +95,14 @@ class GroupCanonicalOrderingTest extends AnyFunSpec with GroupTest {
 
   describe("ExampleItem groups should be ordered by their index") {
     val scrOut = ScenarioOutline(Some(1), "alpha", Feature("ftr", Total))
-    val scr = createScenario(List(), scrOut.parentGroup.name, None, scrOut.name, Some(1), Set())
+    val scr = createScenario(List(), scrOut.parentGroup.name, None, scrOut.name, Some(1), None, Set())
 
     val expected = Seq(
-      ExampleItem(1, scr, scrOut),
-      ExampleItem(2, scr, scrOut),
-      ExampleItem(4, scr, scrOut),
-      ExampleItem(77, scr, scrOut),
-      ExampleItem(123, scr, scrOut),
+      ExampleItem(1, Some("xyz"), scr, scrOut),
+      ExampleItem(2, Some("abc"), scr, scrOut),
+      ExampleItem(4, None, scr, scrOut),
+      ExampleItem(77, Some("123"), scr, scrOut),
+      ExampleItem(123, Some("edf"), scr, scrOut),
     )
 
     testOrderingOfSortedShuffles(expected, (s: Seq[ExampleItem]) => s.sorted)

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/GroupTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/GroupTest.scala
@@ -38,7 +38,7 @@ import org.opencypher.tools.tck.api.Step
 import org.scalatest.matchers.should.Matchers
 
 trait GroupTest extends Matchers {
-  def createScenario(categories: List[String], featureName: String, number: Option[Int], name: String, index: Option[Int], tags: Set[String]): Scenario = {
+  def createScenario(categories: List[String], featureName: String, number: Option[Int], name: String, index: Option[Int], exampleName: Option[String], tags: Set[String]): Scenario = {
     val dummyPickle: Pickle = new io.cucumber.core.gherkin.Pickle() {
       override val getKeyword: String = ""
 
@@ -92,7 +92,7 @@ trait GroupTest extends Matchers {
     val dummySteps: List[Step] = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))
     val dummyPath: java.nio.file.Path = new java.io.File("ftr1.feature").toPath
 
-    Scenario(categories, featureName, number, name, index, tags, dummySteps, dummyPickle, dummyPath)
+    Scenario(categories, featureName, number, name, index, exampleName, tags, dummySteps, dummyPickle, dummyPath)
   }
 
 }

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/TckTreeTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/TckTreeTest.scala
@@ -204,10 +204,10 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
   }
 
   describe("The given list of four scenarios in a top-level feature, the TckTree") {
-    val scr1A = createScenario(List[String](), "ftr1", Some(1), "a", None, Set[String]())
-    val scr2B = createScenario(List[String](), "ftr1", Some(2), "b", None, Set[String]())
-    val scr3A = createScenario(List[String](), "ftr1", Some(3), "a", None, Set[String]())
-    val scr3B = createScenario(List[String](), "ftr1", Some(3), "b", None, Set[String]())
+    val scr1A = createScenario(List[String](), "ftr1", Some(1), "a", None, None, Set[String]())
+    val scr2B = createScenario(List[String](), "ftr1", Some(2), "b", None, None, Set[String]())
+    val scr3A = createScenario(List[String](), "ftr1", Some(3), "a", None, None, Set[String]())
+    val scr3B = createScenario(List[String](), "ftr1", Some(3), "b", None, None, Set[String]())
 
     val scenarios = rand.shuffle(List(scr1A, scr2B, scr3A, scr3B))
     val tckTree = TckTree(scenarios)
@@ -242,8 +242,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
   }
 
   describe("The given list of two scenarios from a scenario outline in a top-level feature, the TckTree") {
-    val scr1 = createScenario(List[String](), "ftr1", Some(1), "scr", Some(1), Set[String]())
-    val scr2 = createScenario(List[String](), "ftr1", Some(1), "scr", Some(2), Set[String]())
+    val scr1 = createScenario(List[String](), "ftr1", Some(1), "scr", Some(1), None, Set[String]())
+    val scr2 = createScenario(List[String](), "ftr1", Some(1), "scr", Some(2), Some("two"), Set[String]())
 
     val scenarios = rand.shuffle(List(scr1, scr2))
     val tckTree = TckTree(scenarios)
@@ -255,8 +255,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         Total -> Set(scr1, scr2),
         Feature("ftr1", Total) -> Set(scr1, scr2),
         ScenarioOutline(Some(1), "scr", Feature("ftr1", Total)) -> Set(scr1, scr2),
-        ExampleItem(1, scr1, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))) -> Set(scr1),
-        ExampleItem(2, scr2, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))) -> Set(scr2),
+        ExampleItem(1, None, scr1, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))) -> Set(scr1),
+        ExampleItem(2, Some("two"), scr2, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))) -> Set(scr2),
       )
 
       tckTree.groupedScenarios should equal(expected)
@@ -267,8 +267,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         Total,
         Feature("ftr1", Total),
         ScenarioOutline(Some(1), "scr", Feature("ftr1", Total)),
-        ExampleItem(1, scr1, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))),
-        ExampleItem(2, scr2, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))),
+        ExampleItem(1, None, scr1, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))),
+        ExampleItem(2, Some("two"), scr2, ScenarioOutline(Some(1), "scr", Feature("ftr1", Total))),
       )
 
       tckTree.groupsOrderedDepthFirst should equal(expected)
@@ -276,10 +276,10 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
   }
 
   describe("The given list of four scenarios, the TckTree") {
-    val scrA = createScenario(List[String](), "ftr5", Some(1), "scrA", None, Set[String]())
-    val scrB = createScenario(List[String](), "ftr1", Some(1), "scrB", None, Set[String]("A"))
-    val scrC = createScenario(List[String]("b"), "ftr11", Some(1), "scrC", None, Set[String]("A"))
-    val scrD = createScenario(List[String]("b"), "ftr3", Some(1), "scrD", None, Set[String]("B"))
+    val scrA = createScenario(List[String](), "ftr5", Some(1), "scrA", None, None, Set[String]())
+    val scrB = createScenario(List[String](), "ftr1", Some(1), "scrB", None, None, Set[String]("A"))
+    val scrC = createScenario(List[String]("b"), "ftr11", Some(1), "scrC", None, None, Set[String]("A"))
+    val scrD = createScenario(List[String]("b"), "ftr3", Some(1), "scrD", None, None, Set[String]("B"))
 
     val scenarios = rand.shuffle(List(scrA, scrB, scrC, scrD))
     val tckTree = TckTree(scenarios)
@@ -375,17 +375,17 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
   }
 
   describe("The given list of ten scenarios, the TckTree") {
-    val scrA = createScenario(List[String](), "ftr5 - a", Some(1), "a", None, Set[String]())
-    val scrB = createScenario(List[String](), "ftr1 - b", Some(1), "b", None, Set[String]("A"))
-    val scrC = createScenario(List[String](), "ftr1 - b", Some(2), "c", None, Set[String]("A"))
-    val scrD = createScenario(List[String]("b"), "ftr11 - c", Some(1), "d", None, Set[String]("A", "C"))
-    val scrE = createScenario(List[String]("b"), "ftr11", Some(1), "e", None, Set[String]("A", "C"))
-    val scrF1 = createScenario(List[String]("a", "b"), "ftr2", Some(1), "f", Some(1), Set[String]("C"))
-    val scrF2 = createScenario(List[String]("a", "b"), "ftr2", Some(1), "f", Some(2), Set[String]("C"))
-    val scrG = createScenario(List[String]("a", "b"), "ftr", Some(1), "g", None, Set[String]("D"))
-    val scrH = createScenario(List[String]("b"), "ftr11 - b", Some(1), "h", None, Set[String]("D", "2"))
-    val scrI = createScenario(List[String]("b"), "ftr3", Some(1), "i", None, Set[String]("B"))
-    val scrJ = createScenario(List[String]("a", "b"), "ftrX", Some(1), "j", None, Set[String]("11"))
+    val scrA = createScenario(List[String](), "ftr5 - a", Some(1), "a", None, None, Set[String]())
+    val scrB = createScenario(List[String](), "ftr1 - b", Some(1), "b", None, None, Set[String]("A"))
+    val scrC = createScenario(List[String](), "ftr1 - b", Some(2), "c", None, None, Set[String]("A"))
+    val scrD = createScenario(List[String]("b"), "ftr11 - c", Some(1), "d", None, None, Set[String]("A", "C"))
+    val scrE = createScenario(List[String]("b"), "ftr11", Some(1), "e", None, None, Set[String]("A", "C"))
+    val scrF1 = createScenario(List[String]("a", "b"), "ftr2", Some(1), "f", Some(1), None, Set[String]("C"))
+    val scrF2 = createScenario(List[String]("a", "b"), "ftr2", Some(1), "f", Some(2), Some("two"), Set[String]("C"))
+    val scrG = createScenario(List[String]("a", "b"), "ftr", Some(1), "g", None, None, Set[String]("D"))
+    val scrH = createScenario(List[String]("b"), "ftr11 - b", Some(1), "h", None, None, Set[String]("D", "2"))
+    val scrI = createScenario(List[String]("b"), "ftr3", Some(1), "i", None, None, Set[String]("B"))
+    val scrJ = createScenario(List[String]("a", "b"), "ftrX", Some(1), "j", None, None, Set[String]("11"))
 
     val scenarios = rand.shuffle(List(scrA, scrB, scrC, scrD, scrE, scrF1, scrF2, scrG, scrH, scrI, scrJ))
     val tckTree = TckTree(scenarios)
@@ -414,8 +414,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         ScenarioItem(scrG, ftr) -> Set(scrG),
         ftr2 -> Set(scrF1, scrF2),
         ScenarioOutline(Some(1), "f", ftr2) -> Set(scrF1, scrF2),
-        ExampleItem(1, scrF1, ScenarioOutline(Some(1), "f", ftr2)) -> Set(scrF1),
-        ExampleItem(2, scrF2, ScenarioOutline(Some(1), "f", ftr2)) -> Set(scrF2),
+        ExampleItem(1, None, scrF1, ScenarioOutline(Some(1), "f", ftr2)) -> Set(scrF1),
+        ExampleItem(2, Some("two"), scrF2, ScenarioOutline(Some(1), "f", ftr2)) -> Set(scrF2),
         ftrX -> Set(scrJ),
         ScenarioItem(scrJ, ftrX) -> Set(scrJ),
         scB -> Set(scrD, scrE, scrH, scrI),
@@ -447,8 +447,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         ScenarioItem(scrD, Tag("C")) -> Set(scrD),
         ScenarioItem(scrE, Tag("C")) -> Set(scrE),
         ScenarioOutline(Some(1), "f", Tag("C")) -> Set(scrF1, scrF2),
-        ExampleItem(1, scrF1, ScenarioOutline(Some(1), "f", Tag("C"))) -> Set(scrF1),
-        ExampleItem(2, scrF2, ScenarioOutline(Some(1), "f", Tag("C"))) -> Set(scrF2),
+        ExampleItem(1, None, scrF1, ScenarioOutline(Some(1), "f", Tag("C"))) -> Set(scrF1),
+        ExampleItem(2, Some("two"), scrF2, ScenarioOutline(Some(1), "f", Tag("C"))) -> Set(scrF2),
         Tag("D") -> Set(scrG, scrH),
         ScenarioItem(scrG, Tag("D")) -> Set(scrG),
         ScenarioItem(scrH, Tag("D")) -> Set(scrH),
@@ -467,8 +467,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         ScenarioItem(scrG, ftr),
         ftr2,
         ScenarioOutline(Some(1), "f", ftr2),
-        ExampleItem(1, scrF1, ScenarioOutline(Some(1), "f", ftr2)),
-        ExampleItem(2, scrF2, ScenarioOutline(Some(1), "f", ftr2)),
+        ExampleItem(1, None, scrF1, ScenarioOutline(Some(1), "f", ftr2)),
+        ExampleItem(2, Some("two"), scrF2, ScenarioOutline(Some(1), "f", ftr2)),
         ftrX,
         ScenarioItem(scrJ, ftrX),
         scB,
@@ -500,8 +500,8 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
         ScenarioItem(scrD, Tag("C")),
         ScenarioItem(scrE, Tag("C")),
         ScenarioOutline(Some(1), "f", Tag("C")),
-        ExampleItem(1, scrF1, ScenarioOutline(Some(1), "f", Tag("C"))),
-        ExampleItem(2, scrF2, ScenarioOutline(Some(1), "f", Tag("C"))),
+        ExampleItem(1, None, scrF1, ScenarioOutline(Some(1), "f", Tag("C"))),
+        ExampleItem(2, Some("two"), scrF2, ScenarioOutline(Some(1), "f", Tag("C"))),
         Tag("D"),
         ScenarioItem(scrG, Tag("D")),
         ScenarioItem(scrH, Tag("D")),

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/PageBasic.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/browser/web/PageBasic.scala
@@ -105,7 +105,7 @@ trait PageBasic {
   }
 
   def scenarioTitle(scenario: Scenario): String =
-    scenario.name + scenario.exampleIndex.map(i => " #" + i).getOrElse("")
+    scenario.name + scenario.exampleIndex.map(i => " #" + i).getOrElse("") + scenario.exampleName.map(n => " (" + n + ")").getOrElse("")
 
   def scenarioLocationFrag(scenario: Scenario,
                            collection: Option[String] = None,

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiff.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiff.scala
@@ -43,6 +43,7 @@ object ScenarioDiffTag {
   case object StepsChanged extends ScenarioDiffTag
   case object SourceChanged extends ScenarioDiffTag
   case object ExampleIndexChanged extends ScenarioDiffTag
+  case object ExampleNameChanged extends ScenarioDiffTag
   case object PotentiallyRenamed extends ScenarioDiffTag
   case object Different extends ScenarioDiffTag
 }
@@ -59,16 +60,18 @@ case class ScenarioDiff(before: Scenario, after: Scenario) extends Diff[Scenario
 
   lazy val exampleIndex: ElementDiff[Option[Int]] = ElementDiff(before.exampleIndex, after.exampleIndex)
 
+  lazy val exampleName: ElementDiff[Option[String]] = ElementDiff(before.exampleName, after.exampleName)
+
   lazy val tags: SetDiff[String] = SetDiff(before.tags, after.tags)
 
   lazy val steps: LCSbasedListDiff[Step] = LCSbasedListDiff(before.steps, after.steps)
 
   lazy val diffTags: Set[ScenarioDiffTag] = diffTags(before, after)
 
-  lazy val potentialDuplicate: Boolean = diffTags subsetOf Set[ScenarioDiffTag](Moved, Retagged, ExampleIndexChanged, StepsChanged, PotentiallyRenamed)
+  lazy val potentialDuplicate: Boolean = diffTags subsetOf Set[ScenarioDiffTag](Moved, Retagged, ExampleIndexChanged, ExampleNameChanged, StepsChanged, PotentiallyRenamed)
 
   private def diffTags(before: Scenario, after: Scenario): Set[ScenarioDiffTag] = {
-    val diff = Set[ScenarioDiffTag](Unchanged, SourceUnchanged, SourceChanged, Moved, NumberChanged, Retagged, StepsChanged, ExampleIndexChanged, PotentiallyRenamed).filter {
+    val diff = Set[ScenarioDiffTag](Unchanged, SourceUnchanged, SourceChanged, Moved, NumberChanged, Retagged, StepsChanged, ExampleIndexChanged, ExampleNameChanged, PotentiallyRenamed).filter {
       case Unchanged => before.equals(after)
       case SourceUnchanged =>
         before.equals(after) &&
@@ -97,6 +100,16 @@ case class ScenarioDiff(before: Scenario, after: Scenario) extends Diff[Scenario
           !number.changed &&
           !name.changed &&
           exampleIndex.changed &&
+          !tags.changed &&
+          !steps.changed &&
+          Pickle(after.source) == Pickle(before.source)
+      case ExampleNameChanged =>
+        !categories.changed &&
+          !featureName.changed &&
+          !number.changed &&
+          !name.changed &&
+          !exampleIndex.changed &&
+          exampleName.changed &&
           !tags.changed &&
           !steps.changed &&
           Pickle(after.source) == Pickle(before.source)

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
@@ -97,7 +97,7 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   private def dummyPath(path: String): java.nio.file.Path = new java.io.File("ftr1.feature").toPath
 
   test("Count single top-level scenario without tags") {
-    val scenarios: Seq[Scenario] = Seq(Scenario(List[String](), "ftr1", Some(1), "scr1", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
+    val scenarios: Seq[Scenario] = Seq(Scenario(List[String](), "ftr1", Some(1), "scr1", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
     val expectedCountOutput: String =
       """Total        1
         || ftr1       1""".stripMargin
@@ -105,7 +105,7 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Count single top-level scenario with tag") {
-    val scenarios: Seq[Scenario] = Seq(Scenario(List[String](), "ftr1", Some(1), "scr1", None, Set[String]("A", "@B", "C"), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
+    val scenarios: Seq[Scenario] = Seq(Scenario(List[String](), "ftr1", Some(1), "scr1", None, None, Set[String]("A", "@B", "C"), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
     val expectedCountOutput: String =
       """Total        1
         || ftr1       1
@@ -116,7 +116,7 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Count single sub-level scenario without tags") {
-    val scenarios: Seq[Scenario] = Seq(Scenario(List[String]("A", "B", "C"), "ftr1", Some(1), "scr1", None, Set[String](), List[Step](), dummyPickle, dummyPath("A/B/C/ftr1.feature")))
+    val scenarios: Seq[Scenario] = Seq(Scenario(List[String]("A", "B", "C"), "ftr1", Some(1), "scr1", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("A/B/C/ftr1.feature")))
     val expectedCountOutput: String =
       """Total              1
         || A                1
@@ -128,8 +128,8 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
 
   test("Count two top-level scenarios in same feature without tags") {
     val scenarios: Seq[Scenario] = Seq(
-      Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
-      Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
+      Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
+      Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
     val expectedCountOutput: String =
       """Total        2
         || ftr1       2""".stripMargin
@@ -138,9 +138,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
 
   test("Count three top-level scenarios in two features without tags") {
     val scenarios: Seq[Scenario] = Seq(
-      Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
-      Scenario(List[String](), "ftr2", Some(1), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature")),
-      Scenario(List[String](), "ftr1", Some(2), "scrC", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
+      Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
+      Scenario(List[String](), "ftr2", Some(1), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature")),
+      Scenario(List[String](), "ftr1", Some(2), "scrC", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
     val expectedCountOutput: String =
       """Total        3
         || ftr1       2
@@ -150,9 +150,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
 
   test("Count three top-level scenarios in two features with tags") {
     val scenarios: Seq[Scenario] = Seq(
-      Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String]("C", "B"), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
-      Scenario(List[String](), "ftr2", Some(1), "scrB", None, Set[String]("C", "D", "A"), List[Step](), dummyPickle, dummyPath("ftr2.feature")),
-      Scenario(List[String](), "ftr1", Some(2), "scrC", None, Set[String]("A", "C"), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
+      Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String]("C", "B"), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
+      Scenario(List[String](), "ftr2", Some(1), "scrB", None, None, Set[String]("C", "D", "A"), List[Step](), dummyPickle, dummyPath("ftr2.feature")),
+      Scenario(List[String](), "ftr1", Some(2), "scrC", None, None, Set[String]("A", "C"), List[Step](), dummyPickle, dummyPath("ftr1.feature")))
     val expectedCountOutput: String =
       """Total        3
         || ftr1       2
@@ -166,9 +166,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
 
   test("Count three mixed-level scenarios without tags") {
     val scenarios: Seq[Scenario] = Seq(
-      Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
-      Scenario(List[String]("T", "C", "K"), "ftr2", Some(1), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
-      Scenario(List[String]("T", "A", "K"), "ftr1", Some(1), "scrC", None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/A/ftr1.feature")))
+      Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
+      Scenario(List[String]("T", "C", "K"), "ftr2", Some(1), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
+      Scenario(List[String]("T", "A", "K"), "ftr1", Some(1), "scrC", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/A/ftr1.feature")))
     val expectedCountOutput: String =
       """Total              3
         || T                2
@@ -184,11 +184,11 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
 
   test("Count five mixed-level scenarios with tags") {
     val scenarios: Seq[Scenario] = Seq(
-      Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String]("C", "B"), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
-      Scenario(List[String]("T", "C", "K"), "ftr2", Some(1), "scrB", None, Set[String]("C", "D", "A"), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
-      Scenario(List[String]("T", "A", "K"), "ftr1", Some(1), "scrC", None, Set[String]("A", "C"), List[Step](), dummyPickle, dummyPath("T/A/K/ftr1.feature")),
-      Scenario(List[String]("T", "C", "K"), "ftr2", Some(2), "scrD", None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
-      Scenario(List[String]("T"), "ftr3", Some(1), "scrE", None, Set[String]("B", "A", "C"), List[Step](), dummyPickle, dummyPath("T/ftr3.feature")))
+      Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String]("C", "B"), List[Step](), dummyPickle, dummyPath("ftr1.feature")),
+      Scenario(List[String]("T", "C", "K"), "ftr2", Some(1), "scrB", None, None, Set[String]("C", "D", "A"), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
+      Scenario(List[String]("T", "A", "K"), "ftr1", Some(1), "scrC", None, None, Set[String]("A", "C"), List[Step](), dummyPickle, dummyPath("T/A/K/ftr1.feature")),
+      Scenario(List[String]("T", "C", "K"), "ftr2", Some(2), "scrD", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("T/C/K/ftr2.feature")),
+      Scenario(List[String]("T"), "ftr3", Some(1), "scrE", None, None, Set[String]("B", "A", "C"), List[Step](), dummyPickle, dummyPath("T/ftr3.feature")))
     val expectedCountOutput: String =
       """Total              5
         || T                4
@@ -229,8 +229,8 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with one scenario added from a top-level same feature without tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrB)),
       TckTree(Seq(scrA, scrB))
@@ -246,8 +246,8 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with one scenario removed from a top-level same feature without tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA, scrB)),
       TckTree(Seq(scrB))
@@ -263,9 +263,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with one scenario moved to another top-level feature without tags") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA1, scrB)),
       TckTree(Seq(scrA2, scrB))
@@ -282,9 +282,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with one scenario moved to another sub-level feature without tags") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA1, scrB)),
       TckTree(Seq(scrA2, scrB))
@@ -302,10 +302,10 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with one scenario moved to another top-level feature and a changed tag") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA1, scrB1)),
       TckTree(Seq(scrA2, scrB2))
@@ -324,12 +324,12 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   }
 
   test("Report pretty diff counts with two scenarios from an outline in a top-level feature have a changed tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrC = Scenario(List[String](), "ftr1", Some(3), "scrC", None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB0x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrC = Scenario(List[String](), "ftr1", Some(3), "scrC", None, None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB0x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), None, Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA, scrB0, scrB1, scrC)),
       TckTree(Seq(scrA, scrB0x, scrB1x, scrC))
@@ -349,9 +349,9 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
   test("Report pretty diff counts with one scenario changed in categories, tags, and content of steps") {
     val stepsA1: List[Step] = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))
     val stepsA2: List[Step] = List[Step](Measure(dummyPickleStep), Dummy(dummyPickleStep))
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val tckTreeDiff = TckTreeDiff(
       TckTree(Seq(scrA1, scrB)),
       TckTree(Seq(scrA2, scrB))

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
@@ -187,6 +187,23 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
     result.removedScenarios should equal(Set())
   }
 
+  test("Diff a group with scenarios from an outline with a change in example name") {
+    val scr0 = Scenario(List[String](), "ftr1", Some(1), "scrB", Some(0), None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scr1 = Scenario(List[String](), "ftr1", Some(1), "scrB", Some(1), Some("a"), Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scr2 = Scenario(List[String](), "ftr1", Some(1), "scrB", Some(2), None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scr1x = Scenario(List[String](), "ftr1", Some(1), "scrB", Some(1), Some("b"), Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val result = GroupDiff(Seq(scr0, scr1, scr2), Seq(scr0, scr1x, scr2))
+
+    val scr1scr1xDiff = ScenarioDiff(scr1, scr1x)
+    scr1scr1xDiff.diffTags should equal(Set(ExampleNameChanged))
+
+    result.unchangedScenarios should equal(Set(scr0, scr2))
+    result.movedScenarios should equal(Set())
+    result.changedScenarios should equal(Set(scr1scr1xDiff))
+    result.addedScenarios should equal(Set())
+    result.removedScenarios should equal(Set())
+  }
+
   test("Diff a group with one scenario has changed tags, one is added, one is removed") {
     val stepsA = List[Step](Dummy(dummyPickleStep))
     val stepsB = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/GroupDiffTest.scala
@@ -95,8 +95,8 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   private def dummyPath(path: String): java.nio.file.Path = new java.io.File("ftr1.feature").toPath
 
   test("Diff a group with one scenario added") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrB), Seq(scrA, scrB))
 
     result.unchangedScenarios should equal(Set(scrB))
@@ -107,8 +107,8 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff a group with one scenario removed") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA, scrB), Seq(scrB))
 
     result.unchangedScenarios should equal(Set(scrB))
@@ -119,9 +119,9 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff a group with one scenario moved to another feature") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA1, scrB), Seq(scrA2, scrB))
 
     val scrA1scrA2Diff = ScenarioDiff(scrA1, scrA2)
@@ -135,9 +135,9 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff a group with one scenario moved to another sub-feature") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA1, scrB), Seq(scrA2, scrB))
 
     val scrA1scrA2Diff = ScenarioDiff(scrA1, scrA2)
@@ -151,10 +151,10 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff a group with one scenario moved to another feature and one with a changed tag") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA1, scrB1), Seq(scrA2, scrB2))
 
     val scrA1scrA2Diff = ScenarioDiff(scrA1, scrA2)
@@ -170,11 +170,11 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff a group with one scenario from an outline in a feature has a changed tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(2), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(2), None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA, scrB0, scrB1, scrB2), Seq(scrA, scrB0, scrB1x, scrB2))
 
     val scrB1scrB1xDiff = ScenarioDiff(scrB1, scrB1x)
@@ -192,11 +192,11 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
     val stepsB = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))
     val stepsC = List[Step](Measure(dummyPickleStep), Dummy(dummyPickleStep))
     val stepsD = List[Step](Measure(dummyPickleStep))
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), stepsA, dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("A"), stepsB, dummyPickle, dummyPath("ftr1.feature"))
-    val scrC1 = Scenario(List[String](), "ftr1", Some(3), "scrC", None, Set[String]("A"), stepsC, dummyPickle, dummyPath("ftr1.feature"))
-    val scrC2 = Scenario(List[String](), "ftr1", Some(3), "scrC", None, Set[String]("B"), stepsC, dummyPickle, dummyPath("ftr1.feature"))
-    val scrD = Scenario(List[String](), "ftr1", Some(4), "scrD", None, Set[String]("B"), stepsD, dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), stepsA, dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("A"), stepsB, dummyPickle, dummyPath("ftr1.feature"))
+    val scrC1 = Scenario(List[String](), "ftr1", Some(3), "scrC", None, None, Set[String]("A"), stepsC, dummyPickle, dummyPath("ftr1.feature"))
+    val scrC2 = Scenario(List[String](), "ftr1", Some(3), "scrC", None, None, Set[String]("B"), stepsC, dummyPickle, dummyPath("ftr1.feature"))
+    val scrD = Scenario(List[String](), "ftr1", Some(4), "scrD", None, None, Set[String]("B"), stepsD, dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA, scrB, scrC1), Seq(scrA, scrC2, scrD))
 
     val scrC1scrC2Diff = ScenarioDiff(scrC1, scrC2)
@@ -212,9 +212,9 @@ class GroupDiffTest extends AnyFunSuite with Matchers {
   test("Diff a group with one scenario changed in categories, tags, and content of steps") {
     val stepsA1 = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))
     val stepsA2 = List[Step](Measure(dummyPickleStep), Dummy(dummyPickleStep))
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val result = GroupDiff(Seq(scrA1, scrB), Seq(scrA2, scrB))
 
     val scrA1scrA2Diff = ScenarioDiff(scrA1, scrA2)

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/ScenarioDiffTest.scala
@@ -115,12 +115,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff equal scenarios not differing in source") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
@@ -130,12 +130,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff equal scenarios differing in source") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(0)), Measure(pickle("2", "s", 2).getSteps.get(1))),
       pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -145,12 +145,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff scenarios differing in category only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("XX", "A"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("XX", "A"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(0)), Measure(pickle("2", "s", 2).getSteps.get(1))),
       pickle("2", "s", 2), new java.io.File("XX/A/f.feature").toPath
     )
@@ -160,12 +160,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff scenarios differing in tags only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "exec", 1).getSteps.get(0)), Measure(pickle("1", "result", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "XX"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "XX"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(0)), Measure(pickle("2", "s", 2).getSteps.get(1))),
       pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -175,12 +175,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff scenarios differing in kind of steps only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Measure(pickle("2", "s", 2).getSteps.get(0)), Dummy(pickle("2", "s", 2).getSteps.get(1))),
       pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -190,12 +190,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff scenarios differing in content of steps only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(1)), Measure(pickle("2", "s", 2).getSteps.get(0))),
       pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -205,12 +205,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff equal scenarios differing in example index only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", Some(0), Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(0), None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", Some(1), Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(1), None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(0)), Measure(pickle("2", "s", 2).getSteps.get(1))),
       pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -218,14 +218,29 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
     ScenarioDiff(scenarioBefore, scenarioAfter).diffTags should equal(Set[ScenarioDiffTag](ExampleIndexChanged))
   }
 
-  test("Diff scenarios differing in categories, tags, and content of steps only") {
+  test("Diff equal scenarios differing in example name only") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(0), Some("a"), Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("XX", "B"), "f", Some(1), "s", None, Set[String]("S", "XX"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(0), Some("b"), Set[String]("S", "T"),
+      List[Step](Dummy(pickle("2", "s", 2).getSteps.get(0)), Measure(pickle("2", "s", 2).getSteps.get(1))),
+      pickle("2", "s", 2), new java.io.File("A/B/f.feature").toPath
+    )
+
+    ScenarioDiff(scenarioBefore, scenarioAfter).diffTags should equal(Set[ScenarioDiffTag](ExampleNameChanged))
+  }
+
+  test("Diff scenarios differing in categories, tags, and content of steps only") {
+    val scenarioBefore: Scenario = Scenario(
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
+      List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
+      pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
+    )
+    val scenarioAfter: Scenario = Scenario(
+      List[String]("XX", "B"), "f", Some(1), "s", None, None, Set[String]("S", "XX"),
       List[Step](Dummy(pickle("2", "s", 2).getSteps.get(1)), Measure(pickle("2", "s", 2).getSteps.get(0))),
       pickle("2", "s", 2), new java.io.File("XX/B/f.feature").toPath
     )
@@ -235,12 +250,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff different scenarios with different name") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", None, Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", None, None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "XX", None, Set[String]("S", "XX"),
+      List[String]("A", "B"), "f", Some(1), "XX", None, None, Set[String]("S", "XX"),
       List[Step](Measure(pickle("2", "XX", 2).getSteps.get(0)), Dummy(pickle("2", "XX", 2).getSteps.get(1))),
       pickle("2", "XX", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -250,12 +265,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff different scenarios with different example number") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", Some(0), Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(0), None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", Some(1), Set[String]("S", "XX"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(1), None, Set[String]("S", "XX"),
       List[Step](Measure(pickle("2", "XX", 2).getSteps.get(0)), Dummy(pickle("2", "XX", 2).getSteps.get(1))),
       pickle("2", "XX", 2), new java.io.File("A/B/f.feature").toPath
     )
@@ -265,12 +280,12 @@ class ScenarioDiffTest extends AnyFunSuite with Matchers {
 
   test("Diff different scenarios with different name and example number") {
     val scenarioBefore: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "s", Some(0), Set[String]("S", "T"),
+      List[String]("A", "B"), "f", Some(1), "s", Some(0), None, Set[String]("S", "T"),
       List[Step](Dummy(pickle("1", "s", 1).getSteps.get(0)), Measure(pickle("1", "s", 1).getSteps.get(1))),
       pickle("1", "s", 1), new java.io.File("A/B/f.feature").toPath
     )
     val scenarioAfter: Scenario = Scenario(
-      List[String]("A", "B"), "f", Some(1), "XX", Some(1), Set[String]("S", "XX"),
+      List[String]("A", "B"), "f", Some(1), "XX", Some(1), None, Set[String]("S", "XX"),
       List[Step](Measure(pickle("2", "XX", 2).getSteps.get(0)), Dummy(pickle("2", "XX", 2).getSteps.get(1))),
       pickle("2", "XX", 2), new java.io.File("A/B/f.feature").toPath
     )

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/TckTreeDiffTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/diff/TckTreeDiffTest.scala
@@ -103,8 +103,8 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   private def dummyPath(path: String): java.nio.file.Path = new java.io.File("ftr1.feature").toPath
 
   test("Diff with one scenario added to the same top-level feature without tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrB)
     val scenariosAfter: Seq[Scenario] = Seq(scrA, scrB)
     val collectBefore = TckTree(scenariosBefore)
@@ -119,8 +119,8 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff with one scenario removed from the same top-level feature without tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA, scrB)
     val scenariosAfter: Seq[Scenario] = Seq(scrB)
     val collectBefore = TckTree(scenariosBefore)
@@ -135,9 +135,9 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff with one scenario moved to another top-level feature without tags") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA1, scrB)
     val scenariosAfter: Seq[Scenario] = Seq(scrA2, scrB)
     val collectBefore = TckTree(scenariosBefore)
@@ -156,9 +156,9 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff with one scenario moved to another sub-level feature without tags") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String]("X"), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("X/ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA1, scrB)
     val scenariosAfter: Seq[Scenario] = Seq(scrA2, scrB)
     val collectBefore = TckTree(scenariosBefore)
@@ -179,10 +179,10 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff with one scenario moved to another top-level feature and a changed tag") {
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String](), List[Step](dummyStep("A")), dummyPickle, dummyPath("ftr2.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("A"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB2 = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String]("B"), List[Step](dummyStep("B")), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA1, scrB1)
     val scenariosAfter: Seq[Scenario] = Seq(scrA2, scrB2)
     val collectBefore = TckTree(scenariosBefore)
@@ -205,12 +205,12 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   }
 
   test("Diff with two scenarios from an outline in a top-level feature have a changed tags") {
-    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrC = Scenario(List[String](), "ftr1", Some(3), "scrC", None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB0x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
-    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB0 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1 = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrC = Scenario(List[String](), "ftr1", Some(3), "scrC", None, None, Set[String]("A"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB0x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(0), None, Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrB1x = Scenario(List[String](), "ftr1", Some(2), "scrB", Some(1), Some("a"), Set[String]("B"), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA, scrB0, scrB1, scrC)
     val scenariosAfter: Seq[Scenario] = Seq(scrA, scrB0x, scrB1x, scrC)
     val collectBefore = TckTree(scenariosBefore)
@@ -234,9 +234,9 @@ class TckTreeDiffTest extends AnyFunSuite with Matchers {
   test("Diff with one scenario changed in categories, tags, and content of steps") {
     val stepsA1 = List[Step](Dummy(dummyPickleStep), Measure(dummyPickleStep))
     val stepsA2 = List[Step](Measure(dummyPickleStep), Dummy(dummyPickleStep))
-    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
-    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
-    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
+    val scrA1 = Scenario(List[String](), "ftr1", Some(1), "scrA", None, None, Set[String]("T"), stepsA1, dummyPickle, dummyPath("ftr1.feature"))
+    val scrA2 = Scenario(List[String](), "ftr2", Some(1), "scrA", None, None, Set[String]("X"), stepsA2, dummyPickle, dummyPath("ftr2.feature"))
+    val scrB = Scenario(List[String](), "ftr1", Some(2), "scrB", None, None, Set[String](), List[Step](), dummyPickle, dummyPath("ftr1.feature"))
     val scenariosBefore: Seq[Scenario] = Seq(scrA1, scrB)
     val scenariosAfter: Seq[Scenario] = Seq(scrA2, scrB)
     val collectBefore = TckTree(scenariosBefore)

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
@@ -52,6 +52,14 @@ trait ValidateScenario extends AppendedClues with Matchers with OptionValues wit
       scenarioSignaturesBefore should not contain scenarioSignature
     }
 
+    withClue("scenario with an example name should have an example index") {
+      (scenario.exampleName, scenario.exampleIndex) should matchPattern {
+        case (Some(_), Some(_)) =>
+        case (None, _) =>
+        // (Some(_), None) is the not allowed case
+      }
+    }
+
     withClue("scenario has a `@NegativeTest` tag and a `Then expect error` step or neither") {
       (scenario.steps exists {
         case _: ExpectError => true


### PR DESCRIPTION
(This PR is based on PR #478)

This PR extends the TCK API and related tools to support naming of examples in scenario outlines.

The PR modifies the `TypeConversion1.[5]` scenario outline to illustrate the facility:

```Gherkin
  @NegativeTest
  Scenario Outline: [5] `toBoolean()` on invalid types #Example: <exampleName>
    Given any graph
    When executing query:
      """
      WITH [true, <invalid>] AS list
      RETURN toBoolean(list[1]) AS b
      """
    Then a TypeError should be raised at runtime: InvalidArgumentValue

    Examples:
      | invalid | exampleName |
      | []      | list        |
      | {}      | map         |
      | 1       | integer     |
      | 1.0     | float       |
```

The outline parameter `<exampleName>` does not contribute to the scenario other than modifying the name of the outline. Note that the parameter in the outline name appears after ` #Example: `. With the change made by this PR, the TCK API detects this pattern.

The `Scenario` has a new field `exampleName: Optional[String]`. This field is set to `None` if the pattern is not used. If the pattern is used, `exampleName` is set to `Some(x)`, where `x` is whatever string comes after the marker ` #Example: `.

For instance, for first example the `TypeConversion1.[5]` scenario outline `exampleName` will be set to the string `list`; for the second example to `map`; and so on. The `name` field in all scenarios resulting from this outline will be set to `` `toBoolean()` on invalid types``, i.e. everything between the number (`[5] `) and the ` #Example: ` marker.

Note that independently of this PR and the use of this pattern, `Scenario` objects have a field `exampleIndex: Option[Int]` that contains the running number (starting at `0`) for all scenarios resulting from the examples of the same outline in the order of the example listing in the feature file.

Since scenario resulting outline have an example index independently from the example name, the example name does not have to be unique, i.e. the same name can be used for multiple examples in the same outline. For instance, `TypeConversion1.[5]` could be modified as follow and would still be valid:

```Gherkin
  @NegativeTest
  Scenario Outline: [5] `toBoolean()` on invalid types #Example: <exampleName>
    Given any graph
    When executing query:
      """
      WITH [true, <invalid>] AS list
      RETURN toBoolean(list[1]) AS b
      """
    Then a TypeError should be raised at runtime: InvalidArgumentValue

    Examples:
      | invalid | exampleName |
      | []      | list        |
      | [1]     | list        |
      | {}      | map         |
      | 1       | integer     |
      | 1.0     | float       |
```

Note that the first and the second example both have the name `list`.

The name of the outline parameter used to provide the example name does not matter, other than is it have to be different from the name of the other outline parameters use in a given outline. It is very sensible to call it `<exampleName>`, but this is not required. For instance `<abc>` would work equally well with regards to the TCK API. (In fact, the TCK API does not even see the parameter name, since outline examples are already instantiated by the Cucumber's Gherkin parser.)

The ScenarioFormatChecker checks that [every scenario with an example name also has an example index](https://github.com/opencypher/openCypher/compare/master...hvub:facilitate-named-examples-in-scenario-outlines?expand=1#diff-cccf4151c32c8d59e8d1a5742857c1f0d3ee94a11e5d363da51badd5f4bc53cdR58-R64). In other words, the marker ` #Example: ` is reserved for providing example names in scenario outlines and prohibited in regular non-outline scenario names.
