### PR TITLE
Link to grammar production

### DIFF
--- a/tools/grammar-production-links/demoForm.html
+++ b/tools/grammar-production-links/demoForm.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="UTF-8">
+    <title>Grammar Link Demo Form</title>
+</head>
+<script type="application/javascript">
+    function updateUrlOutput() {
+        const p = document.getElementById('inputp').value;
+        document.getElementById('urloutput').innerText = 'https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=' + p;
+    }
+
+    function copyToClipboard() {
+        const el = document.createElement('textarea');
+        el.value = document.getElementById("urloutput").innerText;
+        el.setAttribute('readonly', '');
+        el.style.position = 'absolute';
+        el.style.left = '-9999px';
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+    }
+</script>
+<body>
+<form action="https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html" method="get">
+    <div>Production name: <input id="inputp" type="text" name="p" oninput="updateUrlOutput()" onchange="updateUrlOutput()" /> <input type="submit" value="Go!" /></div>
+</form>
+<div>Link url:</div>
+<pre id="urloutput"></pre>
+<div><button onclick="copyToClipboard()">Copy to clipboard</button></div>
+</body>
+</html>

--- a/tools/grammar-production-links/grammarLink.html
+++ b/tools/grammar-production-links/grammarLink.html
@@ -52,7 +52,7 @@
                             if (line > -1) {
                                 window.location.replace(githubOCGrammarPrefix + file + '#L' + (line + 1));
                             } else {
-                                document.body.innerHTML += '&lt;' + production + '&gt; in ' + file + '</br>'
+                                document.body.innerHTML += '&lt;' + production + '&gt; not found in ' + file + '</br>'
                             }
                         }
                     } else {

--- a/tools/grammar-production-links/grammarLink.html
+++ b/tools/grammar-production-links/grammarLink.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<script type="text/javascript">
+    const githubOCGrammarPrefix = 'https://github.com/opencypher/openCypher/blob/master/grammar/';
+    const githubOCGrammarRawPrefix = 'https://raw.githubusercontent.com/opencypher/openCypher/master/grammar/';
+    const githubOCGrammarFiles = [
+        'basic-grammar.xml',
+        'cypher.xml',
+        'commands.xml',
+        'pre-parser.xml',
+        'start.xml'
+    ];
+
+    function lineOf(text, substring) {
+        var line = 0, matchedChars = 0;
+
+        for (var i = 0; i < text.length; i++) {
+            text[i] === substring[matchedChars] ? matchedChars++ : matchedChars = 0;
+
+            if (matchedChars === substring.length){
+                return line;
+            }
+            if (text[i] === '\n'){
+                line++;
+            }
+        }
+
+        return  -1;
+    }
+
+    window.onload = function(){
+        const urlParams = new URLSearchParams(window.location.search);
+        if(urlParams.has('p')) {
+            const production = urlParams.get('p');
+            const searchTerm = 'name="' + production;
+            for(const file of githubOCGrammarFiles) {
+                document.body.innerHTML += 'searching for &lt;' + production + '&gt; in ' + file + ' ...</br>'
+                const request = new XMLHttpRequest();
+                request.open('GET', githubOCGrammarRawPrefix + file, true);
+                request.send(null);
+                request.onreadystatechange = function () {
+                    if (request.readyState === 4 && request.status === 200) {
+                        var type = request.getResponseHeader('Content-Type');
+                        console.log(type);
+                        if (type.indexOf('text') !== 1) {
+                            const grammarRaw = request.responseText;
+                            const line = lineOf(grammarRaw, searchTerm)
+                            if (line > -1) {
+                                window.location.replace(githubOCGrammarPrefix + file + '#L' + (line + 1));
+                            } else {
+                                document.body.innerHTML += '&lt;' + production + '&gt; in ' + file + '</br>'
+                            }
+                        }
+                    } else {
+                    }
+                }
+                console.log(request);
+            }
+        } else {
+            document.body.innerHTML += 'no production name provide to GET parameter p</br>'
+        }
+    }
+</script>
+<body>
+
+</body>
+</html>

--- a/tools/grammar-production-links/index.adoc
+++ b/tools/grammar-production-links/index.adoc
@@ -6,17 +6,19 @@ The `grammarLink.html` provides the possibility to link to a production name in 
 
 Links to existing productions
 
-* link:grammarLink.html?p=RegularQuery[RegularQuery]
-* link:grammarLink.html?p=Atom[Atom]
-* link:grammarLink.html?p=NullOperatorExpression[NullOperatorExpression]
-* link:grammarLink.html?p=UpdatingClause[UpdatingClause]
-* link:grammarLink.html?p=CypherOption[CypherOption]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=RegularQuery[RegularQuery]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=Atom[Atom]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=NullOperatorExpression[NullOperatorExpression]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=UpdatingClause[UpdatingClause]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=CypherOption[CypherOption]
 
 Links with errors
 
-* link:grammarLink.html?p=FooBarABC[Non-existing production given ]
-* link:grammarLink.html[No production given]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=FooBarABC[Non-existing production given]
+* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html[No production given]
 
 == Usage
 
-To link to production _X_ point your link to `grammarLink.html?p=_X_`
+To link to production _X_ point your link to
+
+`https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=_X_`

--- a/tools/grammar-production-links/index.adoc
+++ b/tools/grammar-production-links/index.adoc
@@ -25,4 +25,4 @@ To link to production _X_ of the openCypher grammar in the HEAD point your link 
 
 == Background
 
-The `grammarLink.html` executes JavaScript on load that loads and parse the openCypher grammar `*.xml` files for the production provide as argument for GET parameter `p`.
+The `grammarLink.html` executes JavaScript on load that parses the openCypher grammar `*.xml` files for the definition of the production provided as argument for GET parameter `p` and then redirects to the file and line number where it found the production definition.

--- a/tools/grammar-production-links/index.adoc
+++ b/tools/grammar-production-links/index.adoc
@@ -6,23 +6,27 @@ The `grammarLink.html` provides the possibility to stably link a production by n
 
 Links to existing productions
 
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=RegularQuery[RegularQuery]
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=Atom[Atom]
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=NullOperatorExpression[NullOperatorExpression]
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=UpdatingClause[UpdatingClause]
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=CypherOption[CypherOption]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=RegularQuery[RegularQuery]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=Atom[Atom]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=NullOperatorExpression[NullOperatorExpression]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=UpdatingClause[UpdatingClause]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=CypherOption[CypherOption]
 
 Links with errors
 
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=FooBarABC[Non-existing production given]
-* link:https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html[No production given]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=FooBarABC[Non-existing production given]
+* link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html[No production given]
+
+The link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/demoForm.html[demo form] provides a demo with free input.
 
 == Usage
 
-To link to production _X_ of the openCypher grammar in the HEAD point your link to
+To link to production _X_ of the openCypher grammar in the HEAD point your link to URL
 
-`https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=_X_`
+`https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=_X_`
+
+The link:https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/demoForm.html[demo form] generates the URL upon input of a production name.
 
 == Background
 
-The `grammarLink.html` executes JavaScript on load that parses the openCypher grammar `*.xml` files for the definition of the production provided as argument for GET parameter `p` and then redirects to the file and line number where it found the production definition.
+The `grammarLink.html` executes JavaScript when load that parses the openCypher grammar `*.xml` files for the definition of the production provided as argument for GET parameter `p` and then redirects to the file and line number where it found the production definition.

--- a/tools/grammar-production-links/index.adoc
+++ b/tools/grammar-production-links/index.adoc
@@ -1,6 +1,6 @@
 = openCypher grammar production linking
 
-The `grammarLink.html` provides the possibility to link to a production name in the link:../../grammar[openCypher grammar files] without hard-coding the line number.
+The `grammarLink.html` provides the possibility to stably link a production by name in the link:../../grammar[openCypher grammar files] without hard-coding the line number.
 
 == Demo
 
@@ -19,6 +19,10 @@ Links with errors
 
 == Usage
 
-To link to production _X_ point your link to
+To link to production _X_ of the openCypher grammar in the HEAD point your link to
 
 `https://raw.githack.com/hvub/openCypher/link-to-grammar-production/tools/grammar-production-links/grammarLink.html?p=_X_`
+
+== Background
+
+The `grammarLink.html` executes JavaScript on load that loads and parse the openCypher grammar `*.xml` files for the production provide as argument for GET parameter `p`.

--- a/tools/grammar-production-links/index.adoc
+++ b/tools/grammar-production-links/index.adoc
@@ -1,0 +1,22 @@
+= openCypher grammar production linking
+
+The `grammarLink.html` provides the possibility to link to a production name in the link:../../grammar[openCypher grammar files] without hard-coding the line number.
+
+== Demo
+
+Links to existing productions
+
+* link:grammarLink.html?p=RegularQuery[RegularQuery]
+* link:grammarLink.html?p=Atom[Atom]
+* link:grammarLink.html?p=NullOperatorExpression[NullOperatorExpression]
+* link:grammarLink.html?p=UpdatingClause[UpdatingClause]
+* link:grammarLink.html?p=CypherOption[CypherOption]
+
+Links with errors
+
+* link:grammarLink.html?p=FooBarABC[Non-existing production given ]
+* link:grammarLink.html[No production given]
+
+== Usage
+
+To link to production _X_ point your link to `grammarLink.html?p=_X_`


### PR DESCRIPTION
This PR adds the tool `grammarLink.html` in `tools/grammar-production-links`, which provides the possibility to stably link a production by name in the link:../../grammar[openCypher grammar files] without hard-coding the line number. For more details the `index.adoc` in the same folder.
