### PR TITLE
Scenarios for persistence of side effects over subsequent cardinality changes

### DIFF
--- a/tck/features/clauses/create/Create3.feature
+++ b/tck/features/clauses/create/Create3.feature
@@ -240,3 +240,18 @@ Feature: Create3 - Interoperation with other clauses
     And the side effects should be:
       | +nodes         | 2 |
       | +relationships | 2 |
+
+  Scenario: [13] Merge followed by multiple creates
+    Given an empty graph
+    When executing query:
+      """
+      MERGE (t:T {id: 42})
+      CREATE (f:R)
+      CREATE (t)-[:REL]->(f)
+      """
+    Then the result should be empty
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +labels        | 2 |
+      | +properties    | 1 |

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -30,22 +30,7 @@
 
 Feature: Create6 - Create clause interoperation with other clauses
 
-  Scenario: [1] Merge followed by multiple creates
-    Given an empty graph
-    When executing query:
-      """
-      MERGE (t:T {id: 42})
-      CREATE (f:R)
-      CREATE (t)-[:REL]->(f)
-      """
-    Then the result should be empty
-    And the side effects should be:
-      | +nodes         | 2 |
-      | +relationships | 1 |
-      | +labels        | 2 |
-      | +properties    | 1 |
-
-  Scenario: [2] Limiting to zero results after creating nodes affects the result set but not the side effects
+  Scenario: [1] Limiting to zero results after creating nodes affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -60,7 +45,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [3] Skipping all results after creating nodes affects the result set but not the side effects
+  Scenario: [2] Skipping all results after creating nodes affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -75,7 +60,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [4] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
+  Scenario: [3] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -93,7 +78,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 5 |
 
-  Scenario: [5] Skipping zero result and limiting to all results after creating nodes does not affect the result set nor the side effects
+  Scenario: [4] Skipping zero result and limiting to all results after creating nodes does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -114,7 +99,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 5 |
 
-  Scenario: [6] Limiting to zero results after creating relationships affects the result set but not the side effects
+  Scenario: [5] Limiting to zero results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -129,7 +114,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [7] Skipping all results after creating relationships affects the result set but not the side effects
+  Scenario: [6] Skipping all results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -144,7 +129,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [8] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+  Scenario: [7] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -162,7 +147,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 5  |
       | +properties    | 5  |
 
-  Scenario: [9] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
+  Scenario: [8] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -220,7 +220,7 @@ Feature: Create6 - Persistence of create clause side effects
       | +relationships | 5  |
       | +properties    | 5  |
 
-  Scenario: [12] Filtering after creating nodes affects the result set but not the side effects
+  Scenario: [12] Filtering after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -235,9 +235,9 @@ Feature: Create6 - Persistence of create clause side effects
       | 2   |
       | 4   |
     And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
 
   Scenario: [13] Aggregating in `RETURN` after creating relationships affects the result set but not the side effects
     Given an empty graph

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -44,4 +44,258 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +labels        | 2 |
       | +properties    | 1 |
+
+  Scenario: [2] Limiting to zero results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (n:N {num: 42})
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +nodes         | 1 |
+      | +labels        | 1 |
+      | +properties    | 1 |
+
+  Scenario: [3] Limiting to fewer results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      LIMIT 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [4] Limiting to more results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      LIMIT 10
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [5] Skipping all results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (n:N {num: 42})
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +nodes         | 1 |
+      | +labels        | 1 |
+      | +properties    | 1 |
+
+  Scenario: [6] Skipping a few results after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [7] Skipping zero results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 0
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [8] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [9] Limiting to zero results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      RETURN r
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +properties    | 1 |
+
+  Scenario: [10] Limiting to fewer results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      LIMIT 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [11] Limiting to more results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      LIMIT 10
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [12] Skipping all results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      RETURN r
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +nodes         | 2 |
+      | +relationships | 1 |
+      | +properties    | 1 |
+
+  Scenario: [13] Skipping a few results after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 3
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [14] Skipping zero results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 0
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [15] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
       

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -79,7 +79,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE (n:N {num: x})
       RETURN n.num AS num
       SKIP 2 LIMIT 2
