### PR TITLE
Infer @NegativeTest tag in TCK API

### DIFF
--- a/tck/features/clauses/call/Call1.feature
+++ b/tck/features/clauses/call/Call1.feature
@@ -126,7 +126,6 @@ Feature: Call1 - Basic procedure calling
       | 'C'   |
     And no side effects
 
-  @NegativeTest
   Scenario: [7] Standalone call to procedure should fail if explicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
@@ -137,7 +136,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
-  @NegativeTest
   Scenario: [8] In-query call to procedure should fail if explicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
@@ -149,7 +147,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
-  @NegativeTest
   Scenario: [9] Standalone call to procedure should fail if too many explicit argument are given
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
@@ -160,7 +157,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
-  @NegativeTest
   Scenario: [10] In-query call to procedure should fail if too many explicit argument are given
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
@@ -172,7 +168,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberOfArguments
 
-  @NegativeTest
   Scenario: [11] Standalone call to procedure should fail if implicit argument is missing
     Given an empty graph
     And there exists a procedure test.my.proc(name :: STRING?, in :: INTEGER?) :: (out :: INTEGER?):
@@ -185,7 +180,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a ParameterMissing should be raised at compile time: MissingParameter
 
-  @NegativeTest
   Scenario: [12] In-query call to procedure that has outputs fails if no outputs are yielded
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
@@ -197,7 +191,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest
   Scenario: [13] Standalone call to unknown procedure should fail
     Given an empty graph
     When executing query:
@@ -206,7 +199,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a ProcedureError should be raised at compile time: ProcedureNotFound
 
-  @NegativeTest
   Scenario: [14] In-query call to unknown procedure should fail
     Given an empty graph
     When executing query:
@@ -216,7 +208,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a ProcedureError should be raised at compile time: ProcedureNotFound
 
-  @NegativeTest
   Scenario: [15] In-query procedure call should fail if shadowing an already bound variable
     Given an empty graph
     And there exists a procedure test.labels() :: (label :: STRING?):
@@ -232,7 +223,6 @@ Feature: Call1 - Basic procedure calling
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [16] In-query procedure call should fail if one of the argument expressions uses an aggregation function
     Given an empty graph
     And there exists a procedure test.labels(in :: INTEGER?) :: (label :: STRING?):

--- a/tck/features/clauses/call/Call2.feature
+++ b/tck/features/clauses/call/Call2.feature
@@ -91,7 +91,7 @@ Feature: Call2 - Procedure arguments
       | 'Berlin' | 49           |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [4] In-query call to procedure that takes arguments fails when trying to pass them implicitly
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
@@ -103,7 +103,6 @@ Feature: Call2 - Procedure arguments
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentPassingMode
 
-  @NegativeTest
   Scenario: [5] Standalone call to procedure should fail if input type is wrong
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):
@@ -114,7 +113,6 @@ Feature: Call2 - Procedure arguments
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [6] In-query call to procedure should fail if input type is wrong
     Given an empty graph
     And there exists a procedure test.my.proc(in :: INTEGER?) :: (out :: INTEGER?):

--- a/tck/features/clauses/create/Create1.feature
+++ b/tck/features/clauses/create/Create1.feature
@@ -151,7 +151,6 @@ Feature: Create1 - Creating nodes
       | +properties | 1 |
       | +labels     | 1 |
 
-  @NegativeTest
   Scenario: [11] Fail when creating a node that is already bound
     Given any graph
     When executing query:
@@ -161,7 +160,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [12] Fail when creating a node with properties that is already bound
     Given any graph
     When executing query:
@@ -172,7 +170,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [13] Fail when adding a new label predicate on a node that is already bound 1
     Given an empty graph
     When executing query:
@@ -182,7 +179,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   # Consider improve naming of this and the next three scenarios, they seem to test invariant nature of node patterns
   Scenario: [14] Fail when adding new label predicate on a node that is already bound 2
     Given an empty graph
@@ -193,7 +189,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [15] Fail when adding new label predicate on a node that is already bound 3
     Given an empty graph
     When executing query:
@@ -203,7 +198,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [16] Fail when adding new label predicate on a node that is already bound 4
     Given an empty graph
     When executing query:
@@ -213,7 +207,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [17] Fail when adding new label predicate on a node that is already bound 5
     Given an empty graph
     When executing query:
@@ -223,7 +216,6 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [18] Fail when creating a node using undefined variable in pattern
     Given any graph
     When executing query:

--- a/tck/features/clauses/create/Create2.feature
+++ b/tck/features/clauses/create/Create2.feature
@@ -295,7 +295,6 @@ Feature: Create2 - Creating relationships
       | +relationships | 1 |
       | +properties    | 1 |
 
-  @NegativeTest
   Scenario: [18] Fail when creating a relationship without a type
     Given any graph
     When executing query:
@@ -304,7 +303,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
 
-  @NegativeTest
   Scenario: [19] Fail when creating a relationship without a direction
     Given any graph
     When executing query:
@@ -313,7 +311,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: RequiresDirectedRelationship
 
-  @NegativeTest
   Scenario: [20] Fail when creating a relationship with two directions
     Given any graph
     When executing query:
@@ -322,7 +319,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: RequiresDirectedRelationship
 
-  @NegativeTest
   Scenario: [21] Fail when creating a relationship with more than one type
     Given any graph
     When executing query:
@@ -331,7 +327,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
 
-  @NegativeTest
   Scenario: [22] Fail when creating a variable-length relationship
     Given any graph
     When executing query:
@@ -340,7 +335,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: CreatingVarLength
 
-  @NegativeTest
   Scenario: [23] Fail when creating a relationship that is already bound
     Given any graph
     When executing query:
@@ -350,7 +344,6 @@ Feature: Create2 - Creating relationships
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [24] Fail when creating a relationship using undefined variable in pattern
     Given any graph
     When executing query:

--- a/tck/features/clauses/delete/Delete1.feature
+++ b/tck/features/clauses/delete/Delete1.feature
@@ -113,7 +113,6 @@ Feature: Delete1 - Deleting nodes
     Then the result should be empty
     And no side effects
 
-  @NegativeTest
   Scenario: [7] Failing when deleting connected nodes
     Given an empty graph
     And having executed:
