### PR TITLE
Scenarios for creating multiple nodes with overlapping label sets

### DIFF
--- a/tck/features/clauses/create/Create1.feature
+++ b/tck/features/clauses/create/Create1.feature
@@ -61,7 +61,18 @@ Feature: Create1 - Creating nodes
       | +nodes  | 1 |
       | +labels | 1 |
 
-  Scenario: [4] Create a single node with multiple labels
+  Scenario: [4] Create two nodes with same label
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (:Label), (:Label)
+      """
+    Then the result should be empty
+    And the side effects should be:
+      | +nodes  | 2 |
+      | +labels | 1 |
+
+  Scenario: [5] Create a single node with multiple labels
     Given an empty graph
     When executing query:
       """
@@ -72,7 +83,18 @@ Feature: Create1 - Creating nodes
       | +nodes  | 1 |
       | +labels | 4 |
 
-  Scenario: [5] Create a single node with a property
+  Scenario: [6] Create three nodes with multiple labels
+    Given an empty graph
+    When executing query:
+      """
+      CREATE (:B:A:D), (:B:C), (:D:E:B)
+      """
+    Then the result should be empty
+    And the side effects should be:
+      | +nodes  | 3 |
+      | +labels | 5 |
+
+  Scenario: [7] Create a single node with a property
     Given any graph
     When executing query:
       """
@@ -83,7 +105,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 1 |
 
-  Scenario: [6] Create a single node with a property and return it
+  Scenario: [8] Create a single node with a property and return it
     Given any graph
     When executing query:
       """
@@ -97,7 +119,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 1 |
 
-  Scenario: [7] Create a single node with two properties
+  Scenario: [9] Create a single node with two properties
     Given any graph
     When executing query:
       """
@@ -108,7 +130,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 2 |
 
-  Scenario: [8] Create a single node with two properties and return them
+  Scenario: [10] Create a single node with two properties and return them
     Given any graph
     When executing query:
       """
@@ -122,7 +144,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 2 |
 
-  Scenario: [9] Create a single node with null properties should not return those properties
+  Scenario: [11] Create a single node with null properties should not return those properties
     Given any graph
     When executing query:
       """
@@ -136,7 +158,7 @@ Feature: Create1 - Creating nodes
       | +nodes      | 1 |
       | +properties | 1 |
 
-  Scenario: [10] CREATE does not lose precision on large integers
+  Scenario: [12] CREATE does not lose precision on large integers
     Given an empty graph
     When executing query:
       """
@@ -151,7 +173,7 @@ Feature: Create1 - Creating nodes
       | +properties | 1 |
       | +labels     | 1 |
 
-  Scenario: [11] Fail when creating a node that is already bound
+  Scenario: [13] Fail when creating a node that is already bound
     Given any graph
     When executing query:
       """
@@ -160,7 +182,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [12] Fail when creating a node with properties that is already bound
+  Scenario: [14] Fail when creating a node with properties that is already bound
     Given any graph
     When executing query:
       """
@@ -170,7 +192,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [13] Fail when adding a new label predicate on a node that is already bound 1
+  Scenario: [15] Fail when adding a new label predicate on a node that is already bound 1
     Given an empty graph
     When executing query:
       """
@@ -180,7 +202,7 @@ Feature: Create1 - Creating nodes
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
   # Consider improve naming of this and the next three scenarios, they seem to test invariant nature of node patterns
-  Scenario: [14] Fail when adding new label predicate on a node that is already bound 2
+  Scenario: [16] Fail when adding new label predicate on a node that is already bound 2
     Given an empty graph
     When executing query:
       """
@@ -189,7 +211,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [15] Fail when adding new label predicate on a node that is already bound 3
+  Scenario: [17] Fail when adding new label predicate on a node that is already bound 3
     Given an empty graph
     When executing query:
       """
@@ -198,7 +220,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [16] Fail when adding new label predicate on a node that is already bound 4
+  Scenario: [18] Fail when adding new label predicate on a node that is already bound 4
     Given an empty graph
     When executing query:
       """
@@ -207,7 +229,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [17] Fail when adding new label predicate on a node that is already bound 5
+  Scenario: [19] Fail when adding new label predicate on a node that is already bound 5
     Given an empty graph
     When executing query:
       """
@@ -216,7 +238,7 @@ Feature: Create1 - Creating nodes
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
 
-  Scenario: [18] Fail when creating a node using undefined variable in pattern
+  Scenario: [20] Fail when creating a node using undefined variable in pattern
     Given any graph
     When executing query:
       """


### PR DESCRIPTION
This simple PR adds two scenarios that test the `CREATE` clause for creating multiple nodes with overlapping label sets.