@@ -97,7 +97,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE (n:N {num: x})
       RETURN n.num AS num
       SKIP 0 LIMIT 5
@@ -148,7 +148,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE ()-[r:R {num: x}]->()
       RETURN r.num AS num
       SKIP 2 LIMIT 2
@@ -166,7 +166,7 @@ Feature: Create6 - Create clause interoperation with other clauses
     Given an empty graph
     When executing query:
       """
-      UNWIND [42,42,42,42,42] AS x
+      UNWIND [42, 42, 42, 42, 42] AS x
       CREATE ()-[r:R {num: x}]->()
       RETURN r.num AS num
       SKIP 0 LIMIT 5

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Create6 - Create clause interoperation with other clauses
+Feature: Create6 - Persistence of create side effects
 
   Scenario: [1] Limiting to zero results after creating nodes affects the result set but not the side effects
     Given an empty graph

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -60,47 +60,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [3] Limiting to fewer results after creating nodes affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      LIMIT 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [4] Limiting to more results after creating nodes does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      LIMIT 10
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [5] Skipping all results after creating nodes affects the result set but not the side effects
+  Scenario: [3] Skipping all results after creating nodes affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -115,46 +75,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 1 |
 
-  Scenario: [6] Skipping a few results after creating nodes affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      SKIP 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [7] Skipping zero results after creating nodes does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE (n:N {num: x})
-      RETURN n.num AS num
-      SKIP 0
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 5 |
-      | +labels        | 1 |
-      | +properties    | 5 |
-
-  Scenario: [8] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
+  Scenario: [4] Skipping and limiting to a few results after creating nodes does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -172,7 +93,28 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +labels        | 1 |
       | +properties    | 5 |
 
-  Scenario: [9] Limiting to zero results after creating relationships affects the result set but not the side effects
+  Scenario: [5] Skipping zero result and limiting to all results after creating nodes does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE (n:N {num: x})
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [6] Limiting to zero results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -187,47 +129,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [10] Limiting to fewer results after creating relationships affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      LIMIT 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [11] Limiting to more results after creating relationships does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      LIMIT 10
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [12] Skipping all results after creating relationships affects the result set but not the side effects
+  Scenario: [7] Skipping all results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -242,46 +144,7 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [13] Skipping a few results after creating relationships affects the result set but not the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      SKIP 3
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [14] Skipping zero results after creating relationships does not affect the result set nor the side effects
-    Given an empty graph
-    When executing query:
-      """
-      UNWIND [42,42,42,42,42] AS x
-      CREATE ()-[r:R {num: x}]->()
-      RETURN r.num AS num
-      SKIP 0
-      """
-    Then the result should be, in any order:
-      | num |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-      | 42  |
-    And the side effects should be:
-      | +nodes         | 10 |
-      | +relationships | 5  |
-      | +properties    | 5  |
-
-  Scenario: [15] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+  Scenario: [8] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -298,4 +161,24 @@ Feature: Create6 - Create clause interoperation with other clauses
       | +nodes         | 10 |
       | +relationships | 5  |
       | +properties    | 5  |
-      
+
+  Scenario: [9] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [42,42,42,42,42] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN r.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -99,7 +99,59 @@ Feature: Create6 - Persistence of create clause side effects
       | +labels        | 1 |
       | +properties    | 5 |
 
-  Scenario: [5] Limiting to zero results after creating relationships affects the result set but not the side effects
+  Scenario: [5] Filtering after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE (n:N {num: x})
+      WITH n
+      WHERE n.num % 2 = 0
+      RETURN n.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [6] Aggregating in `RETURN` after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE (n:N {num: x})
+      RETURN sum(n.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [7] Aggregating in `WITH` after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE (n:N {num: x})
+      WITH sum(n.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [8] Limiting to zero results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -114,7 +166,7 @@ Feature: Create6 - Persistence of create clause side effects
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [6] Skipping all results after creating relationships affects the result set but not the side effects
+  Scenario: [9] Skipping all results after creating relationships affects the result set but not the side effects
     Given an empty graph
     When executing query:
       """