@@ -130,7 +129,6 @@ Feature: Delete1 - Deleting nodes
       """
     Then a ConstraintVerificationFailed should be raised at runtime: DeleteConnectedNode
 
-  @NegativeTest
   Scenario: [8] Failing when deleting a label
     Given any graph
     When executing query:

--- a/tck/features/clauses/delete/Delete2.feature
+++ b/tck/features/clauses/delete/Delete2.feature
@@ -93,7 +93,6 @@ Feature: Delete2 - Deleting relationships
       | null |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] Failing when deleting a relationship type
     Given an empty graph
     And having executed:

--- a/tck/features/clauses/delete/Delete5.feature
+++ b/tck/features/clauses/delete/Delete5.feature
@@ -167,7 +167,6 @@ Feature: Delete5 - Delete clause interoperation with built-in data types
       | -relationships | 2 |
       | -labels        | 1 |
 
-  @NegativeTest
   Scenario: [8] Failing when using undefined variable in DELETE
     Given any graph
     When executing query:
@@ -177,7 +176,6 @@ Feature: Delete5 - Delete clause interoperation with built-in data types
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest
   Scenario: [9] Failing when deleting an integer expression
     Given any graph
     When executing query:

--- a/tck/features/clauses/match-where/MatchWhere1.feature
+++ b/tck/features/clauses/match-where/MatchWhere1.feature
@@ -269,7 +269,6 @@ Feature: MatchWhere1 - Filter single variable
       | x |
     And no side effects
 
-  @NegativeTest
   Scenario: [14] Fail when filtering path with property predicate
     Given any graph
     When executing query:
@@ -281,7 +280,6 @@ Feature: MatchWhere1 - Filter single variable
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [15] Fail on aggregation in WHERE
     Given any graph
     When executing query:

--- a/tck/features/clauses/match/Match1.feature
+++ b/tck/features/clauses/match/Match1.feature
@@ -120,7 +120,6 @@ Feature: Match1 - Match nodes
       | 3 | 2 |
     And no side effects
 
-  @NegativeTest
   Scenario: [6] Fail when using parameter as node predicate in MATCH
     Given any graph
     When executing query:
@@ -130,7 +129,6 @@ Feature: Match1 - Match nodes
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
-  @NegativeTest
   Scenario Outline: [7] Fail when a relationship has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -155,7 +153,6 @@ Feature: Match1 - Match nodes
       | ()-[]-()-[]-(), (), ()-[r]-()               |
       | (x), (a)-[q]-(b), (s), (s)-[r]->(t)<-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [8] Fail when a path has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -185,7 +182,6 @@ Feature: Match1 - Match nodes
       | (x), (a)-[q]-(b), r = (s)-[p]-(t)-[]-(b)   |
       | (x), (a)-[q]-(b), r = (s)-[p]->(t)<-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [9] Fail when a relationship has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -223,7 +219,6 @@ Feature: Match1 - Match nodes
       | ()-[*]-()-[r]-(), (), ()-[*]-(r)                |
       | (x), (a)-[r]-(b), (s), (s)-[]->(r)<-[]-(b)      |
 
-  @NegativeTest
   Scenario Outline: [10] Fail when a path has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -256,7 +251,6 @@ Feature: Match1 - Match nodes
       | (x), r = (s)-[p]-(t)-[]-(b), (a)-[q]-(r)        |
       | (x), r = (s)-[p]->(t)<-[]-(b), (r)-[q]-(b)      |
 
-  @NegativeTest
   Scenario Outline: [11] Fail when matching a node variable bound to a value
     Given any graph
     When executing query:

--- a/tck/features/clauses/match/Match2.feature
+++ b/tck/features/clauses/match/Match2.feature
@@ -149,7 +149,6 @@ Feature: Match2 - Match relationships
       | a1 | r | b2 |
     And no side effects
 
-  @NegativeTest
   Scenario: [8] Fail when using parameter as relationship predicate in MATCH
     Given any graph
     When executing query:
@@ -159,7 +158,6 @@ Feature: Match2 - Match relationships
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
-  @NegativeTest
   Scenario Outline: [9] Fail when a node has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -199,7 +197,6 @@ Feature: Match2 - Match relationships
       | (s), (a)-[q]-(b), (r), (s)-[]->(t)<-[]-(b) |
       | (s), (a)-[q]-(b), (t), (s)-[]->(r)<-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [10] Fail when a path has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -232,7 +229,6 @@ Feature: Match2 - Match relationships
       | (x), (a)-[q*]-(b), r = (s)-[p]->(t)<-[]-(b) |
       | (x), (a)-[q]-(b), r = (s)-[p*]->(t)<-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [11] Fail when a node has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -262,7 +258,6 @@ Feature: Match2 - Match relationships
       | (r), (a)-[q]-(b), (s), (s)-[r]-(t)-[]-(b)   |
       | (r), (a)-[q]-(b), (s), (s)-[r]->(t)<-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [12] Fail when a path has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -283,7 +278,6 @@ Feature: Match2 - Match relationships
       | (a)-[p]-(s)-[]-(b), r = (s)-[*]-(t), (t), (t)-[r]-(b)  |
       | (a)-[p]-(s)-[]-(b), r = (s)-[*]-(t), (t), (t)-[r*]-(b) |
 
-  @NegativeTest
   Scenario Outline: [13] Fail when matching a relationship variable bound to a value
     Given any graph
     When executing query:

--- a/tck/features/clauses/match/Match3.feature
+++ b/tck/features/clauses/match/Match3.feature
@@ -553,7 +553,6 @@ Feature: Match3 - Match fixed length patterns
       | b |
     And no side effects
 
-  @NegativeTest
   Scenario: [29] Fail when re-using a relationship in the same pattern
     Given any graph
     When executing query:
@@ -563,7 +562,6 @@ Feature: Match3 - Match fixed length patterns
       """
     Then a SyntaxError should be raised at compile time: RelationshipUniquenessViolation
 
-  @NegativeTest
   Scenario: [30] Fail when using a list or nodes as a node
     Given any graph
     When executing query:

--- a/tck/features/clauses/match/Match4.feature
+++ b/tck/features/clauses/match/Match4.feature
@@ -194,7 +194,7 @@ Feature: Match4 - Match variable length patterns scenarios
       | (:A)  | (:C)   |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [9] Fail when asterisk operator is missing
     Given an empty graph
     And having executed:
@@ -237,7 +237,7 @@ Feature: Match4 - Match variable length patterns scenarios
       """
     Then a SyntaxError should be raised at compile time: InvalidRelationshipPattern
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [10] Fail on negative bound
     Given an empty graph
     And having executed:

--- a/tck/features/clauses/match/Match6.feature
+++ b/tck/features/clauses/match/Match6.feature
@@ -387,7 +387,6 @@ Feature: Match6 - Match named paths scenarios
       | <({name: 'A'})-[:KNOWS]->({name: 'B'})-[:KNOWS]->({name: 'C'})> |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [21] Fail when a node has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -415,7 +414,6 @@ Feature: Match6 - Match named paths scenarios
       | (a)-[r*]-(s)-[]-(b), (p), (t)-[]-(b)  |
       | (a)-[r]-(p)<-[*]-(b), (t), (t)-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [22] Fail when a relationship has the same variable in a preceding MATCH
     Given any graph
     When executing query:
@@ -444,7 +442,6 @@ Feature: Match6 - Match named paths scenarios
       | (a)-[r*]-(s)-[p]-(b), (t), (t)-[]-(b) |
       | (a)-[r]-(s)<-[p]-(b), (t), (t)-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [23] Fail when a node has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -477,7 +474,6 @@ Feature: Match6 - Match named paths scenarios
       | (a)-[r]-(p)-[]-(b), p = (s)-[]-(t), (t), (t)-[]-(b)   |
       | (a)-[r]-(p)<-[*]-(b), p = (s)-[]-(t), (t), (t)-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [24] Fail when a relationship has the same variable in the same pattern
     Given any graph
     When executing query:
@@ -510,7 +506,6 @@ Feature: Match6 - Match named paths scenarios
       | (a)-[r]-(s)-[p]-(b), p = (s)-[]-(t), (t), (t)-[]-(b)   |
       | (a)-[r]-(s)<-[p*]-(b), p = (s)-[]-(t), (t), (t)-[]-(b) |
 
-  @NegativeTest
   Scenario Outline: [25] Fail when matching a path variable bound to a value
     Given any graph
     When executing query:

--- a/tck/features/clauses/merge/Merge1.feature
+++ b/tck/features/clauses/merge/Merge1.feature
@@ -279,7 +279,6 @@ Feature: Merge1 - Merge node
       | -nodes      | 2 |
       | -properties | 2 |
 
-  @NegativeTest
   Scenario: [15] Fail when merge a node that is already bound
     Given any graph
     When executing query:
@@ -289,7 +288,6 @@ Feature: Merge1 - Merge node
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [16] Fail when using parameter as node predicate in MERGE
     Given any graph
     When executing query:
@@ -299,7 +297,6 @@ Feature: Merge1 - Merge node
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
-  @NegativeTest
   Scenario: [17] Fail on merging node with null property
     Given any graph
     When executing query:

--- a/tck/features/clauses/merge/Merge2.feature
+++ b/tck/features/clauses/merge/Merge2.feature
@@ -113,7 +113,6 @@ Feature: Merge2 - Merge node - on create
       | +labels     | 1 |
       | +properties | 1 |
 
-  @NegativeTest
   Scenario: [6] Fail when using undefined variable in ON CREATE
     Given any graph
     When executing query:

--- a/tck/features/clauses/merge/Merge3.feature
+++ b/tck/features/clauses/merge/Merge3.feature
@@ -104,7 +104,6 @@ Feature: Merge3 - Merge node - on match
       | +labels     | 1 |
       | +properties | 1 |
 
-  @NegativeTest
   Scenario: [5] Fail when using undefined variable in ON MATCH
     Given any graph
     When executing query:

--- a/tck/features/clauses/merge/Merge5.feature
+++ b/tck/features/clauses/merge/Merge5.feature
@@ -443,7 +443,6 @@ Feature: Merge5 - Merge relationships
       | +properties    | 1 |
       | -properties    | 2 |
 
-  @NegativeTest
   Scenario: [22] Fail when imposing new predicates on a variable that is already bound
     Given any graph
     When executing query:
@@ -453,7 +452,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [23] Fail when merging relationship without type
     Given any graph
     When executing query:
@@ -463,7 +461,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
 
-  @NegativeTest
   Scenario: [24] Fail when merging relationship without type, no colon
     Given any graph
     When executing query:
@@ -473,7 +470,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
 
-  @NegativeTest
   Scenario: [25] Fail when merging relationship with more than one type
     Given any graph
     When executing query:
@@ -483,7 +479,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: NoSingleRelationshipType
 
-  @NegativeTest
   Scenario: [26] Fail when merging relationship that is already bound
     Given any graph
     When executing query:
@@ -493,7 +488,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  @NegativeTest
   Scenario: [27] Fail when using parameter as relationship predicate in MERGE
     Given any graph
     When executing query:
@@ -505,7 +499,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: InvalidParameterUse
 
-  @NegativeTest
   Scenario: [28] Fail when using variable length relationship in MERGE
     Given any graph
     When executing query:
@@ -516,7 +509,6 @@ Feature: Merge5 - Merge relationships
       """
     Then a SyntaxError should be raised at compile time: CreatingVarLength
 
-  @NegativeTest
   Scenario: [29] Fail on merging relationship with null property
     Given any graph
     When executing query:

--- a/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
@@ -263,7 +263,6 @@ Feature: ReturnOrderBy2 - Order by a single expression (order of projection)
       | [[(:C), (:D), (:E), (:F)]]                               | 3 |
     And no side effects
 
-  @NegativeTest
   Scenario: [13] Fail when sorting on variable removed by DISTINCT
     Given an empty graph
     And having executed:
@@ -278,7 +277,6 @@ Feature: ReturnOrderBy2 - Order by a single expression (order of projection)
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest
   Scenario: [14] Fail on aggregation in ORDER BY after RETURN
     Given any graph
     When executing query:

--- a/tck/features/clauses/return-skip-limit/ReturnSkipLimit1.feature
+++ b/tck/features/clauses/return-skip-limit/ReturnSkipLimit1.feature
@@ -111,7 +111,6 @@ Feature: ReturnSkipLimit1 - Skip
       | n |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] SKIP with an expression that depends on variables should fail
     Given any graph
     When executing query:
@@ -120,7 +119,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
-  @NegativeTest
   Scenario: [6] Negative parameter for SKIP should fail
     Given any graph
     And having executed:
@@ -138,7 +136,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [7] Negative SKIP should fail
     Given any graph
     And having executed:
@@ -154,7 +151,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [8] Floating point parameter for SKIP should fail
     Given any graph
     And having executed:
@@ -172,7 +168,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [9] Floating point SKIP should fail
     Given any graph
     And having executed:
@@ -188,7 +183,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [10] Fail when using non-constants in SKIP
     Given any graph
     When executing query:
@@ -199,7 +193,6 @@ Feature: ReturnSkipLimit1 - Skip
       """
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
-  @NegativeTest
   Scenario: [11] Fail when using negative value in SKIP
     Given any graph
     When executing query:

--- a/tck/features/clauses/return-skip-limit/ReturnSkipLimit2.feature
+++ b/tck/features/clauses/return-skip-limit/ReturnSkipLimit2.feature
@@ -177,7 +177,6 @@ Feature: ReturnSkipLimit2 - Limit
       | 2     | 1        |
     And no side effects
 
-  @NegativeTest
   Scenario: [9] Fail when using non-constants in LIMIT
     Given any graph
     When executing query:
@@ -186,7 +185,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at compile time: NonConstantExpression
 
-  @NegativeTest
   Scenario: [10] Negative parameter for LIMIT should fail
     Given any graph
     And having executed:
@@ -204,7 +202,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [11] Negative parameter for LIMIT with ORDER BY should fail
     Given any graph
     And having executed:
@@ -222,7 +219,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at runtime: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [12] Fail when using negative value in LIMIT 1
     Given any graph
     When executing query:
@@ -233,7 +229,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [13] Fail when using negative value in LIMIT 2
     Given any graph
     And having executed:
@@ -249,7 +244,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
 
-  @NegativeTest
   Scenario: [14] Floating point parameter for LIMIT should fail
     Given any graph
     And having executed:
@@ -267,7 +261,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [15] Floating point parameter for LIMIT with ORDER BY should fail
     Given any graph
     And having executed:
@@ -285,7 +278,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at runtime: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [16] Fail when using floating point in LIMIT 1
     Given any graph
     When executing query:
@@ -296,7 +288,6 @@ Feature: ReturnSkipLimit2 - Limit
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [17] Fail when using floating point in LIMIT 2
     Given any graph
     And having executed:

--- a/tck/features/clauses/return/Return1.feature
+++ b/tck/features/clauses/return/Return1.feature
@@ -46,7 +46,6 @@ Feature: Return1 - Return single variable (correct return of values according to
       | ({numbers: [1, 2, 3]}) |
     And no side effects
 
-  @NegativeTest
   Scenario: [2] Fail when returning an undefined variable
     Given any graph
     When executing query:

--- a/tck/features/clauses/return/Return2.feature
+++ b/tck/features/clauses/return/Return2.feature
@@ -249,7 +249,6 @@ Feature: Return2 - Return single expression (correctly projecting an expression)
     And the side effects should be:
       | -relationships | 1 |
 
-  @NegativeTest
   Scenario: [15] Fail when returning properties of deleted nodes
     Given an empty graph
     And having executed:
@@ -264,7 +263,6 @@ Feature: Return2 - Return single expression (correctly projecting an expression)
       """
     Then a EntityNotFound should be raised at runtime: DeletedEntityAccess
 
-  @NegativeTest
   Scenario: [16] Fail when returning labels of deleted nodes
     Given an empty graph
     And having executed:
@@ -279,7 +277,6 @@ Feature: Return2 - Return single expression (correctly projecting an expression)
       """
     Then a EntityNotFound should be raised at runtime: DeletedEntityAccess
 
-  @NegativeTest
   Scenario: [17] Fail when returning properties of deleted relationships
     Given an empty graph
     And having executed:
@@ -294,7 +291,6 @@ Feature: Return2 - Return single expression (correctly projecting an expression)
       """
     Then a EntityNotFound should be raised at runtime: DeletedEntityAccess
 
-  @NegativeTest
   Scenario: [18] Fail on projecting a non-existent function
     Given any graph
     When executing query:

--- a/tck/features/clauses/return/Return4.feature
+++ b/tck/features/clauses/return/Return4.feature
@@ -178,7 +178,6 @@ Feature: Return4 - Column renaming
       | 42  | 42  | {name: 1} |
     And no side effects
 
-  @NegativeTest
   Scenario: [10] Fail when returning multiple columns with same name
     Given any graph
     When executing query:

--- a/tck/features/clauses/return/Return6.feature
+++ b/tck/features/clauses/return/Return6.feature
@@ -248,7 +248,6 @@ Feature: Return6 - Implicit grouping with aggregates
       | 'a'  | ['c', 'b'] | 1   |
     And no side effects
 
-  @NegativeTest
   Scenario: [14] Aggregates in aggregates
     Given any graph
     When executing query:
@@ -257,7 +256,6 @@ Feature: Return6 - Implicit grouping with aggregates
       """
     Then a SyntaxError should be raised at compile time: NestedAggregation
 
-  @NegativeTest
   Scenario: [15] Using `rand()` in aggregations
     Given any graph
     When executing query:

--- a/tck/features/clauses/return/Return7.feature
+++ b/tck/features/clauses/return/Return7.feature
@@ -46,7 +46,6 @@ Feature: Return7 - Return all variables
       | (:Start) | () | <(:Start)-[:T]->()> |
     And no side effects
 
-  @NegativeTest
   Scenario: [2] Fail when using RETURN * without variables in scope
     Given any graph
     When executing query:

--- a/tck/features/clauses/set/Set1.feature
+++ b/tck/features/clauses/set/Set1.feature
@@ -167,7 +167,6 @@ Feature: Set1 - Set a Property
       | null |
     And no side effects
 
-  @NegativeTest
   Scenario: [9] Failing when using undefined variable in SET
     Given any graph
     When executing query:
@@ -178,7 +177,6 @@ Feature: Set1 - Set a Property
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest
   Scenario: [10] Failing when setting a list of maps as a property
     Given any graph
     When executing query:

--- a/tck/features/clauses/union/Union1.feature
+++ b/tck/features/clauses/union/Union1.feature
@@ -98,7 +98,6 @@ Feature: Union1 - Union
       | (:B) |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] Failing when UNION has different columns
     Given any graph
     When executing query:

--- a/tck/features/clauses/union/Union2.feature
+++ b/tck/features/clauses/union/Union2.feature
@@ -101,7 +101,6 @@ Feature: Union2 - Union All
       | (:B) |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] Failing when UNION ALL has different columns
     Given any graph
     When executing query:

--- a/tck/features/clauses/union/Union3.feature
+++ b/tck/features/clauses/union/Union3.feature
@@ -30,7 +30,6 @@
 
 Feature: Union3 - Union in combination with Union All
 
-  @NegativeTest
   Scenario: [1] Failing when mixing UNION and UNION ALL
     Given any graph
     When executing query:
@@ -43,7 +42,6 @@ Feature: Union3 - Union in combination with Union All
       """
     Then a SyntaxError should be raised at compile time: InvalidClauseComposition
 
-  @NegativeTest
   Scenario: [2] Failing when mixing UNION ALL and UNION
     Given any graph
     When executing query:

--- a/tck/features/clauses/with-orderBy/WithOrderBy1.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy1.feature
@@ -1152,7 +1152,6 @@ Feature: WithOrderBy1 - Order by a single variable
       | localdatetimes | [localdatetime({year: 1984, month: 10, day: 11, hour: 12, minute: 30, second: 14, nanosecond: 12}), localdatetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, second: 14, nanosecond: 645876123}), localdatetime({year: 1, month: 1, day: 1, hour: 1, minute: 1, second: 1, nanosecond: 1}), localdatetime({year: 9999, month: 9, day: 9, hour: 9, minute: 59, second: 59, nanosecond: 999999999}), localdatetime({year: 1980, month: 12, day: 11, hour: 12, minute: 31, second: 14})]                                                                            |
       | datetimes      | [datetime({year: 1984, month: 10, day: 11, hour: 12, minute: 30, second: 14, nanosecond: 12, timezone: '+00:15'}), datetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, second: 14, nanosecond: 645876123, timezone: '+00:17'}), datetime({year: 1, month: 1, day: 1, hour: 1, minute: 1, second: 1, nanosecond: 1, timezone: '-11:59'}), datetime({year: 9999, month: 9, day: 9, hour: 9, minute: 59, second: 59, nanosecond: 999999999, timezone: '+11:59'}), datetime({year: 1980, month: 12, day: 11, hour: 12, minute: 31, second: 14, timezone: '-11:59'})] |
 
-  @NegativeTest
   Scenario Outline: [46] Fail on sorting by an undefined variable #Example: <exampleName>
     Given an empty graph
     And having executed:

--- a/tck/features/clauses/with-orderBy/WithOrderBy2.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy2.feature
@@ -754,7 +754,6 @@ Feature: WithOrderBy2 - Order by a single expression
       | ASC  | 'A' |
       | DESC | 'C' |
 
-  @NegativeTest
   Scenario Outline: [25] Fail on sorting by an aggregation
     Given any graph
     When executing query:

--- a/tck/features/clauses/with-orderBy/WithOrderBy3.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy3.feature
@@ -287,7 +287,6 @@ Feature: WithOrderBy3 - Order by multiple expressions
       | a DESC, -1 * a DESC   | 3     |
       | -1 * a ASC, a DESC    | 3     |
 
-  @NegativeTest
   Scenario Outline: [8] Fail on sorting by any number of undefined variables in any position #Example: <exampleName>
     Given any graph
     When executing query:

--- a/tck/features/clauses/with-orderBy/WithOrderBy4.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy4.feature
@@ -334,7 +334,6 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       | 1   | 13  |
     And no side effects
 
-  @NegativeTest
   Scenario: [13] Fail on sorting by a non-projected aggregation on a variable
     Given an empty graph
     And having executed:
@@ -356,7 +355,6 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest
   Scenario: [14] Fail on sorting by a non-projected aggregation on an expression
     Given an empty graph
     And having executed:

--- a/tck/features/clauses/with/With4.feature
+++ b/tck/features/clauses/with/With4.feature
@@ -90,7 +90,6 @@ Feature: With4 - Variable aliasing
       | 'King Kong'  |
     And no side effects
 
-  @NegativeTest
   Scenario: [4] Fail when forwarding multiple aliases with the same name
     Given any graph
     When executing query:
@@ -100,7 +99,6 @@ Feature: With4 - Variable aliasing
       """
     Then a SyntaxError should be raised at compile time: ColumnNameConflict
 
-  @NegativeTest
   Scenario: [5] Fail when not aliasing expressions in WITH
     Given any graph
     When executing query:

--- a/tck/features/expressions/aggregation/Aggregation6.feature
+++ b/tck/features/expressions/aggregation/Aggregation6.feature
@@ -82,7 +82,6 @@ Feature: Aggregation6 - Percentiles
       | 0.5 | 20.0   |
       | 1.0 | 30.0   |
 
-  @NegativeTest
   Scenario Outline: [3] `percentileCont()` failing on bad arguments
     Given an empty graph
     And having executed:
@@ -104,7 +103,6 @@ Feature: Aggregation6 - Percentiles
       | -1         |
       | 1.1        |
 
-  @NegativeTest
   Scenario Outline: [4] `percentileDisc()` failing on bad arguments
     Given an empty graph
     And having executed:
@@ -126,7 +124,6 @@ Feature: Aggregation6 - Percentiles
       | -1         |
       | 1.1        |
 
-  @NegativeTest
   Scenario: [5] `percentileDisc()` failing in more involved query
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/boolean/Boolean4.feature
+++ b/tck/features/expressions/boolean/Boolean4.feature
@@ -47,7 +47,6 @@ Feature: Boolean4 - NOT logical operations
       | ({name: 'a'}) |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [2] Fail when using NOT on a non-boolean literal
     Given any graph
     When executing query:

--- a/tck/features/expressions/comparison/Comparison1.feature
+++ b/tck/features/expressions/comparison/Comparison1.feature
@@ -312,7 +312,6 @@ Feature: Comparison1 - Equality
       | null  |
     And no side effects
 
-  @NegativeTest
   Scenario: [17] Failing when comparing to an undefined variable
     Given any graph
     When executing query:

--- a/tck/features/expressions/graph/Graph10.feature
+++ b/tck/features/expressions/graph/Graph10.feature
@@ -86,7 +86,6 @@ Feature: Graph10 - Retrieve all properties as a property map
       | {name: 'Popeye', level: 9001} |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] `properties()` failing on an integer literal
     Given any graph
     When executing query:
@@ -95,7 +94,6 @@ Feature: Graph10 - Retrieve all properties as a property map
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [6] `properties()` failing on a string literal
     Given any graph
     When executing query:
@@ -104,7 +102,6 @@ Feature: Graph10 - Retrieve all properties as a property map
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [7] `properties()` failing on a list of booleans
     Given any graph
     When executing query:

--- a/tck/features/expressions/graph/Graph3.feature
+++ b/tck/features/expressions/graph/Graph3.feature
@@ -137,7 +137,6 @@ Feature: Graph3 - Node labels
       | null      | null         |
     And no side effects
 
-  @NegativeTest
   Scenario: [8] `labels()` failing on a path
     Given an empty graph
     And having executed:
@@ -151,7 +150,6 @@ Feature: Graph3 - Node labels
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [9] `labels()` failing on invalid arguments
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/graph/Graph4.feature
+++ b/tck/features/expressions/graph/Graph4.feature
@@ -114,7 +114,6 @@ Feature: Graph4 - Edge relationship type
       | 'T'           |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [6] `type()` failing on invalid arguments
     Given an empty graph
     And having executed:
@@ -136,7 +135,6 @@ Feature: Graph4 - Edge relationship type
       | ''      |
       | []      |
 
-  @NegativeTest
   Scenario: [7] Failing when using `type()` on a node
     Given any graph
     When executing query:

--- a/tck/features/expressions/graph/Graph6.feature
+++ b/tck/features/expressions/graph/Graph6.feature
@@ -31,7 +31,6 @@
 Feature: Graph6 - Static property access
   # Accessing a property of a node or edge by using a symbolic name as the key.
 
-  @NegativeTest
   Scenario: [1] Fail when performing property access on a non-graph element
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/graph/Graph9.feature
+++ b/tck/features/expressions/graph/Graph9.feature
@@ -111,7 +111,6 @@ Feature: Graph9 - Property existence check
       | null              |
     And no side effects
 
-  @NegativeTest
   Scenario: [6] Fail when checking existence of a non-property and non-pattern
     Given any graph
     When executing query:

--- a/tck/features/expressions/list/List1.feature
+++ b/tck/features/expressions/list/List1.feature
@@ -97,7 +97,6 @@ Feature: List1 - Dynamic Element Access
       | 'Apa' |
     And no side effects
 
-  @NegativeTest
   Scenario: [6] Fail at runtime when attempting to index with a String into a List
     Given any graph
     And parameters are:
@@ -110,7 +109,6 @@ Feature: List1 - Dynamic Element Access
       """
     Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
 
