### PR TITLE
Scenarios for LIMIT and SKIP after CREATE and SET

### DIFF
--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -44,4 +44,258 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +labels        | 2 |
       | +properties    | 1 |
+
+  Scenario: [2] Limiting to zero results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (n:N {num: 42})
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +nodes         | 1 |
+      | +labels        | 1 |
+      | +properties    | 1 |
+
+  Scenario: [3] Limiting to fewer results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      LIMIT 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [4] Limiting to more results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      LIMIT 10
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [5] Skipping all results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (n:N {num: 42})
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +nodes         | 1 |
+      | +labels        | 1 |
+      | +properties    | 1 |
+
+  Scenario: [6] Skipping a few results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [7] Skipping zero results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 0
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [8] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [9] Limiting to zero results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      RETURN r
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +properties    | 1 |
+
+  Scenario: [10] Limiting to fewer results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      LIMIT 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [11] Limiting to more results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      LIMIT 10
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [12] Skipping all results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      RETURN r
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +properties    | 1 |
+
+  Scenario: [13] Skipping a few results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [14] Skipping zero results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 0
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [15] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
       

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -79,7 +79,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE (n:N {num: x})
       RETURN n.num AS num
       SKIP 2 LIMIT 2
@@ -97,7 +97,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE (n:N {num: x})
       RETURN n.num AS num
       SKIP 0 LIMIT 5
@@ -148,7 +148,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE ()-[r:R {num: x}]->()
       RETURN r.num AS num
       SKIP 2 LIMIT 2
@@ -166,7 +166,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE ()-[r:R {num: x}]->()
       RETURN r.num AS num
       SKIP 0 LIMIT 5

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -60,47 +60,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [3] Limiting to fewer results after creating nodes affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      LIMIT 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [4] Limiting to more results after creating nodes does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      LIMIT 10
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [5] Skipping all results after creating nodes affects the result set but not the side effects
+  Scenario: [3] Skipping all results after creating nodes affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -115,46 +75,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [6] Skipping a few results after creating nodes affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      SKIP 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [7] Skipping zero results after creating nodes does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      SKIP 0
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [8] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
+  Scenario: [4] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -172,7 +93,28 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 5 |
 
-  Scenario: [9] Limiting to zero results after creating relationships affects the result set but not the side effects
+  Scenario: [5] Skipping zero result and limiting to all results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [6] Limiting to zero results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -187,47 +129,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [10] Limiting to fewer results after creating relationships affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      LIMIT 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [11] Limiting to more results after creating relationships does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      LIMIT 10
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [12] Skipping all results after creating relationships affects the result set but not the side effects
+  Scenario: [7] Skipping all results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -242,46 +144,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [13] Skipping a few results after creating relationships affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      SKIP 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [14] Skipping zero results after creating relationships does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      SKIP 0
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [15] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+  Scenario: [8] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -298,4 +161,24 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +nodes         | 10 |
       | +relationships | 5  |
       | +properties    | 5  |
-      
+
+  Scenario: [9] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -137,7 +137,7 @@ Feature: Set6 - Set clause interoperation with other clauses
     Then the result should be, in any order:
       | n |
     And the side effects should be:
-      | +label | 1 |
+      | +labels | 1 |
 
   Scenario: [6] Skipping all results after adding a label on a node affects the result set but not the side effects
     Given an empty graph
@@ -155,7 +155,7 @@ Feature: Set6 - Set clause interoperation with other clauses
     Then the result should be, in any order:
       | n |
     And the side effects should be:
-      | +label | 1 |
+      | +labels | 1 |
 
   Scenario: [7] Skipping and limiting to a few results after adding a label on a node affects the result set but not the side effects
     Given an empty graph
@@ -179,7 +179,7 @@ Feature: Set6 - Set clause interoperation with other clauses
       | 42  |
       | 42  |
     And the side effects should be:
-      | +label | 5 |
+      | +labels | 1 |
 
   Scenario: [8] Skipping zero result and limiting to all results after adding a label on a node does not affect the result set nor the side effects
     Given an empty graph
@@ -206,7 +206,7 @@ Feature: Set6 - Set clause interoperation with other clauses
       | 42  |
       | 42  |
     And the side effects should be:
-      | +label | 5 |
+      | +labels | 1 |
 
   Scenario: [9] Limiting to zero results after setting a property on a relationship affects the result set but not the side effects
     Given an empty graph
@@ -250,11 +250,11 @@ Feature: Set6 - Set clause interoperation with other clauses
     Given an empty graph
     And having executed:
       """
-      CREATE ()-[r:R {num: 1}]->()
-      CREATE ()-[r:R {num: 2}]->()
-      CREATE ()-[r:R {num: 3}]->()
-      CREATE ()-[r:R {num: 4}]->()
-      CREATE ()-[r:R {num: 5}]->()
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
       """
     When executing query:
       """
@@ -275,11 +275,11 @@ Feature: Set6 - Set clause interoperation with other clauses
     Given an empty graph
     And having executed:
       """
-      CREATE ()-[r:R {num: 1}]->()
-      CREATE ()-[r:R {num: 2}]->()
-      CREATE ()-[r:R {num: 3}]->()
-      CREATE ()-[r:R {num: 4}]->()
-      CREATE ()-[r:R {num: 5}]->()
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
       """
     When executing query:
       """

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -1,0 +1,300 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Set6 - Set clause interoperation with other clauses
+
+  Scenario: [1] Limiting to zero results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 43
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [2] Skipping all results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 43
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [3] Skipping and limiting to a few results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 42
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [4] Skipping zero results and limiting to all results after setting a property on a node does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 42
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [5] Limiting to zero results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +label | 1 |
+
+  Scenario: [6] Skipping all results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +label | 1 |
+
+  Scenario: [7] Skipping and limiting to a few results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +label | 5 |
+
+  Scenario: [8] Skipping zero result and limiting to all results after adding a label on a node does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +label | 5 |
+
+  Scenario: [9] Limiting to zero results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 43
+      RETURN r
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [10] Skipping all results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 43
+      RETURN r
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [11] Skipping and limiting to a few results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 1}]->()
+      CREATE ()-[r:R {num: 2}]->()
+      CREATE ()-[r:R {num: 3}]->()
+      CREATE ()-[r:R {num: 4}]->()
+      CREATE ()-[r:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 42
+      RETURN r.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [12] Skipping zero result and limiting to all results after setting a property on a relationship does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 1}]->()
+      CREATE ()-[r:R {num: 2}]->()
+      CREATE ()-[r:R {num: 3}]->()
+      CREATE ()-[r:R {num: 4}]->()
+      CREATE ()-[r:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 42
+      RETURN r.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |


### PR DESCRIPTION
This PR add scenarios that test that `SKIP` and  `LIMIT` in a `RETURN` clause after a `SET` or a `CREATE` clause do not affect the side effects these clauses.