@@ -129,7 +181,7 @@ Feature: Create6 - Persistence of create clause side effects
       | +relationships | 1 |
       | +properties    | 1 |
 
-  Scenario: [7] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
+  Scenario: [10] Skipping and limiting to a few results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -147,7 +199,7 @@ Feature: Create6 - Persistence of create clause side effects
       | +relationships | 5  |
       | +properties    | 5  |
 
-  Scenario: [8] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
+  Scenario: [11] Skipping zero result and limiting to all results after creating relationships does not affect the result set nor the side effects
     Given an empty graph
     When executing query:
       """
@@ -163,6 +215,58 @@ Feature: Create6 - Persistence of create clause side effects
       | 42  |
       | 42  |
       | 42  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [12] Filtering after creating nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE ()-[r:R {num: x}]->()
+      WITH r
+      WHERE r.num % 2 = 0
+      RETURN r.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | +nodes         | 5 |
+      | +labels        | 1 |
+      | +properties    | 5 |
+
+  Scenario: [13] Aggregating in `RETURN` after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE ()-[r:R {num: x}]->()
+      RETURN sum(r.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | +nodes         | 10 |
+      | +relationships | 5  |
+      | +properties    | 5  |
+
+  Scenario: [14] Aggregating in `WITH` after creating relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [1, 2, 3, 4, 5] AS x
+      CREATE ()-[r:R {num: x}]->()
+      WITH sum(r.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
     And the side effects should be:
       | +nodes         | 10 |
       | +relationships | 5  |

--- a/tck/features/clauses/create/Create6.feature
+++ b/tck/features/clauses/create/Create6.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Create6 - Persistence of create side effects
+Feature: Create6 - Persistence of create clause side effects
 
   Scenario: [1] Limiting to zero results after creating nodes affects the result set but not the side effects
     Given an empty graph

--- a/tck/features/clauses/delete/Delete5.feature
+++ b/tck/features/clauses/delete/Delete5.feature
@@ -166,3 +166,23 @@ Feature: Delete5 - Delete clause interoperation with built-in data types
       | -nodes         | 2 |
       | -relationships | 2 |
       | -labels        | 1 |
+
+  @NegativeTest
+  Scenario: [8] Failing when using undefined variable in DELETE
+    Given any graph
+    When executing query:
+      """
+      MATCH (a)
+      DELETE x
+      """
+    Then a SyntaxError should be raised at compile time: UndefinedVariable
+
+  @NegativeTest
+  Scenario: [9] Failing when deleting an integer expression
+    Given any graph
+    When executing query:
+      """
+      MATCH ()
+      DELETE 1 + 1
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType

--- a/tck/features/clauses/delete/Delete6.feature
+++ b/tck/features/clauses/delete/Delete6.feature
@@ -127,7 +127,7 @@ Feature: Delete6 - Persistence of delete clause side effects
 
   Scenario: [5] Filtering after deleting nodes affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE (:N {num: 1})
       CREATE (:N {num: 2})
@@ -149,13 +149,13 @@ Feature: Delete6 - Persistence of delete clause side effects
       | 2   |
       | 4   |
     And the side effects should be:
-      | -nodes         | 5 |
-      | -labels        | 1 |
-      | -properties    | 5 |
+      | -nodes      | 5 |
+      | -labels     | 1 |
+      | -properties | 5 |
 
   Scenario: [6] Aggregating in `RETURN` after deleting nodes affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE (:N {num: 1})
       CREATE (:N {num: 2})
@@ -174,13 +174,13 @@ Feature: Delete6 - Persistence of delete clause side effects
       | sum |
       | 15  |
     And the side effects should be:
-      | -nodes         | 5 |
-      | -labels        | 1 |
-      | -properties    | 5 |
+      | -nodes      | 5 |
+      | -labels     | 1 |
+      | -properties | 5 |
 
   Scenario: [7] Aggregating in `WITH` after deleting nodes affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE (:N {num: 1})
       CREATE (:N {num: 2})
@@ -200,9 +200,9 @@ Feature: Delete6 - Persistence of delete clause side effects
       | sum |
       | 15  |
     And the side effects should be:
-      | -nodes         | 5 |
-      | -labels        | 1 |
-      | -properties    | 5 |
+      | -nodes      | 5 |
+      | -labels     | 1 |
+      | -properties | 5 |
 
   Scenario: [8] Limiting to zero results after deleting relationships affects the result set but not the side effects
     Given an empty graph
@@ -297,7 +297,7 @@ Feature: Delete6 - Persistence of delete clause side effects
 
   Scenario: [12] Filtering after deleting relationships affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE ()-[:R {num: 1}]->()
       CREATE ()-[:R {num: 2}]->()
@@ -324,7 +324,7 @@ Feature: Delete6 - Persistence of delete clause side effects
 
   Scenario: [13] Aggregating in `RETURN` after deleting relationships affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE ()-[:R {num: 1}]->()
       CREATE ()-[:R {num: 2}]->()
@@ -348,7 +348,7 @@ Feature: Delete6 - Persistence of delete clause side effects
 
   Scenario: [14] Aggregating in `WITH` after deleting relationships affects the result set but not the side effects
     Given an empty graph
-    When executing query:
+    And having executed:
       """
       CREATE ()-[:R {num: 1}]->()
       CREATE ()-[:R {num: 2}]->()

--- a/tck/features/clauses/delete/Delete6.feature
+++ b/tck/features/clauses/delete/Delete6.feature
@@ -28,24 +28,4 @@
 
 #encoding: utf-8
 
-Feature: Delete6 - Negative scenarios
-
-  @NegativeTest
-  Scenario: [1] Failing when using undefined variable in DELETE
-    Given any graph
-    When executing query:
-      """
-      MATCH (a)
-      DELETE x
-      """
-    Then a SyntaxError should be raised at compile time: UndefinedVariable
-
-  @NegativeTest
-  Scenario: [2] Failing when deleting an integer expression
-    Given any graph
-    When executing query:
-      """
-      MATCH ()
-      DELETE 1 + 1
-      """
-    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+Feature: Delete6 - Persistence of delete clause side effects

--- a/tck/features/clauses/delete/Delete6.feature
+++ b/tck/features/clauses/delete/Delete6.feature
@@ -29,3 +29,344 @@
 #encoding: utf-8
 
 Feature: Delete6 - Persistence of delete clause side effects
+
+  Scenario: [1] Limiting to zero results after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      DELETE n
+      RETURN 42 AS num
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | num |
+    And the side effects should be:
+      | -nodes      | 1 |
+      | -labels     | 1 |
+      | -properties | 1 |
+
+  Scenario: [2] Skipping all results after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      DELETE n
+      RETURN 42 AS num
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | num |
+    And the side effects should be:
+      | -nodes      | 1 |
+      | -labels     | 1 |
+      | -properties | 1 |
+
+  Scenario: [3] Skipping and limiting to a few results after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      DELETE n
+      RETURN 42 AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -nodes      | 5 |
+      | -labels     | 1 |
+      | -properties | 5 |
+
+  Scenario: [4] Skipping zero results and limiting to all results after deleting nodes does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      DELETE n
+      RETURN 42 AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -nodes      | 5 |
+      | -labels     | 1 |
+      | -properties | 5 |
+
+  Scenario: [5] Filtering after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      WITH n, n.num AS num
+      DELETE n
+      WITH num
+      WHERE num % 2 = 0
+      RETURN num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | -nodes         | 5 |
+      | -labels        | 1 |
+      | -properties    | 5 |
+
+  Scenario: [6] Aggregating in `RETURN` after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      WITH n, n.num AS num
+      DELETE n
+      RETURN sum(num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -nodes         | 5 |
+      | -labels        | 1 |
+      | -properties    | 5 |
+
+  Scenario: [7] Aggregating in `WITH` after deleting nodes affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      WITH n, n.num AS num
+      DELETE n
+      WITH sum(num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -nodes         | 5 |
+      | -labels        | 1 |
+      | -properties    | 5 |
+
+  Scenario: [8] Limiting to zero results after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      DELETE r
+      RETURN 42 AS num
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | num |
+    And the side effects should be:
+      | -relationships | 1 |
+      | -properties    | 1 |
+
+  Scenario: [9] Skipping all results after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      DELETE r
+      RETURN 42 AS num
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | num |
+    And the side effects should be:
+      | -relationships | 1 |
+      | -properties    | 1 |
+
+  Scenario: [10] Skipping and limiting to a few results after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      DELETE r
+      RETURN 42 AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -relationships | 5 |
+      | -properties    | 5 |
+
+  Scenario: [11] Skipping zero result and limiting to all results after deleting relationships does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      DELETE r
+      RETURN 42 AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -relationships | 5 |
+      | -properties    | 5 |
+
+  Scenario: [12] Filtering after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      WITH r, r.num AS num
+      DELETE r
+      WITH num
+      WHERE num % 2 = 0
+      RETURN num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | -relationships | 5 |
+      | -properties    | 5 |
+
+  Scenario: [13] Aggregating in `RETURN` after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      WITH r, r.num AS num
+      DELETE r
+      RETURN sum(num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -relationships | 5 |
+      | -properties    | 5 |
+
+  Scenario: [14] Aggregating in `WITH` after deleting relationships affects the result set but not the side effects
+    Given an empty graph
+    When executing query:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      WITH r, r.num AS num
+      DELETE r
+      WITH sum(num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -relationships | 5 |
+      | -properties    | 5 |

--- a/tck/features/clauses/remove/Remove3.feature
+++ b/tck/features/clauses/remove/Remove3.feature
@@ -1,0 +1,502 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Remove3 - Persistence of remove clause side effects
+
+  Scenario: [1] Limiting to zero results after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.num
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | -properties | 1 |
+
+  Scenario: [2] Skipping all results after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.num
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | -properties | 1 |
+
+  Scenario: [3] Skipping and limiting to a few results after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.name
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [4] Skipping zero results and limiting to all results after removing a property from nodes does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      CREATE (:N {name: 'a', num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.name
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [5] Filtering after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {name: 'a', num: 1})
+      CREATE (:N {name: 'a', num: 2})
+      CREATE (:N {name: 'a', num: 3})
+      CREATE (:N {name: 'a', num: 4})
+      CREATE (:N {name: 'a', num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.name
+      WITH n
+      WHERE n.num % 2 = 0
+      RETURN n.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [6] Aggregating in `RETURN` after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {name: 'a', num: 1})
+      CREATE (:N {name: 'a', num: 2})
+      CREATE (:N {name: 'a', num: 3})
+      CREATE (:N {name: 'a', num: 4})
+      CREATE (:N {name: 'a', num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.name
+      RETURN sum(n.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [7] Aggregating in `WITH` after removing a property from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {name: 'a', num: 1})
+      CREATE (:N {name: 'a', num: 2})
+      CREATE (:N {name: 'a', num: 3})
+      CREATE (:N {name: 'a', num: 4})
+      CREATE (:N {name: 'a', num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n.name
+      WITH sum(n.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [8] Limiting to zero results after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [9] Skipping all results after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [10] Skipping and limiting to a few results after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [11] Skipping zero result and limiting to all results after removing a label from nodes does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [12] Filtering after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      WITH n
+      WHERE n.num % 2 = 0
+      RETURN n.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [13] Aggregating in `RETURN` after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      RETURN sum(n.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [14] Aggregating in `WITH` after removing a label from nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      REMOVE n:N
+      WITH sum(n.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -labels | 1 |
+
+  Scenario: [15] Limiting to zero results after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.num
+      RETURN r
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | -properties | 1 |
+
+  Scenario: [16] Skipping all results after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.num
+      RETURN r
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | -properties | 1 |
+
+  Scenario: [17] Skipping and limiting to a few results after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.name
+      RETURN r.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [18] Skipping zero result and limiting to all results after removing a property from relationships does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      CREATE ()-[:R {name: 'a', num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.name
+      RETURN r.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [19] Filtering after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {name: 'a', num: 1}]->()
+      CREATE ()-[:R {name: 'a', num: 2}]->()
+      CREATE ()-[:R {name: 'a', num: 3}]->()
+      CREATE ()-[:R {name: 'a', num: 4}]->()
+      CREATE ()-[:R {name: 'a', num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.name
+      WITH r
+      WHERE r.num % 2 = 0
+      RETURN r.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [20] Aggregating in `RETURN` after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {name: 'a', num: 1}]->()
+      CREATE ()-[:R {name: 'a', num: 2}]->()
+      CREATE ()-[:R {name: 'a', num: 3}]->()
+      CREATE ()-[:R {name: 'a', num: 4}]->()
+      CREATE ()-[:R {name: 'a', num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.name
+      RETURN sum(r.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -properties | 5 |
+
+  Scenario: [21] Aggregating in `WITH` after removing a property from relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {name: 'a', num: 1}]->()
+      CREATE ()-[:R {name: 'a', num: 2}]->()
+      CREATE ()-[:R {name: 'a', num: 3}]->()
+      CREATE ()-[:R {name: 'a', num: 4}]->()
+      CREATE ()-[:R {name: 'a', num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      REMOVE r.name
+      WITH sum(r.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | -properties | 5 |

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -137,7 +137,7 @@ Feature: Set6 - Set clause interoperation with other clauses
     Then the result should be, in any order:
       | n |
     And the side effects should be:
-      | +label | 1 |
+      | +labels | 1 |
 
   Scenario: [6] Skipping all results after adding a label on a node affects the result set but not the side effects
     Given an empty graph
@@ -155,7 +155,7 @@ Feature: Set6 - Set clause interoperation with other clauses
     Then the result should be, in any order:
       | n |
     And the side effects should be:
-      | +label | 1 |
+      | +labels | 1 |
 
   Scenario: [7] Skipping and limiting to a few results after adding a label on a node affects the result set but not the side effects
     Given an empty graph
@@ -179,7 +179,7 @@ Feature: Set6 - Set clause interoperation with other clauses
       | 42  |
       | 42  |
     And the side effects should be:
-      | +label | 5 |
+      | +labels | 1 |
 
   Scenario: [8] Skipping zero result and limiting to all results after adding a label on a node does not affect the result set nor the side effects
     Given an empty graph
@@ -206,7 +206,7 @@ Feature: Set6 - Set clause interoperation with other clauses
       | 42  |
       | 42  |
     And the side effects should be:
-      | +label | 5 |
+      | +labels | 1 |
 
   Scenario: [9] Limiting to zero results after setting a property on a relationship affects the result set but not the side effects
     Given an empty graph
@@ -250,11 +250,11 @@ Feature: Set6 - Set clause interoperation with other clauses
     Given an empty graph
     And having executed:
       """