-  @NegativeTest
   Scenario: [7] Fail at runtime when trying to index into a list with a list
     Given any graph
     And parameters are:
@@ -123,7 +121,6 @@ Feature: List1 - Dynamic Element Access
       """
     Then a TypeError should be raised at compile time: ListElementAccessByNonInteger
 
-  @NegativeTest
   Scenario: [8] Fail at compile time when attempting to index with a non-integer into a list
     Given any graph
     When executing query:
@@ -133,7 +130,6 @@ Feature: List1 - Dynamic Element Access
       """
     Then a SyntaxError should be raised at compile time: ListElementAccessByNonInteger
 
-  @NegativeTest
   Scenario: [9] Fail at runtime when trying to index something which is not a list
     Given any graph
     And parameters are:

--- a/tck/features/expressions/list/List11.feature
+++ b/tck/features/expressions/list/List11.feature
@@ -114,7 +114,6 @@ Feature: List11 - Create a list from a range
       | true |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [4] Fail on invalid arguments for `range()`
     Given any graph
     When executing query:
@@ -130,7 +129,6 @@ Feature: List11 - Create a list from a range
       | -2    | 8    | 0    |
       | 2     | -8   | 0    |
 
-  @NegativeTest
   Scenario Outline: [5] Fail on invalid argument types for `range()`
     Given any graph
     When executing query:

--- a/tck/features/expressions/list/List12.feature
+++ b/tck/features/expressions/list/List12.feature
@@ -143,7 +143,6 @@ Feature: List12 - List Comprehension
       | (:C) |
     And no side effects
 
-  @NegativeTest
   Scenario: [7] Fail when using aggregation in list comprehension
     Given any graph
     When executing query:

--- a/tck/features/expressions/list/List5.feature
+++ b/tck/features/expressions/list/List5.feature
@@ -487,7 +487,6 @@ Feature: List5 - List Membership Validation - IN Operator
       | true |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [42] Failing when using IN on a non-list literal
     Given any graph
     When executing query:

--- a/tck/features/expressions/list/List6.feature
+++ b/tck/features/expressions/list/List6.feature
@@ -82,7 +82,6 @@ Feature: List6 - List size
       | null    | null       |
     And no side effects
 
-  @NegativeTest
   Scenario: [5] Fail for `size()` on paths
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals2.feature
+++ b/tck/features/expressions/literals/Literals2.feature
@@ -118,7 +118,6 @@ Feature: Literals2 - Decimal integer
       | -9223372036854775808 |
     And no side effects
 
-  @NegativeTest
   Scenario: [9] Fail on a too large integer
     Given any graph
     When executing query:
@@ -127,7 +126,6 @@ Feature: Literals2 - Decimal integer
       """
     Then a SyntaxError should be raised at compile time: IntegerOverflow
 
-  @NegativeTest
   Scenario: [10] Fail on a too small integer
     Given any graph
     When executing query:
@@ -136,7 +134,7 @@ Feature: Literals2 - Decimal integer
       """
     Then a SyntaxError should be raised at compile time: IntegerOverflow
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [11] Fail on an integer containing a alphabetic character
     Given any graph
     When executing query:
@@ -145,7 +143,7 @@ Feature: Literals2 - Decimal integer
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberLiteral
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [12] Fail on an integer containing a invalid symbol character
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals3.feature
+++ b/tck/features/expressions/literals/Literals3.feature
@@ -151,7 +151,7 @@ Feature: Literals3 - Hexadecimal integer
       | 460367961908983 |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [12] Fail on an incomplete hexadecimal integer
     Given any graph
     When executing query:
@@ -160,7 +160,7 @@ Feature: Literals3 - Hexadecimal integer
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberLiteral
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [13] Fail on an hexadecimal literal containing a lower case invalid alphanumeric character
     Given any graph
     When executing query:
@@ -169,7 +169,7 @@ Feature: Literals3 - Hexadecimal integer
       """
     Then a SyntaxError should be raised at compile time: InvalidNumberLiteral
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [14] Fail on an hexadecimal literal containing a upper case invalid alphanumeric character
     Given any graph
     When executing query:
@@ -188,7 +188,6 @@ Feature: Literals3 - Hexadecimal integer
 #      """
 #    Then a SyntaxError should be raised at compile time: InvalidNumberLiteral
 
-  @NegativeTest
   Scenario: [16] Fail on a too large hexadecimal integer
     Given any graph
     When executing query:
@@ -197,7 +196,6 @@ Feature: Literals3 - Hexadecimal integer
       """
     Then a SyntaxError should be raised at compile time: IntegerOverflow
 
-  @NegativeTest
   Scenario: [17] Fail on a too small hexadecimal integer
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals4.feature
+++ b/tck/features/expressions/literals/Literals4.feature
@@ -118,7 +118,6 @@ Feature: Literals4 - Octal integer
       | -9223372036854775808 |
     And no side effects
 
-  @NegativeTest
   Scenario: [9] Fail on a too large octal integer
     Given any graph
     When executing query:
@@ -127,7 +126,6 @@ Feature: Literals4 - Octal integer
       """
     Then a SyntaxError should be raised at compile time: IntegerOverflow
 
-  @NegativeTest
   Scenario: [10] Fail on a too small octal integer
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals5.feature
+++ b/tck/features/expressions/literals/Literals5.feature
@@ -316,7 +316,6 @@ Feature: Literals5 - Float
       | 1.23456789e308 |
     And no side effects
 
-  @NegativeTest
   Scenario: [27] Fail when float value is too large
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals6.feature
+++ b/tck/features/expressions/literals/Literals6.feature
@@ -166,7 +166,7 @@ Feature: Literals6 - String
       | '🧐🍌❖⋙⚐' |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [13] Failing on incorrect unicode literal
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals7.feature
+++ b/tck/features/expressions/literals/Literals7.feature
@@ -297,7 +297,7 @@ Feature: Literals7 - List
       | [{id: '0001', type: 'donut', name: 'Cake', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}, {id: '1002', type: 'Chocolate'}, {id: '1003', type: 'Blueberry'}, {id: '1004', type: 'Devils Food'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5005', type: 'Sugar'}, {id: '5007', type: 'Powdered Sugar'}, {id: '5006', type: 'Chocolate Sprinkles'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}, {id: '0002', type: 'donut', name: 'Raised', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5005', type: 'Sugar'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}, {id: '0003', type: 'donut', name: 'Old Fashioned', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}, {id: '1002', type: 'Chocolate'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}] |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [19] Fail on a list containing only a comma
     Given any graph
     When executing query:
@@ -306,7 +306,7 @@ Feature: Literals7 - List
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [20] Fail on a nested list with non-matching brackets
     Given any graph
     When executing query:
@@ -315,7 +315,7 @@ Feature: Literals7 - List
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [21] Fail on a nested list with missing commas
     Given any graph
     When executing query:

--- a/tck/features/expressions/literals/Literals8.feature
+++ b/tck/features/expressions/literals/Literals8.feature
@@ -296,7 +296,7 @@ Feature: Literals8 - Maps
       | {data: [{id: '0001', type: 'donut', name: 'Cake', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}, {id: '1002', type: 'Chocolate'}, {id: '1003', type: 'Blueberry'}, {id: '1004', type: 'Devils Food'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5005', type: 'Sugar'}, {id: '5007', type: 'Powdered Sugar'}, {id: '5006', type: 'Chocolate Sprinkles'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}, {id: '0002', type: 'donut', name: 'Raised', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5005', type: 'Sugar'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}, {id: '0003', type: 'donut', name: 'Old Fashioned', ppu: 0.55, batters: {batter: [{id: '1001', type: 'Regular'}, {id: '1002', type: 'Chocolate'}]}, topping: [{id: '5001', type: 'None'}, {id: '5002', type: 'Glazed'}, {id: '5003', type: 'Chocolate'}, {id: '5004', type: 'Maple'}]}]} |
     And no side effects
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [19] Fail on a map containing key starting with a number
     Given any graph
     When executing query:
@@ -305,7 +305,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [20] Fail on a map containing key with symbol
     Given any graph
     When executing query:
@@ -314,7 +314,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [21] Fail on a map containing key with dot
     Given any graph
     When executing query:
@@ -323,7 +323,6 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest
   Scenario: [22] Fail on a map containing unquoted string
     Given any graph
     When executing query:
@@ -332,7 +331,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UndefinedVariable
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [23] Fail on a map containing only a comma
     Given any graph
     When executing query:
@@ -341,7 +340,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [24] Fail on a map containing a value without key
     Given any graph
     When executing query:
@@ -350,7 +349,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [25] Fail on a map containing a list without key
     Given any graph
     When executing query:
@@ -359,7 +358,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [26] Fail on a map containing a map without key
     Given any graph
     When executing query:
@@ -368,7 +367,7 @@ Feature: Literals8 - Maps
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [27] Fail on a nested map with non-matching braces
     Given any graph
     When executing query:

--- a/tck/features/expressions/map/Map1.feature
+++ b/tck/features/expressions/map/Map1.feature
@@ -43,7 +43,6 @@ Feature: Map1 - Static value access
       | 0             |
     And no side effects
 
-  @NegativeTest
   Scenario: [2] Fail when performing property access on a non-map
     Given any graph
     When executing query:

--- a/tck/features/expressions/map/Map2.feature
+++ b/tck/features/expressions/map/Map2.feature
@@ -61,7 +61,6 @@ Feature: Map2 - Dynamic Value Access
       | 'Apa' |
     And no side effects
 
-  @NegativeTest
   Scenario: [3] Fail at runtime when attempting to index with an Int into a Map
     Given any graph
     And parameters are:
@@ -74,7 +73,6 @@ Feature: Map2 - Dynamic Value Access
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
 
-  @NegativeTest
   Scenario: [4] Fail at runtime when trying to index into a map with a non-string
     Given any graph
     And parameters are:
@@ -87,7 +85,6 @@ Feature: Map2 - Dynamic Value Access
       """
     Then a TypeError should be raised at runtime: MapElementAccessByNonString
 
-  @NegativeTest
   Scenario: [5] Fail at runtime when trying to index something which is not a map
     Given any graph
     And parameters are:

--- a/tck/features/expressions/mathematical/Mathematical3.feature
+++ b/tck/features/expressions/mathematical/Mathematical3.feature
@@ -30,7 +30,7 @@
 
 Feature: Mathematical3 - Subtraction
 
-  @NegativeTest @skipGrammarCheck
+  @skipGrammarCheck
   Scenario: [1] Fail for invalid Unicode hyphen in subtraction
     Given any graph
     When executing query:

--- a/tck/features/expressions/path/Path3.feature
+++ b/tck/features/expressions/path/Path3.feature
@@ -48,7 +48,6 @@ Feature: Path3 - Length of a path
       | (:A) | (:B) | 1 |
     And no side effects
 
-  @NegativeTest
   Scenario: [2] Failing when using `length()` on a node
     Given any graph
     When executing query:
@@ -58,7 +57,6 @@ Feature: Path3 - Length of a path
       """
     Then a SyntaxError should be raised at compile time: InvalidArgumentType
 
-  @NegativeTest
   Scenario: [3] Failing when using `length()` on a relationship
     Given any graph
     When executing query:

--- a/tck/features/expressions/typeConversion/TypeConversion1.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion1.feature
@@ -82,7 +82,6 @@ Feature: TypeConversion1 - To Boolean
       | null |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [5] `toBoolean()` on invalid types #Example: <exampleName>
     Given any graph
     When executing query:

--- a/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -121,7 +121,6 @@ Feature: TypeConversion2 - To Integer
       | 42   |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [8] `toInteger()` failing on invalid arguments
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/typeConversion/TypeConversion3.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion3.feature
@@ -96,7 +96,6 @@ Feature: TypeConversion3 - To Float
       | 4.0   |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [6] `toFloat()` failing on invalid arguments
     Given an empty graph
     And having executed:

--- a/tck/features/expressions/typeConversion/TypeConversion4.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion4.feature
@@ -148,7 +148,6 @@ Feature: TypeConversion4 - To String
       | 'x'      |
     And no side effects
 
-  @NegativeTest
   Scenario Outline: [10] `toString()` failing on invalid arguments
     Given an empty graph
     And having executed:

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -267,7 +267,16 @@ object CypherTCK {
       scenarioSteps
     }.toList
     val (name, number) = parseNameAndNumber(nameAndNumber)