-      CREATE ()-[r:R {num: 1}]->()
-      CREATE ()-[r:R {num: 2}]->()
-      CREATE ()-[r:R {num: 3}]->()
-      CREATE ()-[r:R {num: 4}]->()
-      CREATE ()-[r:R {num: 5}]->()
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
       """
     When executing query:
       """
@@ -275,11 +275,11 @@ Feature: Set6 - Set clause interoperation with other clauses
     Given an empty graph
     And having executed:
       """
-      CREATE ()-[r:R {num: 1}]->()
-      CREATE ()-[r:R {num: 2}]->()
-      CREATE ()-[r:R {num: 3}]->()
-      CREATE ()-[r:R {num: 4}]->()
-      CREATE ()-[r:R {num: 5}]->()
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
       """
     When executing query:
       """

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Set6 - Set clause interoperation with other clauses
+Feature: Set6 - Persistence of set clause side effects
 
   Scenario: [1] Limiting to zero results after setting a property on a node affects the result set but not the side effects
     Given an empty graph

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -30,7 +30,7 @@
 
 Feature: Set6 - Persistence of set clause side effects
 
-  Scenario: [1] Limiting to zero results after setting a property on a node affects the result set but not the side effects
+  Scenario: [1] Limiting to zero results after setting a property on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -49,7 +49,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: [2] Skipping all results after setting a property on a node affects the result set but not the side effects
+  Scenario: [2] Skipping all results after setting a property on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -68,7 +68,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: [3] Skipping and limiting to a few results after setting a property on a node affects the result set but not the side effects
+  Scenario: [3] Skipping and limiting to a few results after setting a property on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -93,7 +93,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 5 |
       | -properties | 5 |
 
-  Scenario: [4] Skipping zero results and limiting to all results after setting a property on a node does not affect the result set nor the side effects
+  Scenario: [4] Skipping zero results and limiting to all results after setting a property on nodes does not affect the result set nor the side effects
     Given an empty graph
     And having executed:
       """