-    Scenario(categories.toList, featureName, number, name, exampleIndex, exampleName, tags, steps, pickle, sourceFile)
+    val tagsInferred = {
+      if (steps.exists {
+        case ExpectError(_, _, _, _) => true
+        case _ => false
+      })
+        tags + TCKTags.NEGATIVE_TEST
+      else
+        tags
+    }
+    Scenario(categories.toList, featureName, number, name, exampleIndex, exampleName, tagsInferred, steps, pickle, sourceFile)
   }
 
   private def tagNames(pickle: io.cucumber.core.gherkin.Pickle): Set[String] = pickle.getTags.asScala.toSet

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
@@ -27,8 +27,9 @@
  */
 package org.opencypher.tools.tck.api
 
-import java.net.URI
+import org.opencypher.tools.tck.constants.TCKTags
 
+import java.net.URI
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -91,5 +92,10 @@ class TCKApiTest extends AnyFunSuite with Matchers {
     val someLevelScenarios = scenarios.filter(_.featureName == "Test")
     someLevelScenarios.foreach(_.sourceFile should
       equal(java.nio.file.Paths.get(fooUri).resolve("foo/bar/boo/Test.feature")))
+  }
+
+  test("scenarios with an ExpectError step have the TCKTags.NEGATIVE_TEST tag") {
+    val negativeTestScenarios = scenarios.filter(_.name == "Fail")
+    negativeTestScenarios.foreach(_.tags should contain (TCKTags.NEGATIVE_TEST))
   }
 }

--- a/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
+++ b/tools/tck-inspection/src/test/scala/org/opencypher/tools/tck/inspection/browser/cli/CountScenariosTest.scala
@@ -211,20 +211,21 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
     val fooUri: URI = getClass.getResource("cucumber").toURI
     val scenarios: Seq[Scenario] = CypherTCK.parseFeatures(fooUri).flatMap(_.scenarios)
     val expectedCountOutput: String =
-      """Total               13
-        || foo                8
-        || | bar              6
-        || | | boo            4
-        || | | | Boo          1
-        || | | | Test 2       3
-        || | | Test 1         2
-        || | dummy            2
-        || | | Dummy          2
-        || Foo                5
-        || @Fail              3
-        || @TestA             2
-        || @TestB             1
-        || @TestC             3""".stripMargin
+      """Total                13
+        || foo                 8
+        || | bar               6
+        || | | boo             4
+        || | | | Boo           1
+        || | | | Test 2        3
+        || | | Test 1          2
+        || | dummy             2
+        || | | Dummy           2
+        || Foo                 5
+        || @Fail               3
+        || @NegativeTest       4
+        || @TestA              2
+        || @TestB              1
+        || @TestC              3""".stripMargin
     CountScenarios.reportCountsInPrettyPrint(TckTree(scenarios)) should equal(expectedCountOutput)
   }
 
@@ -375,24 +376,25 @@ class CountScenariosTest extends AnyFunSuite with Matchers {
     val scenariosBefore: Seq[Scenario] = CypherTCK.parseFeatures(fooUriBefore).flatMap(_.scenarios)
     val scenariosAfter: Seq[Scenario] = CypherTCK.parseFeatures(fooUriAfter).flatMap(_.scenarios)
     val expectedResult: String =
-      """Group          unchanged  moved only  changed more  added  removed
-        |––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
-        |Total                 12           1             0      0        0
-        |- foo                  7           1             0      0        0
-        |  - bar                5           0             0      0        1
-        |    - boo              3           0             0      0        1
-        |      - Boo            0           0             0      0        1
-        |      - Test 2         3           0             0      0        0
-        |    - Test 1           2           0             0      0        0
-        |  - dummy              2           0             0      0        0
-        |    - Dummy            2           0             0      0        0
-        |  - new                0           0             0      1        0
-        |    - New              0           0             0      1        0
-        |- Foo                  5           0             0      0        0
-        |- @Fail                3           0             0      0        0
-        |- @TestA               2           0             0      0        0
-        |- @TestB               1           0             0      0        0
-        |- @TestC               2           1             0      0        0""".stripMargin
+      """Group           unchanged  moved only  changed more  added  removed
+        |–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+        |Total                  12           1             0      0        0
+        |- foo                   7           1             0      0        0
+        |  - bar                 5           0             0      0        1
+        |    - boo               3           0             0      0        1
+        |      - Boo             0           0             0      0        1
+        |      - Test 2          3           0             0      0        0
+        |    - Test 1            2           0             0      0        0
+        |  - dummy               2           0             0      0        0
+        |    - Dummy             2           0             0      0        0
+        |  - new                 0           0             0      1        0
+        |    - New               0           0             0      1        0
+        |- Foo                   5           0             0      0        0
+        |- @Fail                 3           0             0      0        0
+        |- @NegativeTest         4           0             0      0        0
+        |- @TestA                2           0             0      0        0
+        |- @TestB                1           0             0      0        0
+        |- @TestC                2           1             0      0        0""".stripMargin
     CountScenarios.reportDiffCountsInPrettyPrint(TckTreeDiff(
       TckTree(scenariosBefore),
       TckTree(scenariosAfter)

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
@@ -60,13 +60,6 @@ trait ValidateScenario extends AppendedClues with Matchers with OptionValues wit
       }
     }
 
-    withClue("scenario has a `@NegativeTest` tag and a `Then expect error` step or neither") {
-      (scenario.steps exists {
-        case _: ExpectError => true
-        case _ => false
-      }) should equal(scenario.tags contains TCKTags.NEGATIVE_TEST)
-    }
-
     validateSteps(scenario.steps, scenario.tags)
   }
 }


### PR DESCRIPTION
**This PR builds on #487**

The PR changes the TCK API so that it adds the `@NegativeTest` tag to all scenarios that have an `ExpectedError` step, which is precisely the meaning of the tag. As a result, the tag has not to be provided manually in feature files anymore, but appears automatically when scenarios are parser through the API. If a scenario still has the tag in the feature file, the TCK API does not add the tag.

The PR removes the `@NegativeTest` tag from scenarios in exiting feature files.

The PR removes a check in the `ScenarioFormatChecker`, that checked that scenarios have either both, an `ExpectedError` step and `@NegativeTest` tag, or neither of the two. Since, the TCP API takes care of the tag this check is superfluous, now.

It can be argued that, with this PR, the `ScenarioFormatChecker` should check that the scenarios in the feature files do not contain the `@NegativeTest` tag. However, that is not straightforward since the `ScenarioFormatChecker` consumes the scenarios through the TCK API, too. It is certainly imaginable to let the `ScenarioFormatChecker` know if a tag was added by the TCK API or allow switching off tag inference. However, that seems unnecessarily complicated and not worth the cost at this point. Such things can still be added later, probably when more tag inferencing is added to the TCP API or as a separate tool.

The purpose of the `@NegativeTest` tag is to ease finding and filtering negative test scenarios. 