@@ -121,7 +121,81 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 5 |
       | -properties | 5 |
 
-  Scenario: [5] Limiting to zero results after adding a label on a node affects the result set but not the side effects
+  Scenario: [5] Filtering after setting a property on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = n.num + 1
+      WITH n
+      WHERE n.num % 2 = 0
+      RETURN n.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+      | 6   |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [6] Aggregating in `RETURN` after setting a property on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = n.num + 1
+      RETURN sum(n.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 20  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [7] Aggregating in `WITH` after setting a property on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = n.num + 1
+      WITH sum(n.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 20  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [8] Limiting to zero results after adding a label on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -139,7 +213,7 @@ Feature: Set6 - Persistence of set clause side effects
     And the side effects should be:
       | +labels | 1 |
 
-  Scenario: [6] Skipping all results after adding a label on a node affects the result set but not the side effects
+  Scenario: [9] Skipping all results after adding a label on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -157,7 +231,7 @@ Feature: Set6 - Persistence of set clause side effects
     And the side effects should be:
       | +labels | 1 |
 
-  Scenario: [7] Skipping and limiting to a few results after adding a label on a node affects the result set but not the side effects
+  Scenario: [10] Skipping and limiting to a few results after adding a label on nodes affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -181,7 +255,7 @@ Feature: Set6 - Persistence of set clause side effects
     And the side effects should be:
       | +labels | 1 |
 
-  Scenario: [8] Skipping zero result and limiting to all results after adding a label on a node does not affect the result set nor the side effects
+  Scenario: [11] Skipping zero result and limiting to all results after adding a label on nodes does not affect the result set nor the side effects
     Given an empty graph
     And having executed:
       """
@@ -208,7 +282,77 @@ Feature: Set6 - Persistence of set clause side effects
     And the side effects should be:
       | +labels | 1 |
 
-  Scenario: [9] Limiting to zero results after setting a property on a relationship affects the result set but not the side effects
+  Scenario: [12] Filtering after adding a label on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      WITH n
+      WHERE n.num % 2 = 0
+      RETURN n.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+    And the side effects should be:
+      | +labels | 1 |
+
+  Scenario: [13] Aggregating in `RETURN` after adding a label on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN sum(n.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | +labels | 1 |
+
+  Scenario: [14] Aggregating in `WITH` after adding a label on nodes affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      WITH sum(n.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 15  |
+    And the side effects should be:
+      | +labels | 1 |
+
+  Scenario: [15] Limiting to zero results after setting a property on relationships affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -227,7 +371,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: [10] Skipping all results after setting a property on a relationship affects the result set but not the side effects
+  Scenario: [16] Skipping all results after setting a property on relationships affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -246,7 +390,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 1 |
       | -properties | 1 |
 
-  Scenario: [11] Skipping and limiting to a few results after setting a property on a relationship affects the result set but not the side effects
+  Scenario: [17] Skipping and limiting to a few results after setting a property on relationships affects the result set but not the side effects
     Given an empty graph
     And having executed:
       """
@@ -271,7 +415,7 @@ Feature: Set6 - Persistence of set clause side effects
       | +properties | 5 |
       | -properties | 5 |
 
-  Scenario: [12] Skipping zero result and limiting to all results after setting a property on a relationship does not affect the result set nor the side effects
+  Scenario: [18] Skipping zero result and limiting to all results after setting a property on relationships does not affect the result set nor the side effects
     Given an empty graph
     And having executed:
       """
@@ -295,6 +439,80 @@ Feature: Set6 - Persistence of set clause side effects
       | 42  |
       | 42  |
       | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [19] Filtering after setting a property on relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = r.num + 1
+      WITH r
+      WHERE r.num % 2 = 0
+      RETURN r.num AS num
+      """
+    Then the result should be, in any order:
+      | num |
+      | 2   |
+      | 4   |
+      | 6   |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [20] Aggregating in `RETURN` after setting a property on relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = r.num + 1
+      RETURN sum(r.num) AS sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 20  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [21] Aggregating in `WITH` after setting a property on relationships affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:R {num: 1}]->()
+      CREATE ()-[:R {num: 2}]->()
+      CREATE ()-[:R {num: 3}]->()
+      CREATE ()-[:R {num: 4}]->()
+      CREATE ()-[:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = r.num + 1
+      WITH sum(r.num) AS sum
+      RETURN sum
+      """
+    Then the result should be, in any order:
+      | sum |
+      | 20  |
     And the side effects should be:
       | +properties | 5 |
       | -properties | 5 |

--- a/tck/features/clauses/set/Set6.feature
+++ b/tck/features/clauses/set/Set6.feature
@@ -1,0 +1,300 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Set6 - Set clause interoperation with other clauses
+
+  Scenario: [1] Limiting to zero results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 43
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [2] Skipping all results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 43
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [3] Skipping and limiting to a few results after setting a property on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 42
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [4] Skipping zero results and limiting to all results after setting a property on a node does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 1})
+      CREATE (:N {num: 2})
+      CREATE (:N {num: 3})
+      CREATE (:N {num: 4})
+      CREATE (:N {num: 5})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n.num = 42
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [5] Limiting to zero results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +label | 1 |
+
+  Scenario: [6] Skipping all results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | n |
+    And the side effects should be:
+      | +label | 1 |
+
+  Scenario: [7] Skipping and limiting to a few results after adding a label on a node affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +label | 5 |
+
+  Scenario: [8] Skipping zero result and limiting to all results after adding a label on a node does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      CREATE (:N {num: 42})
+      """
+    When executing query:
+      """
+      MATCH (n:N)
+      SET n:Foo
+      RETURN n.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +label | 5 |
+
+  Scenario: [9] Limiting to zero results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 43
+      RETURN r
+      LIMIT 0
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [10] Skipping all results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 42}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 43
+      RETURN r
+      SKIP 1
+      """
+    Then the result should be, in any order:
+      | r |
+    And the side effects should be:
+      | +properties | 1 |
+      | -properties | 1 |
+
+  Scenario: [11] Skipping and limiting to a few results after setting a property on a relationship affects the result set but not the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 1}]->()
+      CREATE ()-[r:R {num: 2}]->()
+      CREATE ()-[r:R {num: 3}]->()
+      CREATE ()-[r:R {num: 4}]->()
+      CREATE ()-[r:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 42
+      RETURN r.num AS num
+      SKIP 2 LIMIT 2
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |
+
+  Scenario: [12] Skipping zero result and limiting to all results after setting a property on a relationship does not affect the result set nor the side effects
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[r:R {num: 1}]->()
+      CREATE ()-[r:R {num: 2}]->()
+      CREATE ()-[r:R {num: 3}]->()
+      CREATE ()-[r:R {num: 4}]->()
+      CREATE ()-[r:R {num: 5}]->()
+      """
+    When executing query:
+      """
+      MATCH ()-[r:R]->()
+      SET r.num = 42
+      RETURN r.num AS num
+      SKIP 0 LIMIT 5
+      """
+    Then the result should be, in any order:
+      | num |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+      | 42  |
+    And the side effects should be:
+      | +properties | 5 |
+      | -properties | 5 |


### PR DESCRIPTION
This PR follows up https://github.com/neo4j/neo4j-documentation/pull/848 on the openCypher side in a generalized form. It adds scenarios that test that cardinality changes caused by `RETURN … SKIP`, `RETURN … LIMIT`, `WITH … WHERE`, and aggregation in `WITH` and `RETURN` after a `CREATE`, `DELETE`, `SET`, or `REMOVE` clause do not affect the side effects of these clauses. PR does not represent an openCypher specification change, but makes assumed semantics explicit in form of TCK scenarios.

The PR does deliberately does not address the same kind of test for `MERGE`.

