### PR TITLE
Fill quantifier features

### DIFF
--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -256,7 +256,7 @@ Feature: Quantifier1 - None quantifier
     Given any graph
     When executing query:
       """
-      RETURN none(x IN <list> WHERE <condition> IS NULL) AS result
+      RETURN none(x IN <list> WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -412,7 +412,67 @@ Feature: Quantifier1 - None quantifier
       | false  |
     And no side effects
 
-  Scenario Outline: [15] Fail none quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [15] None quantifier is always equal the boolean negative of the any quantifier
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH none(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [15] None quantifier is always equal the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH none(x IN list WHERE <predicate>) = all(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [16] Fail none quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -30,3 +30,317 @@
 
 Feature: Quantifier1 - None quantifier
 
+  Scenario Outline: [1] None quantifier on list literal containing booleans
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x         | true   |
+      | [true]                 | x         | false  |
+      | [false]                | x         | true   |
+      | [true, false]          | x         | false  |
+      | [false, true]          | x         | false  |
+      | [true, false, true]    | x         | false  |
+      | [false, true, false]   | x         | false  |
+      | [true, true, true]     | x         | false  |
+      | [false, false, false]  | x         | true   |
+
+  Scenario Outline: [2] None quantifier on list literal containing integers
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x = 2     | true   |
+      | [1]                    | x = 2     | true   |
+      | [1, 3]                 | x = 2     | true   |
+      | [1, 3, 20, 5000]       | x = 2     | true   |
+      | [20, 3, 5000, -2]      | x = 2     | true   |
+      | [2]                    | x = 2     | false  |
+      | [1, 2]                 | x = 2     | false  |
+      | [1, 2, 3]              | x = 2     | false  |
+      | [2, 2]                 | x = 2     | false  |
+      | [2, 3]                 | x = 2     | false  |
+      | [3, 2, 3]              | x = 2     | false  |
+      | [2, 3, 2]              | x = 2     | false  |
+      | [2, -10, 3, 9, 0]      | x < 10    | true   |
+      | [2, -10, 3, 2, 10]     | x < 10    | false  |
+      | [2, -10, 3, 21, 10]    | x < 10    | false  |
+      | [200, -10, 36, 21, 10] | x < 10    | false  |
+      | [200, 15, 36, 21, 10]  | x < 10    | false  |
+
+  Scenario Outline: [3] None quantifier on list literal containing floats
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                       | condition | result |
+      | []                         | x = 2.1   | true   |
+      | [1.1]                      | x = 2.1   | true   |
+      | [1.1, 3.5]                 | x = 2.1   | true   |
+      | [1.1, 3.5, 20.0, 50.42435] | x = 2.1   | true   |
+      | [20.0, 3.4, 50.2, -2.1]    | x = 2.1   | true   |
+      | [2.1]                      | x = 2.1   | false  |
+      | [1.43, 2.1]                | x = 2.1   | false  |
+      | [1.43, 2.1, 3.5]           | x = 2.1   | false  |
+      | [2.1, 2.1]                 | x = 2.1   | false  |
+      | [2.1, 3.5]                 | x = 2.1   | false  |
+      | [3.5, 2.1, 3.5]            | x = 2.1   | false  |
+      | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
+
+  Scenario Outline: [4] None quantifier on list literal containing strings
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                  | condition   | result |
+      | []                    | size(x) = 3 | true   |
+      | ['abc']               | size(x) = 3 | false  |
+      | ['ef']                | size(x) = 3 | true   |
+      | ['abc', 'ef']         | size(x) = 3 | false  |
+      | ['ef', 'abc']         | size(x) = 3 | false  |
+      | ['abc', 'ef', 'abc']  | size(x) = 3 | false  |
+      | ['ef', 'abc', 'ef']   | size(x) = 3 | false  |
+      | ['abc', 'abc', 'abc'] | size(x) = 3 | false  |
+      | ['ef', 'ef', 'ef']    | size(x) = 3 | true   |
+
+  Scenario Outline: [5] None quantifier on list literal containing lists
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                              | condition   | result |
+      | []                                | size(x) = 3 | true   |
+      | [[1, 2, 3]]                       | size(x) = 3 | false  |
+      | [['a']]                           | size(x) = 3 | true   |
+      | [[1, 2, 3], ['a']]                | size(x) = 3 | false  |
+      | [['a'], [1, 2, 3]]                | size(x) = 3 | false  |
+      | [[1, 2, 3], ['a'], [1, 2, 3]]     | size(x) = 3 | false  |
+      | [['a'], [1, 2, 3], ['a']]         | size(x) = 3 | false  |
+      | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | false  |
+      | [['a'], ['a'], ['a']]             | size(x) = 3 | true   |
+
+  Scenario Outline: [6] None quantifier on list literal containing maps
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                                       | condition | result |
+      | []                                         | x.a = 2   | true   |
+      | [{a: 2, b: 5}]                             | x.a = 2   | false  |
+      | [{a: 4}]                                   | x.a = 2   | true   |
+      | [{a: 2, b: 5}, {a: 4}]                     | x.a = 2   | false  |
+      | [{a: 4}, {a: 2, b: 5}]                     | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 4}, {a: 2, b: 5}]       | x.a = 2   | false  |
+      | [{a: 4}, {a: 2, b: 5}, {a: 4}]             | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | false  |
+      | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | true   |
+
+  Scenario Outline: [7] None quantifier on lists containing nulls
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                    | condition | result |
+      | [null]                  | x = 2     | null   |
+      | [null, null]            | x = 2     | null   |
+      | [0, null]               | x = 2     | null   |
+      | [2, null]               | x = 2     | false  |
+      | [null, 2]               | x = 2     | false  |
+      | [34, 0, null, 5, 900]   | x < 10    | false  |
+      | [34, 10, null, 15, 900] | x < 10    | null   |
+
+  Scenario Outline: [8] None quantifier with IS NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE x IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | true   |
+      | [0]                      | true   |
+      | [34, 0, 8, 900]          | true   |
+      | [null]                   | false  |
+      | [null, null]             | false  |
+      | [0, null]                | false  |
+      | [2, null]                | false  |
+      | [null, 2]                | false  |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | false  |
+
+  Scenario Outline: [9] None quantifier with IS NOT NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE x IS NOT NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | true   |
+      | [0]                      | false  |
+      | [34, 0, 8, 900]          | false  |
+      | [null]                   | true   |
+      | [null, null]             | true   |
+      | [0, null]                | false  |
+      | [2, null]                | false  |
+      | [null, 2]                | false  |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | true   |
+
+  Scenario Outline: [10] None quantifier can nest itself and other quantifiers
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition> IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                      | condition                      | result |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'abc')   | true   |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | false  |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | true   |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | false  |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | true   |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | false  |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | true   |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
+
+  Scenario: [11] None quantifier is always true if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      WITH none(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario: [12] None quantifier is always false if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      WITH none(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario Outline: [13] Fail none quantifier on type mismatch between list elements and predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN <list> WHERE <condition>) AS result
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | list                              | condition |
+      | ['Clara']                         | x % 2 = 0 |
+      | [false, true]                     | x % 2 = 0 |
+      | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
+      # add examples with heterogeneously-typed lists
+
+

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -356,52 +356,7 @@ Feature: Quantifier1 - None quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | true   |
 
-  Scenario Outline: [13] None quantifier can nest itself and other quantifiers on nested lists
-    Given any graph
-    When executing query:
-      """
-      RETURN none(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                      | result |
-      | none(y IN x WHERE y = 'abc')   | true   |
-      | none(y IN x WHERE y = 'ghi')   | false  |
-      | single(y IN x WHERE y = 'ghi') | true   |
-      | single(y IN x WHERE y = 'abc') | false  |
-      | any(y IN x WHERE y = 'ghi')    | true   |
-      | any(y IN x WHERE y = 'abc')    | false  |
-      | all(y IN x WHERE y = 'def')    | true   |
-      | all(y IN x WHERE y = 'abc')    | false  |
-
-  Scenario Outline: [14] None quantifier can nest itself and other quantifiers on the same list
-    Given any graph
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
-      RETURN none(x IN list WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                              | result |
-      | none(y IN list WHERE x <= y)           | true   |
-      | none(y IN list WHERE x < y)            | false  |
-      | single(y IN list WHERE abs(x - y) < 3) | true   |
-      | single(y IN list WHERE x + y = 15)     | false  |
-      | any(y IN list WHERE x + y < 2)         | true   |
-      | any(y IN list WHERE x + y <= 3)        | false  |
-      | all(y IN list WHERE x < y)             | true   |
-      | all(y IN list WHERE x <= y)            | false  |
-
-  Scenario: [15] None quantifier is true if the predicate is statically false and the list is not empty
+  Scenario: [13] None quantifier is true if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -412,7 +367,7 @@ Feature: Quantifier1 - None quantifier
       | true   |
     And no side effects
 
-  Scenario: [16] None quantifier is false if the predicate is statically true and the list is not empty
+  Scenario: [14] None quantifier is false if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -423,64 +378,7 @@ Feature: Quantifier1 - None quantifier
       | false  |
     And no side effects
 
-  Scenario Outline: [17] None quantifier is equal the boolean negative of the any quantifier
-    Given any graph
-    When executing query:
-      """
-      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>)) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [18] None quantifier is equal the all quantifier on the boolean negative of the predicate
-    Given any graph
-    When executing query:
-      """
-      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [19] None quantifier is equal whether the size of the list filtered with same the predicate is zero
-    Given any graph
-    When executing query:
-      """
-      RETURN none([1, 2, 3, 4, 5, 6, 7, 8, 9] IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [20] Fail none quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [15] Fail none quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -484,7 +484,43 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] Fail none quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [18] None quantifier is always equal whether the size of the list filtered with same the predicate is zero
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH none(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [19] Fail none quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -356,11 +356,11 @@ Feature: Quantifier1 - None quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | true   |
 
-  Scenario Outline: [13] None quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] None quantifier can nest itself and other quantifiers on nested lists
     Given any graph
     When executing query:
       """
-      RETURN none(x IN <list> WHERE <condition>) AS result
+      RETURN none(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |
@@ -368,17 +368,40 @@ Feature: Quantifier1 - None quantifier
     And no side effects
 
     Examples:
-      | list                      | condition                      | result |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'abc')   | true   |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | false  |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | true   |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | false  |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | true   |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | false  |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | true   |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
+      | condition                      | result |
+      | none(y IN x WHERE y = 'abc')   | true   |
+      | none(y IN x WHERE y = 'ghi')   | false  |
+      | single(y IN x WHERE y = 'ghi') | true   |
+      | single(y IN x WHERE y = 'abc') | false  |
+      | any(y IN x WHERE y = 'ghi')    | true   |
+      | any(y IN x WHERE y = 'abc')    | false  |
+      | all(y IN x WHERE y = 'def')    | true   |
+      | all(y IN x WHERE y = 'abc')    | false  |
 
-  Scenario: [14] None quantifier is always true if the predicate is statically false and the list is not empty
+  Scenario Outline: [14] None quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN none(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                              | result |
+      | none(y IN list WHERE x <= y)           | true   |
+      | none(y IN list WHERE x < y)            | false  |
+      | single(y IN list WHERE abs(x - y) < 3) | true   |
+      | single(y IN list WHERE x + y = 15)     | false  |
+      | any(y IN list WHERE x + y < 2)         | true   |
+      | any(y IN list WHERE x + y <= 3)        | false  |
+      | all(y IN list WHERE x < y)             | true   |
+      | all(y IN list WHERE x <= y)            | false  |
+
+  Scenario: [15] None quantifier is always true if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -401,7 +424,7 @@ Feature: Quantifier1 - None quantifier
       | true   |
     And no side effects
 
-  Scenario: [15] None quantifier is always false if the predicate is statically true and the list is not empty
+  Scenario: [16] None quantifier is always false if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -424,7 +447,7 @@ Feature: Quantifier1 - None quantifier
       | false  |
     And no side effects
 
-  Scenario Outline: [16] None quantifier is always equal the boolean negative of the any quantifier
+  Scenario Outline: [17] None quantifier is always equal the boolean negative of the any quantifier
     Given any graph
     When executing query:
       """
@@ -454,7 +477,7 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [17] None quantifier is always equal the all quantifier on the boolean negative of the predicate
+  Scenario Outline: [18] None quantifier is always equal the all quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -484,7 +507,7 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] None quantifier is always equal whether the size of the list filtered with same the predicate is zero
+  Scenario Outline: [19] None quantifier is always equal whether the size of the list filtered with same the predicate is zero
     Given any graph
     When executing query:
       """
@@ -520,7 +543,7 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] Fail none quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [20] Fail none quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -30,7 +30,18 @@
 
 Feature: Quantifier1 - None quantifier
 
-  Scenario Outline: [1] None quantifier on list literal containing booleans
+  Scenario: [1] None quantifier is always true on empty list
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN [] WHERE true) AS a, none(x IN [] WHERE false) AS b, none(x IN [] WHERE x) AS c
+      """
+    Then the result should be, in any order:
+      | a    | b    | c    |
+      | true | true | true |
+    And no side effects
+
+  Scenario Outline: [2] None quantifier on list literal containing booleans
     Given any graph
     When executing query:
       """
@@ -53,7 +64,7 @@ Feature: Quantifier1 - None quantifier
       | [true, true, true]     | x         | false  |
       | [false, false, false]  | x         | true   |
 
-  Scenario Outline: [2] None quantifier on list literal containing integers
+  Scenario Outline: [3] None quantifier on list literal containing integers
     Given any graph
     When executing query:
       """
@@ -84,7 +95,7 @@ Feature: Quantifier1 - None quantifier
       | [200, -10, 36, 21, 10] | x < 10    | false  |
       | [200, 15, 36, 21, 10]  | x < 10    | true   |
 
-  Scenario Outline: [3] None quantifier on list literal containing floats
+  Scenario Outline: [4] None quantifier on list literal containing floats
     Given any graph
     When executing query:
       """
@@ -110,7 +121,7 @@ Feature: Quantifier1 - None quantifier
       | [3.5, 2.1, 3.5]            | x = 2.1   | false  |
       | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
 
-  Scenario Outline: [4] None quantifier on list literal containing strings
+  Scenario Outline: [5] None quantifier on list literal containing strings
     Given any graph
     When executing query:
       """
@@ -133,7 +144,7 @@ Feature: Quantifier1 - None quantifier
       | ['abc', 'abc', 'abc'] | size(x) = 3 | false  |
       | ['ef', 'ef', 'ef']    | size(x) = 3 | true   |
 
-  Scenario Outline: [5] None quantifier on list literal containing lists
+  Scenario Outline: [6] None quantifier on list literal containing lists
     Given any graph
     When executing query:
       """
@@ -156,7 +167,7 @@ Feature: Quantifier1 - None quantifier
       | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | false  |
       | [['a'], ['a'], ['a']]             | size(x) = 3 | true   |
 
-  Scenario Outline: [6] None quantifier on list literal containing maps
+  Scenario Outline: [7] None quantifier on list literal containing maps
     Given any graph
     When executing query:
       """
@@ -179,7 +190,7 @@ Feature: Quantifier1 - None quantifier
       | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | false  |
       | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | true   |
 
-  Scenario: [7] None quantifier on list containing nodes
+  Scenario: [8] None quantifier on list containing nodes
     Given an empty graph
     And having executed:
       """
@@ -225,7 +236,7 @@ Feature: Quantifier1 - None quantifier
       | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | true   |
     And no side effects
 
-  Scenario: [8] None quantifier on list containing relationships
+  Scenario: [9] None quantifier on list containing relationships
     Given an empty graph
     And having executed:
       """
@@ -271,7 +282,7 @@ Feature: Quantifier1 - None quantifier
       | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | true   |
     And no side effects
 
-  Scenario Outline: [9] None quantifier on lists containing nulls
+  Scenario Outline: [10] None quantifier on lists containing nulls
     Given any graph
     When executing query:
       """
@@ -293,7 +304,7 @@ Feature: Quantifier1 - None quantifier
       | [34, 10, null, 15, 900] | x < 10    | null   |
       | [4, 0, null, -15, 9]    | x < 10    | false  |
 
-  Scenario Outline: [10] None quantifier with IS NULL predicate
+  Scenario Outline: [11] None quantifier with IS NULL predicate
     Given any graph
     When executing query:
       """
@@ -319,7 +330,7 @@ Feature: Quantifier1 - None quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [11] None quantifier with IS NOT NULL predicate
+  Scenario Outline: [12] None quantifier with IS NOT NULL predicate
     Given any graph
     When executing query:
       """
@@ -345,7 +356,7 @@ Feature: Quantifier1 - None quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | true   |
 
-  Scenario Outline: [12] None quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] None quantifier can nest itself and other quantifiers
     Given any graph
     When executing query:
       """
@@ -367,7 +378,7 @@ Feature: Quantifier1 - None quantifier
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | true   |
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
 
-  Scenario: [13] None quantifier is always true if the predicate is statically false and the list is not empty
+  Scenario: [14] None quantifier is always true if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -390,7 +401,7 @@ Feature: Quantifier1 - None quantifier
       | true   |
     And no side effects
 
-  Scenario: [14] None quantifier is always false if the predicate is statically true and the list is not empty
+  Scenario: [15] None quantifier is always false if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -413,7 +424,7 @@ Feature: Quantifier1 - None quantifier
       | false  |
     And no side effects
 
-  Scenario Outline: [15] None quantifier is always equal the boolean negative of the any quantifier
+  Scenario Outline: [16] None quantifier is always equal the boolean negative of the any quantifier
     Given any graph
     When executing query:
       """
@@ -443,7 +454,7 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [15] None quantifier is always equal the all quantifier on the boolean negative of the predicate
+  Scenario Outline: [17] None quantifier is always equal the all quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -473,7 +484,7 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [16] Fail none quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [18] Fail none quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -401,68 +401,33 @@ Feature: Quantifier1 - None quantifier
       | all(y IN list WHERE x < y)             | true   |
       | all(y IN list WHERE x <= y)            | false  |
 
-  Scenario: [15] None quantifier is always true if the predicate is statically false and the list is not empty
+  Scenario: [15] None quantifier is true if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH none(x IN list WHERE false) AS result, count(*) AS cnt
-      RETURN result
+      RETURN none(x IN [1, null, true, 4.5, 'abc', false] WHERE false) AS result
       """
     Then the result should be, in any order:
       | result |
       | true   |
     And no side effects
 
-  Scenario: [16] None quantifier is always false if the predicate is statically true and the list is not empty
+  Scenario: [16] None quantifier is false if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH none(x IN list WHERE true) AS result, count(*) AS cnt
-      RETURN result
+      RETURN none(x IN [1, null, true, 4.5, 'abc', false] WHERE true) AS result
       """
     Then the result should be, in any order:
       | result |
       | false  |
     And no side effects
 
-  Scenario Outline: [17] None quantifier is always equal the boolean negative of the any quantifier
+  Scenario Outline: [17] None quantifier is equal the boolean negative of the any quantifier
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH none(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
-      RETURN result
+      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>)) AS result
       """
     Then the result should be, in any order:
       | result |
@@ -477,22 +442,11 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] None quantifier is always equal the all quantifier on the boolean negative of the predicate
+  Scenario Outline: [18] None quantifier is equal the all quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH none(x IN list WHERE <predicate>) = all(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
-      RETURN result
+      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
       """
     Then the result should be, in any order:
       | result |
@@ -507,28 +461,11 @@ Feature: Quantifier1 - None quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] None quantifier is always equal whether the size of the list filtered with same the predicate is zero
+  Scenario Outline: [19] None quantifier is equal whether the size of the list filtered with same the predicate is zero
     Given any graph
     When executing query:
       """
-      UNWIND [{list: [2], fixed: true},
-              {list: [6], fixed: true},
-              {list: [7], fixed: true},
-              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
-      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
-           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH coalesce(fixedList, list) AS list
-      WITH none(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result, count(*) AS cnt
-      RETURN result
+      RETURN none([1, 2, 3, 4, 5, 6, 7, 8, 9] IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -371,20 +371,16 @@ Feature: Quantifier1 - None quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
       WITH none(x IN list WHERE false) AS result, count(*) AS cnt
       RETURN result
       """
@@ -398,20 +394,16 @@ Feature: Quantifier1 - None quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
       WITH none(x IN list WHERE true) AS result, count(*) AS cnt
       RETURN result
       """

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -291,6 +291,7 @@ Feature: Quantifier1 - None quantifier
       | [null, 2]               | x = 2     | false  |
       | [34, 0, null, 5, 900]   | x < 10    | false  |
       | [34, 10, null, 15, 900] | x < 10    | null   |
+      | [4, 0, null, -15, 9]    | x < 10    | false  |
 
   Scenario Outline: [10] None quantifier with IS NULL predicate
     Given any graph

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -78,11 +78,11 @@ Feature: Quantifier1 - None quantifier
       | [2, 3]                 | x = 2     | false  |
       | [3, 2, 3]              | x = 2     | false  |
       | [2, 3, 2]              | x = 2     | false  |
-      | [2, -10, 3, 9, 0]      | x < 10    | true   |
+      | [2, -10, 3, 9, 0]      | x < 10    | false  |
       | [2, -10, 3, 2, 10]     | x < 10    | false  |
       | [2, -10, 3, 21, 10]    | x < 10    | false  |
       | [200, -10, 36, 21, 10] | x < 10    | false  |
-      | [200, 15, 36, 21, 10]  | x < 10    | false  |
+      | [200, 15, 36, 21, 10]  | x < 10    | true   |
 
   Scenario Outline: [3] None quantifier on list literal containing floats
     Given any graph

--- a/tck/features/expressions/quantifier/Quantifier1.feature
+++ b/tck/features/expressions/quantifier/Quantifier1.feature
@@ -426,5 +426,3 @@ Feature: Quantifier1 - None quantifier
       | [false, true]                     | x % 2 = 0 |
       | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
       # add examples with heterogeneously-typed lists
-
-

--- a/tck/features/expressions/quantifier/Quantifier10.feature
+++ b/tck/features/expressions/quantifier/Quantifier10.feature
@@ -28,9 +28,9 @@
 
 #encoding: utf-8
 
-Feature: Quantifier8 - All quantifier invariants
+Feature: Quantifier10 - Single quantifier invariants
 
-  Scenario: [1] All quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [1] Single quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -45,7 +45,7 @@ Feature: Quantifier8 - All quantifier invariants
       WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
       WITH list WHERE size(list) > 0
-      WITH all(x IN list WHERE false) AS result, count(*) AS cnt
+      WITH single(x IN list WHERE false) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:
@@ -53,7 +53,7 @@ Feature: Quantifier8 - All quantifier invariants
       | false  |
     And no side effects
 
-  Scenario: [2] All quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [2] Single quantifier is always false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
@@ -67,30 +67,22 @@ Feature: Quantifier8 - All quantifier invariants
       UNWIND inputList AS x
       WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH all(x IN list WHERE true) AS result, count(*) AS cnt
+      WITH list WHERE size(list) > 1
+      WITH single(x IN list WHERE true) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:
       | result |
-      | true   |
+      | false  |
     And no side effects
 
-  Scenario Outline: [3] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+  Scenario: [3] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH all(x IN list WHERE <predicate>) = none(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
+      WITH [1, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS element
+      WITH single(x IN [element] WHERE true) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:
@@ -98,45 +90,7 @@ Feature: Quantifier8 - All quantifier invariants
       | true   |
     And no side effects
 
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [4] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
-    Given any graph
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH all(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
-      RETURN result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [5] All quantifier is always equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
+  Scenario Outline: [4] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
     Given any graph
     When executing query:
       """
@@ -156,7 +110,7 @@ Feature: Quantifier8 - All quantifier invariants
       WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
       WITH coalesce(fixedList, list) AS list
-      WITH all(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = size(list)) AS result, count(*) AS cnt
+      WITH single(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 1) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:

--- a/tck/features/expressions/quantifier/Quantifier11.feature
+++ b/tck/features/expressions/quantifier/Quantifier11.feature
@@ -28,9 +28,9 @@
 
 #encoding: utf-8
 
-Feature: Quantifier6 - Single quantifier invariants
+Feature: Quantifier11 - Any quantifier invariants
 
-  Scenario: [1] Single quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [1] Any quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -45,7 +45,7 @@ Feature: Quantifier6 - Single quantifier invariants
       WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
       WITH list WHERE size(list) > 0
-      WITH single(x IN list WHERE false) AS result, count(*) AS cnt
+      WITH any(x IN list WHERE false) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:
@@ -53,7 +53,7 @@ Feature: Quantifier6 - Single quantifier invariants
       | false  |
     And no side effects
 
-  Scenario: [2] Single quantifier is always false if the predicate is statically true and the list has more than one element
+  Scenario: [2] Any quantifier is always true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -67,22 +67,8 @@ Feature: Quantifier6 - Single quantifier invariants
       UNWIND inputList AS x
       WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 1
-      WITH single(x IN list WHERE true) AS result, count(*) AS cnt
-      RETURN result
-      """
-    Then the result should be, in any order:
-      | result |
-      | false  |
-    And no side effects
-
-  Scenario: [3] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
-    Given any graph
-    When executing query:
-      """
-      WITH [1, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS element
-      WITH single(x IN [element] WHERE true) AS result, count(*) AS cnt
+      WITH list WHERE size(list) > 0
+      WITH any(x IN list WHERE true) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:
@@ -90,7 +76,103 @@ Feature: Quantifier6 - Single quantifier invariants
       | true   |
     And no side effects
 
-  Scenario Outline: [4] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
+  Scenario Outline: [3] Any quantifier is always true if the single or the all quantifier is true
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH list WHERE single(<operands>) OR all(<operands>)
+      WITH any(<operands>) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | operands                  |
+      | x IN list WHERE x = 2     |
+      | x IN list WHERE x % 2 = 0 |
+      | x IN list WHERE x % 3 = 0 |
+      | x IN list WHERE x < 7     |
+      | x IN list WHERE x >= 3    |
+
+  Scenario Outline: [4] Any quantifier is always equal the boolean negative of the none quantifier
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT none(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT all(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [6] Any quantifier is always equal whether the size of the list filtered with same the predicate is grater zero
     Given any graph
     When executing query:
       """
@@ -110,7 +192,7 @@ Feature: Quantifier6 - Single quantifier invariants
       WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
       WITH coalesce(fixedList, list) AS list
-      WITH single(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 1) AS result, count(*) AS cnt
+      WITH any(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) > 0) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -291,6 +291,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 2]               | x = 2     | null   |
       | [34, 0, null, 5, 900]   | x < 10    | false  |
       | [34, 10, null, 15, 900] | x < 10    | null   |
+      | [4, 0, null, -15, 9]    | x < 10    | false  |
 
   Scenario Outline: [10] Single quantifier with IS NULL predicate
     Given any graph

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -179,7 +179,99 @@ Feature: Quantifier2 - Single quantifier
       | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | false  |
       | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
 
-  Scenario Outline: [7] Single quantifier on lists containing nulls
+  Scenario: [7] Single quantifier on list containing nodes
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (s1:SRelationships), (s2:SNodes)
+      CREATE (a:A {name: 'a'}), (b:B {name: 'b'})
+      CREATE (aa:A {name: 'a'}), (ab:B {name: 'b'}),
+             (ba:A {name: 'a'}), (bb:B {name: 'b'})
+      CREATE (aaa:A {name: 'a'}), (aab:B {name: 'b'}),
+             (aba:A {name: 'a'}), (abb:B {name: 'b'}),
+             (baa:A {name: 'a'}), (bab:B {name: 'b'}),
+             (bba:A {name: 'a'}), (bbb:B {name: 'b'})
+      CREATE (s1)-[:I]->(s2),
+             (s2)-[:RA {name: 'a'}]->(a), (s2)-[:RB {name: 'b'}]->(b)
+      CREATE (a)-[:RA {name: 'a'}]->(aa), (a)-[:RB {name: 'b'}]->(ab),
+             (b)-[:RA {name: 'a'}]->(ba), (b)-[:RB {name: 'b'}]->(bb)
+      CREATE (aa)-[:RA {name: 'a'}]->(aaa), (aa)-[:RB {name: 'b'}]->(aab),
+             (ab)-[:RA {name: 'a'}]->(aba), (ab)-[:RB {name: 'b'}]->(abb),
+             (ba)-[:RA {name: 'a'}]->(baa), (ba)-[:RB {name: 'b'}]->(bab),
+             (bb)-[:RA {name: 'a'}]->(bba), (bb)-[:RB {name: 'b'}]->(bbb)
+      """
+    When executing query:
+      """
+      MATCH p = (:SNodes)-[*0..3]->(x)
+      WITH tail(nodes(p)) AS nodes
+      RETURN nodes, single(x IN nodes WHERE x.name = 'a') AS result
+      """
+    Then the result should be, in any order:
+      | nodes                                                  | result |
+      | []                                                     | false  |
+      | [(:A {name: 'a'})]                                     | true   |
+      | [(:A {name: 'a'}), (:A {name: 'a'})]                   | false  |
+      | [(:A {name: 'a'}), (:A {name: 'a'}), (:A {name: 'a'})] | false  |
+      | [(:A {name: 'a'}), (:A {name: 'a'}), (:B {name: 'b'})] | false  |
+      | [(:A {name: 'a'}), (:B {name: 'b'})]                   | true   |
+      | [(:A {name: 'a'}), (:B {name: 'b'}), (:A {name: 'a'})] | false  |
+      | [(:A {name: 'a'}), (:B {name: 'b'}), (:B {name: 'b'})] | true   |
+      | [(:B {name: 'b'})]                                     | false  |
+      | [(:B {name: 'b'}), (:A {name: 'a'})]                   | true   |
+      | [(:B {name: 'b'}), (:A {name: 'a'}), (:A {name: 'a'})] | false  |
+      | [(:B {name: 'b'}), (:A {name: 'a'}), (:B {name: 'b'})] | true   |
+      | [(:B {name: 'b'}), (:B {name: 'b'})]                   | false  |
+      | [(:B {name: 'b'}), (:B {name: 'b'}), (:A {name: 'a'})] | true   |
+      | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
+    And no side effects
+
+  Scenario: [8] Single quantifier on list containing relationships
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (s1:SRelationships), (s2:SNodes)
+      CREATE (a:A {name: 'a'}), (b:B {name: 'b'})
+      CREATE (aa:A {name: 'a'}), (ab:B {name: 'b'}),
+             (ba:A {name: 'a'}), (bb:B {name: 'b'})
+      CREATE (aaa:A {name: 'a'}), (aab:B {name: 'b'}),
+             (aba:A {name: 'a'}), (abb:B {name: 'b'}),
+             (baa:A {name: 'a'}), (bab:B {name: 'b'}),
+             (bba:A {name: 'a'}), (bbb:B {name: 'b'})
+      CREATE (s1)-[:I]->(s2),
+             (s2)-[:RA {name: 'a'}]->(a), (s2)-[:RB {name: 'b'}]->(b)
+      CREATE (a)-[:RA {name: 'a'}]->(aa), (a)-[:RB {name: 'b'}]->(ab),
+             (b)-[:RA {name: 'a'}]->(ba), (b)-[:RB {name: 'b'}]->(bb)
+      CREATE (aa)-[:RA {name: 'a'}]->(aaa), (aa)-[:RB {name: 'b'}]->(aab),
+             (ab)-[:RA {name: 'a'}]->(aba), (ab)-[:RB {name: 'b'}]->(abb),
+             (ba)-[:RA {name: 'a'}]->(baa), (ba)-[:RB {name: 'b'}]->(bab),
+             (bb)-[:RA {name: 'a'}]->(bba), (bb)-[:RB {name: 'b'}]->(bbb)
+      """
+    When executing query:
+      """
+      MATCH p = (:SRelationships)-[*0..4]->(x)
+      WITH tail(relationships(p)) AS relationships, COUNT(*) AS c
+      RETURN relationships, single(x IN relationships WHERE x.name = 'a') AS result
+      """
+    Then the result should be, in any order:
+      | relationships                                             | result |
+      | []                                                        | false  |
+      | [[:RA {name: 'a'}]]                                       | true   |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}]]                    | false  |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}], [:RA {name: 'a'}]] | false  |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}], [:RB {name: 'b'}]] | false  |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}]]                    | true   |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}], [:RA {name: 'a'}]] | false  |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | true   |
+      | [[:RB {name: 'b'}]]                                       | false  |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}]]                    | true   |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}], [:RA {name: 'a'}]] | false  |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}], [:RB {name: 'b'}]] | true   |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}]]                    | false  |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RA {name: 'a'}]] | true   |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
+    And no side effects
+
+  Scenario Outline: [9] Single quantifier on lists containing nulls
     Given any graph
     When executing query:
       """
@@ -200,7 +292,7 @@ Feature: Quantifier2 - Single quantifier
       | [34, 0, null, 5, 900]   | x < 10    | false  |
       | [34, 10, null, 15, 900] | x < 10    | null   |
 
-  Scenario Outline: [8] Single quantifier with IS NULL predicate
+  Scenario Outline: [10] Single quantifier with IS NULL predicate
     Given any graph
     When executing query:
       """
@@ -226,7 +318,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [9] Single quantifier with IS NOT NULL predicate
+  Scenario Outline: [11] Single quantifier with IS NOT NULL predicate
     Given any graph
     When executing query:
       """
@@ -252,7 +344,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [10] Single quantifier can nest itself and other quantifiers
+  Scenario Outline: [12] Single quantifier can nest itself and other quantifiers
     Given any graph
     When executing query:
       """
@@ -274,7 +366,7 @@ Feature: Quantifier2 - Single quantifier
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
 
-  Scenario: [11] Single quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [13] Single quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -301,7 +393,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [12] Single quantifier is always false if the predicate is statically true and the list has more than one element
+  Scenario: [14] Single quantifier is always false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
@@ -328,7 +420,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [13] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+  Scenario: [15] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
@@ -342,7 +434,7 @@ Feature: Quantifier2 - Single quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [14] Fail single quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [16] Fail single quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -30,3 +30,329 @@
 
 Feature: Quantifier2 - Single quantifier
 
+  Scenario Outline: [1] Single quantifier on list literal
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x         | false  |
+      | [true]                 | x         | true   |
+      | [false]                | x         | false  |
+      | [true, false]          | x         | true   |
+      | [false, true]          | x         | true   |
+      | [true, false, true]    | x         | false  |
+      | [false, true, false]   | x         | true   |
+      | [true, true, true]     | x         | false  |
+      | [false, false, false]  | x         | false  |
+
+  Scenario Outline: [2] Single quantifier on list literal containing integers
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x = 2     | false  |
+      | [1]                    | x = 2     | false  |
+      | [1, 3]                 | x = 2     | false  |
+      | [1, 3, 20, 5000]       | x = 2     | false  |
+      | [20, 3, 5000, -2]      | x = 2     | false  |
+      | [2]                    | x = 2     | true   |
+      | [1, 2]                 | x = 2     | true   |
+      | [1, 2, 3]              | x = 2     | true   |
+      | [2, 2]                 | x = 2     | false  |
+      | [2, 3]                 | x = 2     | true   |
+      | [3, 2, 3]              | x = 2     | true   |
+      | [2, 3, 2]              | x = 2     | false  |
+      | [2, -10, 3, 9, 0]      | x < 10    | false  |
+      | [2, -10, 3, 2, 10]     | x < 10    | false  |
+      | [2, -10, 3, 21, 10]    | x < 10    | false  |
+      | [200, -10, 36, 21, 10] | x < 10    | true   |
+      | [200, 15, 36, 21, 10]  | x < 10    | false  |
+
+  Scenario Outline: [3] Single quantifier on list literal containing floats
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                       | condition | result |
+      | []                         | x = 2.1   | false  |
+      | [1.1]                      | x = 2.1   | false  |
+      | [1.1, 3.5]                 | x = 2.1   | false  |
+      | [1.1, 3.5, 20.0, 50.42435] | x = 2.1   | false  |
+      | [20.0, 3.4, 50.2, -2.1]    | x = 2.1   | false  |
+      | [2.1]                      | x = 2.1   | true   |
+      | [1.43, 2.1]                | x = 2.1   | true   |
+      | [1.43, 2.1, 3.5]           | x = 2.1   | true   |
+      | [2.1, 2.1]                 | x = 2.1   | false  |
+      | [2.1, 3.5]                 | x = 2.1   | true   |
+      | [3.5, 2.1, 3.5]            | x = 2.1   | true   |
+      | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
+
+  Scenario Outline: [4] Single quantifier on list literal containing strings
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                  | condition   | result |
+      | []                    | size(x) = 3 | false  |
+      | ['abc']               | size(x) = 3 | true   |
+      | ['ef']                | size(x) = 3 | false  |
+      | ['abc', 'ef']         | size(x) = 3 | true   |
+      | ['ef', 'abc']         | size(x) = 3 | true   |
+      | ['abc', 'ef', 'abc']  | size(x) = 3 | false  |
+      | ['ef', 'abc', 'ef']   | size(x) = 3 | true   |
+      | ['abc', 'abc', 'abc'] | size(x) = 3 | false  |
+      | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
+
+  Scenario Outline: [5] Single quantifier on list literal containing lists
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                              | condition   | result |
+      | []                                | size(x) = 3 | false  |
+      | [[1, 2, 3]]                       | size(x) = 3 | true   |
+      | [['a']]                           | size(x) = 3 | false  |
+      | [[1, 2, 3], ['a']]                | size(x) = 3 | true   |
+      | [['a'], [1, 2, 3]]                | size(x) = 3 | true   |
+      | [[1, 2, 3], ['a'], [1, 2, 3]]     | size(x) = 3 | false  |
+      | [['a'], [1, 2, 3], ['a']]         | size(x) = 3 | true   |
+      | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | false  |
+      | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
+
+  Scenario Outline: [6] Single quantifier on list literal containing maps
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                                       | condition | result |
+      | []                                         | x.a = 2   | false  |
+      | [{a: 2, b: 5}]                             | x.a = 2   | true   |
+      | [{a: 4}]                                   | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 4}]                     | x.a = 2   | true   |
+      | [{a: 4}, {a: 2, b: 5}]                     | x.a = 2   | true   |
+      | [{a: 2, b: 5}, {a: 4}, {a: 2, b: 5}]       | x.a = 2   | false  |
+      | [{a: 4}, {a: 2, b: 5}, {a: 4}]             | x.a = 2   | true   |
+      | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | false  |
+      | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
+
+  Scenario Outline: [7] Single quantifier on lists containing nulls
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                    | condition | result |
+      | [null]                  | x = 2     | null   |
+      | [null, null]            | x = 2     | null   |
+      | [0, null]               | x = 2     | null   |
+      | [2, null]               | x = 2     | null   |
+      | [null, 2]               | x = 2     | null   |
+      | [34, 0, null, 5, 900]   | x < 10    | false  |
+      | [34, 10, null, 15, 900] | x < 10    | null   |
+
+  Scenario Outline: [8] Single quantifier with IS NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE x IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | false  |
+      | [0]                      | false  |
+      | [34, 0, 8, 900]          | false  |
+      | [null]                   | true   |
+      | [null, null]             | false  |
+      | [0, null]                | true   |
+      | [2, null]                | true   |
+      | [null, 2]                | true   |
+      | [34, 0, null, 8, 900]    | true   |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | false  |
+
+  Scenario Outline: [9] Single quantifier with IS NOT NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE x IS NOT NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | false  |
+      | [0]                      | true   |
+      | [34, 0, 8, 900]          | false  |
+      | [null]                   | false  |
+      | [null, null]             | false  |
+      | [0, null]                | true   |
+      | [2, null]                | true   |
+      | [null, 2]                | true   |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | true   |
+      | [null, null, null, null] | false  |
+
+  Scenario Outline: [10] Single quantifier can nest itself and other quantifiers
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition> IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                      | condition                      | result |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | true   |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | false  |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'def') | true   |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | false  |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'def')    | true   |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | false  |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
+
+  Scenario: [11] Single quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      WITH single(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [12] Single quantifier is always false if the predicate is statically true and the list has more than one element
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 1
+      WITH single(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [13] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+    Given any graph
+    When executing query:
+      """
+      WITH [1, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS element
+      WITH single(x IN [element] WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [14] Fail single quantifier on type mismatch between list elements and predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN <list> WHERE <condition>) AS result
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | list                              | condition |
+      | ['Clara']                         | x % 2 = 0 |
+      | [false, true]                     | x % 2 = 0 |
+      | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
+      # add examples with heterogeneously-typed lists

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -356,11 +356,11 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] Single quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] Single quantifier can nest itself and other quantifiers on nested lists
     Given any graph
     When executing query:
       """
-      RETURN single(x IN <list> WHERE <condition>) AS result
+      RETURN single(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |
@@ -368,17 +368,40 @@ Feature: Quantifier2 - Single quantifier
     And no side effects
 
     Examples:
-      | list                      | condition                      | result |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | true   |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | false  |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'def') | true   |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | false  |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'def')    | true   |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | false  |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
+      | condition                      | result |
+      | none(y IN x WHERE y = 'def')   | true   |
+      | none(y IN x WHERE y = 'ghi')   | false  |
+      | single(y IN x WHERE y = 'def') | true   |
+      | single(y IN x WHERE y = 'abc') | false  |
+      | any(y IN x WHERE y = 'def')    | true   |
+      | any(y IN x WHERE y = 'abc')    | false  |
+      | all(y IN x WHERE y = 'abc')    | true   |
+      | all(y IN x WHERE y = 'def')    | false  |
 
-  Scenario: [14] Single quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario Outline: [14] Single quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN single(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                           | result |
+      | none(y IN list WHERE x < y)         | true   |
+      | none(y IN list WHERE x % y = 0)     | false  |
+      | single(y IN list WHERE x + y < 5)   | true   |
+      | single(y IN list WHERE x % y = 1)   | false  |
+      | any(y IN list WHERE 2 * x + y > 25) | true   |
+      | any(y IN list WHERE x < y)          | false  |
+      | all(y IN list WHERE x <= y)         | true   |
+      | all(y IN list WHERE x <= y + 1)     | false  |
+
+  Scenario: [15] Single quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -401,7 +424,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [15] Single quantifier is always false if the predicate is statically true and the list has more than one element
+  Scenario: [16] Single quantifier is always false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
@@ -424,7 +447,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [16] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+  Scenario: [17] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
@@ -438,7 +461,7 @@ Feature: Quantifier2 - Single quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [17] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
+  Scenario Outline: [18] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
     Given any graph
     When executing query:
       """
@@ -474,7 +497,7 @@ Feature: Quantifier2 - Single quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] Fail single quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [19] Fail single quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -30,7 +30,18 @@
 
 Feature: Quantifier2 - Single quantifier
 
-  Scenario Outline: [1] Single quantifier on list literal
+  Scenario: [1] Single quantifier is always false on empty list
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN [] WHERE true) AS a, single(x IN [] WHERE false) AS b, single(x IN [] WHERE x) AS c
+      """
+    Then the result should be, in any order:
+      | a     | b     | c     |
+      | false | false | false |
+    And no side effects
+
+  Scenario Outline: [2] Single quantifier on list literal
     Given any graph
     When executing query:
       """
@@ -53,7 +64,7 @@ Feature: Quantifier2 - Single quantifier
       | [true, true, true]     | x         | false  |
       | [false, false, false]  | x         | false  |
 
-  Scenario Outline: [2] Single quantifier on list literal containing integers
+  Scenario Outline: [3] Single quantifier on list literal containing integers
     Given any graph
     When executing query:
       """
@@ -84,7 +95,7 @@ Feature: Quantifier2 - Single quantifier
       | [200, -10, 36, 21, 10] | x < 10    | true   |
       | [200, 15, 36, 21, 10]  | x < 10    | false  |
 
-  Scenario Outline: [3] Single quantifier on list literal containing floats
+  Scenario Outline: [4] Single quantifier on list literal containing floats
     Given any graph
     When executing query:
       """
@@ -110,7 +121,7 @@ Feature: Quantifier2 - Single quantifier
       | [3.5, 2.1, 3.5]            | x = 2.1   | true   |
       | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
 
-  Scenario Outline: [4] Single quantifier on list literal containing strings
+  Scenario Outline: [5] Single quantifier on list literal containing strings
     Given any graph
     When executing query:
       """
@@ -133,7 +144,7 @@ Feature: Quantifier2 - Single quantifier
       | ['abc', 'abc', 'abc'] | size(x) = 3 | false  |
       | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
 
-  Scenario Outline: [5] Single quantifier on list literal containing lists
+  Scenario Outline: [6] Single quantifier on list literal containing lists
     Given any graph
     When executing query:
       """
@@ -156,7 +167,7 @@ Feature: Quantifier2 - Single quantifier
       | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | false  |
       | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
 
-  Scenario Outline: [6] Single quantifier on list literal containing maps
+  Scenario Outline: [7] Single quantifier on list literal containing maps
     Given any graph
     When executing query:
       """
@@ -179,7 +190,7 @@ Feature: Quantifier2 - Single quantifier
       | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | false  |
       | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
 
-  Scenario: [7] Single quantifier on list containing nodes
+  Scenario: [8] Single quantifier on list containing nodes
     Given an empty graph
     And having executed:
       """
@@ -225,7 +236,7 @@ Feature: Quantifier2 - Single quantifier
       | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
     And no side effects
 
-  Scenario: [8] Single quantifier on list containing relationships
+  Scenario: [9] Single quantifier on list containing relationships
     Given an empty graph
     And having executed:
       """
@@ -271,7 +282,7 @@ Feature: Quantifier2 - Single quantifier
       | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
     And no side effects
 
-  Scenario Outline: [9] Single quantifier on lists containing nulls
+  Scenario Outline: [10] Single quantifier on lists containing nulls
     Given any graph
     When executing query:
       """
@@ -293,7 +304,7 @@ Feature: Quantifier2 - Single quantifier
       | [34, 10, null, 15, 900] | x < 10    | null   |
       | [4, 0, null, -15, 9]    | x < 10    | false  |
 
-  Scenario Outline: [10] Single quantifier with IS NULL predicate
+  Scenario Outline: [11] Single quantifier with IS NULL predicate
     Given any graph
     When executing query:
       """
@@ -319,7 +330,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [11] Single quantifier with IS NOT NULL predicate
+  Scenario Outline: [12] Single quantifier with IS NOT NULL predicate
     Given any graph
     When executing query:
       """
@@ -345,7 +356,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [12] Single quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] Single quantifier can nest itself and other quantifiers
     Given any graph
     When executing query:
       """
@@ -367,7 +378,7 @@ Feature: Quantifier2 - Single quantifier
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
 
-  Scenario: [13] Single quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [14] Single quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -390,7 +401,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [14] Single quantifier is always false if the predicate is statically true and the list has more than one element
+  Scenario: [15] Single quantifier is always false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
@@ -413,7 +424,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [15] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+  Scenario: [16] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
@@ -427,7 +438,7 @@ Feature: Quantifier2 - Single quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [16] Fail single quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [17] Fail single quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -401,88 +401,44 @@ Feature: Quantifier2 - Single quantifier
       | all(y IN list WHERE x <= y)         | true   |
       | all(y IN list WHERE x <= y + 1)     | false  |
 
-  Scenario: [15] Single quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [15] Single quantifier is false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH single(x IN list WHERE false) AS result, count(*) AS cnt
-      RETURN result
+      RETURN single(x IN [1, null, true, 4.5, 'abc', false] WHERE false) AS result
       """
     Then the result should be, in any order:
       | result |
       | false  |
     And no side effects
 
-  Scenario: [16] Single quantifier is always false if the predicate is statically true and the list has more than one element
+  Scenario: [16] Single quantifier is false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 1
-      WITH single(x IN list WHERE true) AS result, count(*) AS cnt
-      RETURN result
+      RETURN single(x IN [1, null, true, 4.5, 'abc', false] WHERE true) AS result
       """
     Then the result should be, in any order:
       | result |
       | false  |
     And no side effects
 
-  Scenario: [17] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+  Scenario: [17] Single quantifier is true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
-      WITH [1, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS element
-      WITH single(x IN [element] WHERE true) AS result, count(*) AS cnt
-      RETURN result
+      RETURN single(x IN [1] WHERE true) AS result
       """
     Then the result should be, in any order:
       | result |
       | true   |
     And no side effects
 
-  Scenario Outline: [18] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
+  Scenario Outline: [18] Single quantifier is equal whether the size of the list filtered with same the predicate is one
     Given any graph
     When executing query:
       """
-      UNWIND [{list: [2], fixed: true},
-              {list: [6], fixed: true},
-              {list: [7], fixed: true},
-              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
-      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
-           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH coalesce(fixedList, list) AS list
-      WITH single(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 1) AS result, count(*) AS cnt
-      RETURN result
+      RETURN single(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = 1) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -371,20 +371,16 @@ Feature: Quantifier2 - Single quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
       WITH single(x IN list WHERE false) AS result, count(*) AS cnt
       RETURN result
       """
@@ -398,20 +394,16 @@ Feature: Quantifier2 - Single quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 1
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 1
       WITH single(x IN list WHERE true) AS result, count(*) AS cnt
       RETURN result
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -356,52 +356,7 @@ Feature: Quantifier2 - Single quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] Single quantifier can nest itself and other quantifiers on nested lists
-    Given any graph
-    When executing query:
-      """
-      RETURN single(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                      | result |
-      | none(y IN x WHERE y = 'def')   | true   |
-      | none(y IN x WHERE y = 'ghi')   | false  |
-      | single(y IN x WHERE y = 'def') | true   |
-      | single(y IN x WHERE y = 'abc') | false  |
-      | any(y IN x WHERE y = 'def')    | true   |
-      | any(y IN x WHERE y = 'abc')    | false  |
-      | all(y IN x WHERE y = 'abc')    | true   |
-      | all(y IN x WHERE y = 'def')    | false  |
-
-  Scenario Outline: [14] Single quantifier can nest itself and other quantifiers on the same list
-    Given any graph
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
-      RETURN single(x IN list WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                           | result |
-      | none(y IN list WHERE x < y)         | true   |
-      | none(y IN list WHERE x % y = 0)     | false  |
-      | single(y IN list WHERE x + y < 5)   | true   |
-      | single(y IN list WHERE x % y = 1)   | false  |
-      | any(y IN list WHERE 2 * x + y > 25) | true   |
-      | any(y IN list WHERE x < y)          | false  |
-      | all(y IN list WHERE x <= y)         | true   |
-      | all(y IN list WHERE x <= y + 1)     | false  |
-
-  Scenario: [15] Single quantifier is false if the predicate is statically false and the list is not empty
+  Scenario: [13] Single quantifier is false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -412,7 +367,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [16] Single quantifier is false if the predicate is statically true and the list has more than one element
+  Scenario: [14] Single quantifier is false if the predicate is statically true and the list has more than one element
     Given any graph
     When executing query:
       """
@@ -423,7 +378,7 @@ Feature: Quantifier2 - Single quantifier
       | false  |
     And no side effects
 
-  Scenario: [17] Single quantifier is true if the predicate is statically true and the list has exactly one non-null element
+  Scenario: [15] Single quantifier is true if the predicate is statically true and the list has exactly one non-null element
     Given any graph
     When executing query:
       """
@@ -434,26 +389,7 @@ Feature: Quantifier2 - Single quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [18] Single quantifier is equal whether the size of the list filtered with same the predicate is one
-    Given any graph
-    When executing query:
-      """
-      RETURN single(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = 1) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [19] Fail single quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [16] Fail single quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -438,7 +438,43 @@ Feature: Quantifier2 - Single quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [17] Fail single quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [17] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH single(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 1) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [18] Fail single quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier2.feature
+++ b/tck/features/expressions/quantifier/Quantifier2.feature
@@ -256,7 +256,7 @@ Feature: Quantifier2 - Single quantifier
     Given any graph
     When executing query:
       """
-      RETURN single(x IN <list> WHERE <condition> IS NULL) AS result
+      RETURN single(x IN <list> WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -443,7 +443,98 @@ Feature: Quantifier3 - Any quantifier
       | x IN list WHERE x < 7     |
       | x IN list WHERE x >= 3    |
 
-  Scenario Outline: [16] Fail any quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [16] Any quantifier is always equal the boolean negative of the none quantifier
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT none(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [17] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT all(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [18] Any quantifier is always true if the all quantifier is true
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE all(<operands>)
+      WITH any(<operands>) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | operands                  |
+      | x IN list WHERE x = 2     |
+      | x IN list WHERE x % 2 = 0 |
+      | x IN list WHERE x % 3 = 0 |
+      | x IN list WHERE x < 7     |
+      | x IN list WHERE x >= 3    |
+
+  Scenario Outline: [19] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -333,20 +333,16 @@ Feature: Quantifier3 - Any quantifier
     When executing query:
       """
       WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE single(<operands>)
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE single(<operands>)
       WITH any(<operands>) AS result, count(*) AS cnt
       RETURN result
       """
@@ -360,8 +356,8 @@ Feature: Quantifier3 - Any quantifier
       | x IN list WHERE x = 2     |
       | x IN list WHERE x % 2 = 0 |
       | x IN list WHERE x % 3 = 0 |
-      | x IN list WHERE x < 5     |
-      | x IN list WHERE x >= 6    |
+      | x IN list WHERE x < 7     |
+      | x IN list WHERE x >= 3    |
 
   Scenario Outline: [14] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -356,52 +356,7 @@ Feature: Quantifier3 - Any quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] Any quantifier can nest itself and other quantifiers on nested lists
-    Given any graph
-    When executing query:
-      """
-      RETURN any(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                      | result |
-      | none(y IN x WHERE y = 'def')   | true   |
-      | none(y IN x WHERE y = 'abc')   | false  |
-      | single(y IN x WHERE y = 'def') | true   |
-      | single(y IN x WHERE y = 'ghi') | false  |
-      | any(y IN x WHERE y = 'abc')    | true   |
-      | any(y IN x WHERE y = 'ghi')    | false  |
-      | all(y IN x WHERE y = 'abc')    | true   |
-      | all(y IN x WHERE y = 'def')    | false  |
-
-  Scenario Outline: [14] Any quantifier can nest itself and other quantifiers on the same list
-    Given any graph
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
-      RETURN any(x IN list WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                         | result |
-      | none(y IN list WHERE x = y * y)   | true   |
-      | none(y IN list WHERE x % y = 0)   | false  |
-      | single(y IN list WHERE x = y * y) | true   |
-      | single(y IN list WHERE x < y * y) | false  |
-      | any(y IN list WHERE x = y)        | true   |
-      | any(y IN list WHERE x = 10 * y)   | false  |
-      | all(y IN list WHERE x <= y)       | true   |
-      | all(y IN list WHERE x < y)        | false  |
-
-  Scenario: [15] Any quantifier is false if the predicate is statically false and the list is not empty
+  Scenario: [13] Any quantifier is false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -412,7 +367,7 @@ Feature: Quantifier3 - Any quantifier
       | false  |
     And no side effects
 
-  Scenario: [16] Any quantifier is true if the predicate is statically true and the list is not empty
+  Scenario: [14] Any quantifier is true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -423,84 +378,7 @@ Feature: Quantifier3 - Any quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [17] Any quantifier is true if the single or the all quantifier is true
-    Given any graph
-    When executing query:
-      """
-      RETURN (single(<operands>) OR all(<operands>)) <= any(<operands>) AS result
-      """
-    # Note that FALSE is less than TRUE, hence A <= B is effectively equivalent to the implication A -> B
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | operands                                         |
-      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x = 2     |
-      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x % 2 = 0 |
-      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x % 3 = 0 |
-      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x < 7     |
-      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x >= 3    |
-
-  Scenario Outline: [18] Any quantifier is equal the boolean negative of the none quantifier
-    Given any graph
-    When executing query:
-      """
-      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>)) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [19] Any quantifier is equal the boolean negative of the all quantifier on the boolean negative of the predicate
-    Given any graph
-    When executing query:
-      """
-      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>))) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [20] Any quantifier is equal whether the size of the list filtered with same the predicate is grater zero
-    Given any graph
-    When executing query:
-      """
-      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) > 0) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [21] Fail any quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [15] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -30,7 +30,18 @@
 
 Feature: Quantifier3 - Any quantifier
 
-  Scenario Outline: [1] Any quantifier on list literal
+  Scenario: [1] Any quantifier is always false on empty list
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN [] WHERE true) AS a, any(x IN [] WHERE false) AS b, any(x IN [] WHERE x) AS c
+      """
+    Then the result should be, in any order:
+      | a     | b     | c     |
+      | false | false | false |
+    And no side effects
+
+  Scenario Outline: [2] Any quantifier on list literal
     Given any graph
     When executing query:
       """
@@ -53,7 +64,7 @@ Feature: Quantifier3 - Any quantifier
       | [true, true, true]     | x         | true   |
       | [false, false, false]  | x         | false  |
 
-  Scenario Outline: [2] Any quantifier on list literal containing integers
+  Scenario Outline: [3] Any quantifier on list literal containing integers
     Given any graph
     When executing query:
       """
@@ -84,7 +95,7 @@ Feature: Quantifier3 - Any quantifier
       | [200, -10, 36, 21, 10] | x < 10    | true   |
       | [200, 15, 36, 21, 10]  | x < 10    | false  |
 
-  Scenario Outline: [3] Any quantifier on list literal containing floats
+  Scenario Outline: [4] Any quantifier on list literal containing floats
     Given any graph
     When executing query:
       """
@@ -110,7 +121,7 @@ Feature: Quantifier3 - Any quantifier
       | [3.5, 2.1, 3.5]            | x = 2.1   | true   |
       | [2.1, 3.5, 2.1]            | x = 2.1   | true   |
 
-  Scenario Outline: [4] Any quantifier on list literal containing strings
+  Scenario Outline: [5] Any quantifier on list literal containing strings
     Given any graph
     When executing query:
       """
@@ -133,7 +144,7 @@ Feature: Quantifier3 - Any quantifier
       | ['abc', 'abc', 'abc'] | size(x) = 3 | true   |
       | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
 
-  Scenario Outline: [5] Any quantifier on list literal containing lists
+  Scenario Outline: [6] Any quantifier on list literal containing lists
     Given any graph
     When executing query:
       """
@@ -156,7 +167,7 @@ Feature: Quantifier3 - Any quantifier
       | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | true   |
       | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
 
-  Scenario Outline: [6] Any quantifier on list literal containing maps
+  Scenario Outline: [7] Any quantifier on list literal containing maps
     Given any graph
     When executing query:
       """
@@ -179,7 +190,7 @@ Feature: Quantifier3 - Any quantifier
       | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | true   |
       | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
 
-  Scenario: [7] Any quantifier on list containing nodes
+  Scenario: [8] Any quantifier on list containing nodes
     Given an empty graph
     And having executed:
       """
@@ -225,7 +236,7 @@ Feature: Quantifier3 - Any quantifier
       | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
     And no side effects
 
-  Scenario: [8] Any quantifier on list containing relationships
+  Scenario: [9] Any quantifier on list containing relationships
     Given an empty graph
     And having executed:
       """
@@ -271,7 +282,7 @@ Feature: Quantifier3 - Any quantifier
       | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
     And no side effects
 
-  Scenario Outline: [9] Any quantifier on lists containing nulls
+  Scenario Outline: [10] Any quantifier on lists containing nulls
     Given any graph
     When executing query:
       """
@@ -293,7 +304,7 @@ Feature: Quantifier3 - Any quantifier
       | [34, 10, null, 15, 900] | x < 10    | null   |
       | [4, 0, null, -15, 9]    | x < 10    | true   |
 
-  Scenario Outline: [10] Any quantifier with IS NULL predicate
+  Scenario Outline: [11] Any quantifier with IS NULL predicate
     Given any graph
     When executing query:
       """
@@ -319,7 +330,7 @@ Feature: Quantifier3 - Any quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | true   |
 
-  Scenario Outline: [11] Any quantifier with IS NOT NULL predicate
+  Scenario Outline: [12] Any quantifier with IS NOT NULL predicate
     Given any graph
     When executing query:
       """
@@ -345,7 +356,7 @@ Feature: Quantifier3 - Any quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [12] Any quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] Any quantifier can nest itself and other quantifiers
     Given any graph
     When executing query:
       """
@@ -367,7 +378,7 @@ Feature: Quantifier3 - Any quantifier
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
 
-  Scenario: [13] Any quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [14] Any quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -390,7 +401,7 @@ Feature: Quantifier3 - Any quantifier
       | false  |
     And no side effects
 
-  Scenario: [14] Any quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [15] Any quantifier is always true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -413,7 +424,7 @@ Feature: Quantifier3 - Any quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [15] Any quantifier is always true if the single or the all quantifier is true
+  Scenario Outline: [16] Any quantifier is always true if the single or the all quantifier is true
     Given any graph
     When executing query:
       """
@@ -449,7 +460,7 @@ Feature: Quantifier3 - Any quantifier
       | x IN list WHERE x < 7     |
       | x IN list WHERE x >= 3    |
 
-  Scenario Outline: [16] Any quantifier is always equal the boolean negative of the none quantifier
+  Scenario Outline: [17] Any quantifier is always equal the boolean negative of the none quantifier
     Given any graph
     When executing query:
       """
@@ -479,7 +490,7 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [17] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
+  Scenario Outline: [18] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -509,7 +520,7 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] Fail any quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [19] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -520,7 +520,43 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] Fail any quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [19] Any quantifier is always equal whether the size of the list filtered with same the predicate is grater zero
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH any(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) > 0) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [20] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -420,7 +420,7 @@ Feature: Quantifier3 - Any quantifier
       UNWIND [{list: [2], fixed: true},
               {list: [6], fixed: true},
               {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
-      WITH CASE WHEN input.fixed THEN input.list ELSE NULL END AS fixedList,
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
            CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
       UNWIND inputList AS x
       WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
@@ -431,7 +431,7 @@ Feature: Quantifier3 - Any quantifier
       UNWIND inputList AS x
       WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
       WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH COALESCE(fixedList, list) AS list
+      WITH coalesce(fixedList, list) AS list
       WITH list WHERE single(<operands>) OR all(<operands>)
       WITH any(<operands>) AS result, count(*) AS cnt
       RETURN result

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -244,12 +244,12 @@ Feature: Quantifier3 - Any quantifier
       | [34, 0, 8, 900]          | true   |
       | [null]                   | false  |
       | [null, null]             | false  |
-      | [0, null]                | false  |
-      | [2, null]                | false  |
-      | [null, 2]                | false  |
-      | [34, 0, null, 8, 900]    | false  |
-      | [34, 0, null, 8, null]   | false  |
-      | [null, 123, null, null]  | false  |
+      | [0, null]                | true   |
+      | [2, null]                | true   |
+      | [null, 2]                | true   |
+      | [34, 0, null, 8, 900]    | true   |
+      | [34, 0, null, 8, null]   | true   |
+      | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
   Scenario Outline: [10] Any quantifier can nest itself and other quantifiers
@@ -347,7 +347,7 @@ Feature: Quantifier3 - Any quantifier
       UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
       WITH *, rand() AS s WHERE rand() > 0.75
       WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE single(<operands>)
-      WITH any(x IN list WHERE <operands>) AS result, count(*) AS cnt
+      WITH any(<operands>) AS result, count(*) AS cnt
       RETURN result
       """
     Then the result should be, in any order:

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -30,3 +30,352 @@
 
 Feature: Quantifier3 - Any quantifier
 
+  Scenario Outline: [1] Any quantifier on list literal
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x         | false  |
+      | [true]                 | x         | true   |
+      | [false]                | x         | false  |
+      | [true, false]          | x         | true   |
+      | [false, true]          | x         | true   |
+      | [true, false, true]    | x         | true   |
+      | [false, true, false]   | x         | true   |
+      | [true, true, true]     | x         | true   |
+      | [false, false, false]  | x         | false  |
+
+  Scenario Outline: [2] Any quantifier on list literal containing integers
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x = 2     | false  |
+      | [1]                    | x = 2     | false  |
+      | [1, 3]                 | x = 2     | false  |
+      | [1, 3, 20, 5000]       | x = 2     | false  |
+      | [20, 3, 5000, -2]      | x = 2     | false  |
+      | [2]                    | x = 2     | true   |
+      | [1, 2]                 | x = 2     | true   |
+      | [1, 2, 3]              | x = 2     | true   |
+      | [2, 2]                 | x = 2     | true   |
+      | [2, 3]                 | x = 2     | true   |
+      | [3, 2, 3]              | x = 2     | true   |
+      | [2, 3, 2]              | x = 2     | true   |
+      | [2, -10, 3, 9, 0]      | x < 10    | true   |
+      | [2, -10, 3, 2, 10]     | x < 10    | true   |
+      | [2, -10, 3, 21, 10]    | x < 10    | true   |
+      | [200, -10, 36, 21, 10] | x < 10    | true   |
+      | [200, 15, 36, 21, 10]  | x < 10    | false  |
+
+  Scenario Outline: [3] Any quantifier on list literal containing floats
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                       | condition | result |
+      | []                         | x = 2.1   | false  |
+      | [1.1]                      | x = 2.1   | false  |
+      | [1.1, 3.5]                 | x = 2.1   | false  |
+      | [1.1, 3.5, 20.0, 50.42435] | x = 2.1   | false  |
+      | [20.0, 3.4, 50.2, -2.1]    | x = 2.1   | false  |
+      | [2.1]                      | x = 2.1   | true   |
+      | [1.43, 2.1]                | x = 2.1   | true   |
+      | [1.43, 2.1, 3.5]           | x = 2.1   | true   |
+      | [2.1, 2.1]                 | x = 2.1   | true   |
+      | [2.1, 3.5]                 | x = 2.1   | true   |
+      | [3.5, 2.1, 3.5]            | x = 2.1   | true   |
+      | [2.1, 3.5, 2.1]            | x = 2.1   | true   |
+
+  Scenario Outline: [4] Any quantifier on list literal containing strings
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                  | condition   | result |
+      | []                    | size(x) = 3 | false  |
+      | ['abc']               | size(x) = 3 | true   |
+      | ['ef']                | size(x) = 3 | false  |
+      | ['abc', 'ef']         | size(x) = 3 | true   |
+      | ['ef', 'abc']         | size(x) = 3 | true   |
+      | ['abc', 'ef', 'abc']  | size(x) = 3 | true   |
+      | ['ef', 'abc', 'ef']   | size(x) = 3 | true   |
+      | ['abc', 'abc', 'abc'] | size(x) = 3 | true   |
+      | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
+
+  Scenario Outline: [5] Any quantifier on list literal containing lists
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                              | condition   | result |
+      | []                                | size(x) = 3 | false  |
+      | [[1, 2, 3]]                       | size(x) = 3 | true   |
+      | [['a']]                           | size(x) = 3 | false  |
+      | [[1, 2, 3], ['a']]                | size(x) = 3 | true   |
+      | [['a'], [1, 2, 3]]                | size(x) = 3 | true   |
+      | [[1, 2, 3], ['a'], [1, 2, 3]]     | size(x) = 3 | true   |
+      | [['a'], [1, 2, 3], ['a']]         | size(x) = 3 | true   |
+      | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | true   |
+      | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
+
+  Scenario Outline: [6] Any quantifier on list literal containing maps
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                                       | condition | result |
+      | []                                         | x.a = 2   | false  |
+      | [{a: 2, b: 5}]                             | x.a = 2   | true   |
+      | [{a: 4}]                                   | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 4}]                     | x.a = 2   | true   |
+      | [{a: 4}, {a: 2, b: 5}]                     | x.a = 2   | true   |
+      | [{a: 2, b: 5}, {a: 4}, {a: 2, b: 5}]       | x.a = 2   | true   |
+      | [{a: 4}, {a: 2, b: 5}, {a: 4}]             | x.a = 2   | true   |
+      | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | true   |
+      | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
+
+  Scenario Outline: [7] Any quantifier on lists containing nulls
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                    | condition | result |
+      | [null]                  | x = 2     | null   |
+      | [null, null]            | x = 2     | null   |
+      | [0, null]               | x = 2     | null   |
+      | [2, null]               | x = 2     | true   |
+      | [null, 2]               | x = 2     | true   |
+      | [34, 0, null, 5, 900]   | x < 10    | true   |
+      | [34, 10, null, 15, 900] | x < 10    | null   |
+
+  Scenario Outline: [8] Any quantifier with IS NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE x IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | false  |
+      | [0]                      | false  |
+      | [34, 0, 8, 900]          | false  |
+      | [null]                   | true   |
+      | [null, null]             | true   |
+      | [0, null]                | true   |
+      | [2, null]                | true   |
+      | [null, 2]                | true   |
+      | [34, 0, null, 8, 900]    | true   |
+      | [34, 0, null, 8, null]   | true   |
+      | [null, 123, null, null]  | true   |
+      | [null, null, null, null] | true   |
+
+  Scenario Outline: [9] Any quantifier with IS NOT NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE x IS NOT NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | false  |
+      | [0]                      | true   |
+      | [34, 0, 8, 900]          | true   |
+      | [null]                   | false  |
+      | [null, null]             | false  |
+      | [0, null]                | false  |
+      | [2, null]                | false  |
+      | [null, 2]                | false  |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | false  |
+
+  Scenario Outline: [10] Any quantifier can nest itself and other quantifiers
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition> IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                      | condition                      | result |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | true   |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'abc')   | false  |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'def') | true   |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | false  |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | true   |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | false  |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
+
+  Scenario: [11] Any quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      WITH any(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [12] Any quantifier is always true if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      WITH any(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [13] Any quantifier is always true if the single quantifier is true on the same operands
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
+      WITH * WHERE rand() > 0.75
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
+      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
+      WITH *, rand() AS s WHERE rand() > 0.75
+      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE single(<operands>)
+      WITH any(x IN list WHERE <operands>) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | operands                  |
+      | x IN list WHERE x = 2     |
+      | x IN list WHERE x % 2 = 0 |
+      | x IN list WHERE x % 3 = 0 |
+      | x IN list WHERE x < 5     |
+      | x IN list WHERE x >= 6    |
+
+  Scenario Outline: [14] Fail any quantifier on type mismatch between list elements and predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN <list> WHERE <condition>) AS result
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | list                              | condition |
+      | ['Clara']                         | x % 2 = 0 |
+      | [false, true]                     | x % 2 = 0 |
+      | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
+      # add examples with heterogeneously-typed lists
+
+

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -256,7 +256,7 @@ Feature: Quantifier3 - Any quantifier
     Given any graph
     When executing query:
       """
-      RETURN any(x IN <list> WHERE <condition> IS NULL) AS result
+      RETURN any(x IN <list> WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -371,20 +371,16 @@ Feature: Quantifier3 - Any quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
       WITH any(x IN list WHERE false) AS result, count(*) AS cnt
       RETURN result
       """
@@ -398,20 +394,16 @@ Feature: Quantifier3 - Any quantifier
     When executing query:
       """
       WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x0
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x1
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x2
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x3
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x4
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x5
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x6
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x7
-      WITH * WHERE rand() > 0.75
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x8
-      UNWIND([x IN inputList WHERE rand() > 0.75 | x]) AS x9
-      WITH *, rand() AS s WHERE rand() > 0.75
-      WITH [x IN [x0, x1, x2, x3, x4, x5, x6, x7, x8, x9] WHERE rand() > s | x] AS list WHERE size(list) > 0
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
       WITH any(x IN list WHERE true) AS result, count(*) AS cnt
       RETURN result
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -356,11 +356,11 @@ Feature: Quantifier3 - Any quantifier
       | [null, 123, null, null]  | true   |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] Any quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] Any quantifier can nest itself and other quantifiers on nested lists
     Given any graph
     When executing query:
       """
-      RETURN any(x IN <list> WHERE <condition>) AS result
+      RETURN any(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |
@@ -368,17 +368,40 @@ Feature: Quantifier3 - Any quantifier
     And no side effects
 
     Examples:
-      | list                      | condition                      | result |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | true   |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'abc')   | false  |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'def') | true   |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | false  |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | true   |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | false  |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | true   |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'def')    | false  |
+      | condition                      | result |
+      | none(y IN x WHERE y = 'def')   | true   |
+      | none(y IN x WHERE y = 'abc')   | false  |
+      | single(y IN x WHERE y = 'def') | true   |
+      | single(y IN x WHERE y = 'ghi') | false  |
+      | any(y IN x WHERE y = 'abc')    | true   |
+      | any(y IN x WHERE y = 'ghi')    | false  |
+      | all(y IN x WHERE y = 'abc')    | true   |
+      | all(y IN x WHERE y = 'def')    | false  |
 
-  Scenario: [14] Any quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario Outline: [14] Any quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN any(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                         | result |
+      | none(y IN list WHERE x = y * y)   | true   |
+      | none(y IN list WHERE x % y = 0)   | false  |
+      | single(y IN list WHERE x = y * y) | true   |
+      | single(y IN list WHERE x < y * y) | false  |
+      | any(y IN list WHERE x = y)        | true   |
+      | any(y IN list WHERE x = 10 * y)   | false  |
+      | all(y IN list WHERE x <= y)       | true   |
+      | all(y IN list WHERE x < y)        | false  |
+
+  Scenario: [15] Any quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -401,7 +424,7 @@ Feature: Quantifier3 - Any quantifier
       | false  |
     And no side effects
 
-  Scenario: [15] Any quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [16] Any quantifier is always true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -424,7 +447,7 @@ Feature: Quantifier3 - Any quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [16] Any quantifier is always true if the single or the all quantifier is true
+  Scenario Outline: [17] Any quantifier is always true if the single or the all quantifier is true
     Given any graph
     When executing query:
       """
@@ -460,7 +483,7 @@ Feature: Quantifier3 - Any quantifier
       | x IN list WHERE x < 7     |
       | x IN list WHERE x >= 3    |
 
-  Scenario Outline: [17] Any quantifier is always equal the boolean negative of the none quantifier
+  Scenario Outline: [18] Any quantifier is always equal the boolean negative of the none quantifier
     Given any graph
     When executing query:
       """
@@ -490,7 +513,7 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
+  Scenario Outline: [19] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -520,7 +543,7 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] Any quantifier is always equal whether the size of the list filtered with same the predicate is grater zero
+  Scenario Outline: [20] Any quantifier is always equal whether the size of the list filtered with same the predicate is grater zero
     Given any graph
     When executing query:
       """
@@ -556,7 +579,7 @@ Feature: Quantifier3 - Any quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [20] Fail any quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [21] Fail any quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier3.feature
+++ b/tck/features/expressions/quantifier/Quantifier3.feature
@@ -457,5 +457,3 @@ Feature: Quantifier3 - Any quantifier
       | [false, true]                     | x % 2 = 0 |
       | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
       # add examples with heterogeneously-typed lists
-
-

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -360,7 +360,7 @@ Feature: Quantifier4 - All quantifier
     Given any graph
     When executing query:
       """
-      RETURN all(x IN [1, null, true, 4.5, 'abc', false] WHERE false)
+      RETURN all(x IN [1, null, true, 4.5, 'abc', false] WHERE false) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -356,52 +356,7 @@ Feature: Quantifier4 - All quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] All quantifier can nest itself and other quantifiers on nested lists
-    Given any graph
-    When executing query:
-      """
-      RETURN all(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                      | result |
-      | none(y IN x WHERE y = 'ghi')   | true   |
-      | none(y IN x WHERE y = 'def')   | false  |
-      | single(y IN x WHERE y = 'abc') | true   |
-      | single(y IN x WHERE y = 'ghi') | false  |
-      | any(y IN x WHERE y = 'abc')    | true   |
-      | any(y IN x WHERE y = 'ghi')    | false  |
-      | all(y IN x WHERE y <> 'ghi')   | true   |
-      | all(y IN x WHERE y = 'abc')    | false  |
-
-  Scenario Outline: [14] All quantifier can nest itself and other quantifiers on the same list
-    Given any graph
-    When executing query:
-      """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
-      RETURN all(x IN list WHERE <condition>) AS result
-      """
-    Then the result should be, in any order:
-      | result   |
-      | <result> |
-    And no side effects
-
-    Examples:
-      | condition                            | result |
-      | none(y IN list WHERE x = 10 * y)     | true   |
-      | none(y IN list WHERE x = y)          | false  |
-      | single(y IN list WHERE x = y)        | true   |
-      | single(y IN list WHERE x < y)        | false  |
-      | any(y IN list WHERE x % y = 0)       | true   |
-      | any(y IN list WHERE x < y)           | false  |
-      | all(y IN list WHERE abs(x - y) < 10) | true   |
-      | all(y IN list WHERE x < y + 7)       | false  |
-
-  Scenario: [15] All quantifier is false if the predicate is statically false and the list is not empty
+  Scenario: [13] All quantifier is false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -412,7 +367,7 @@ Feature: Quantifier4 - All quantifier
       | false  |
     And no side effects
 
-  Scenario: [16] All quantifier is true if the predicate is statically true and the list is not empty
+  Scenario: [14] All quantifier is true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -423,64 +378,7 @@ Feature: Quantifier4 - All quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [17] All quantifier is equal the none quantifier on the boolean negative of the predicate
-    Given any graph
-    When executing query:
-      """
-      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [18] All quantifier is equal the boolean negative of the any quantifier on the boolean negative of the predicate
-    Given any graph
-    When executing query:
-      """
-      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>))) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [19] All quantifier is equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
-    Given any graph
-    When executing query:
-      """
-      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = size(list)) AS result
-      """
-    Then the result should be, in any order:
-      | result |
-      | true   |
-    And no side effects
-
-    Examples:
-      | predicate |
-      | x = 2     |
-      | x % 2 = 0 |
-      | x % 3 = 0 |
-      | x < 7     |
-      | x >= 3    |
-
-  Scenario Outline: [20] Fail all quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [15] Fail all quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -401,68 +401,33 @@ Feature: Quantifier4 - All quantifier
       | all(y IN list WHERE abs(x - y) < 10) | true   |
       | all(y IN list WHERE x < y + 7)       | false  |
 
-  Scenario: [15] All quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [15] All quantifier is false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH all(x IN list WHERE false) AS result, count(*) AS cnt
-      RETURN result
+      RETURN all(x IN [1, null, true, 4.5, 'abc', false] WHERE false)
       """
     Then the result should be, in any order:
       | result |
       | false  |
     And no side effects
 
-  Scenario: [16] All quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [16] All quantifier is true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
-      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH list WHERE size(list) > 0
-      WITH all(x IN list WHERE true) AS result, count(*) AS cnt
-      RETURN result
+      RETURN all(x IN [1, null, true, 4.5, 'abc', false] WHERE true) AS result
       """
     Then the result should be, in any order:
       | result |
       | true   |
     And no side effects
 
-  Scenario Outline: [17] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+  Scenario Outline: [17] All quantifier is equal the none quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH all(x IN list WHERE <predicate>) = none(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
-      RETURN result
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
       """
     Then the result should be, in any order:
       | result |
@@ -477,22 +442,11 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
+  Scenario Outline: [18] All quantifier is equal the boolean negative of the any quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH all(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
-      RETURN result
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>))) AS result
       """
     Then the result should be, in any order:
       | result |
@@ -507,28 +461,11 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] All quantifier is always equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
+  Scenario Outline: [19] All quantifier is equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
     Given any graph
     When executing query:
       """
-      UNWIND [{list: [2], fixed: true},
-              {list: [6], fixed: true},
-              {list: [7], fixed: true},
-              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
-      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
-           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      UNWIND inputList AS x
-      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
-      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
-      WITH coalesce(fixedList, list) AS list
-      WITH all(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = size(list)) AS result, count(*) AS cnt
-      RETURN result
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = size(list)) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -356,11 +356,11 @@ Feature: Quantifier4 - All quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [13] All quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] All quantifier can nest itself and other quantifiers on nested lists
     Given any graph
     When executing query:
       """
-      RETURN all(x IN <list> WHERE <condition>) AS result
+      RETURN all(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
       """
     Then the result should be, in any order:
       | result   |
@@ -368,17 +368,40 @@ Feature: Quantifier4 - All quantifier
     And no side effects
 
     Examples:
-      | list                      | condition                      | result |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | true   |
-      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | false  |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | true   |
-      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | false  |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | true   |
-      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | false  |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y <> 'ghi')   | true   |
-      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
+      | condition                      | result |
+      | none(y IN x WHERE y = 'ghi')   | true   |
+      | none(y IN x WHERE y = 'def')   | false  |
+      | single(y IN x WHERE y = 'abc') | true   |
+      | single(y IN x WHERE y = 'ghi') | false  |
+      | any(y IN x WHERE y = 'abc')    | true   |
+      | any(y IN x WHERE y = 'ghi')    | false  |
+      | all(y IN x WHERE y <> 'ghi')   | true   |
+      | all(y IN x WHERE y = 'abc')    | false  |
 
-  Scenario: [14] All quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario Outline: [14] All quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN all(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                            | result |
+      | none(y IN list WHERE x = 10 * y)     | true   |
+      | none(y IN list WHERE x = y)          | false  |
+      | single(y IN list WHERE x = y)        | true   |
+      | single(y IN list WHERE x < y)        | false  |
+      | any(y IN list WHERE x % y = 0)       | true   |
+      | any(y IN list WHERE x < y)           | false  |
+      | all(y IN list WHERE abs(x - y) < 10) | true   |
+      | all(y IN list WHERE x < y + 7)       | false  |
+
+  Scenario: [15] All quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -401,7 +424,7 @@ Feature: Quantifier4 - All quantifier
       | false  |
     And no side effects
 
-  Scenario: [15] All quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [16] All quantifier is always true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -424,7 +447,7 @@ Feature: Quantifier4 - All quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [16] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+  Scenario Outline: [17] All quantifier is always equal the none quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -454,7 +477,7 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [17] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
+  Scenario Outline: [18] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -484,7 +507,7 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [18] All quantifier is always equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
+  Scenario Outline: [19] All quantifier is always equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
     Given any graph
     When executing query:
       """
@@ -520,7 +543,7 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [19] Fail all quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [20] Fail all quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -30,7 +30,18 @@
 
 Feature: Quantifier4 - All quantifier
 
-  Scenario Outline: [1] All quantifier on list literal
+  Scenario: [1] All quantifier is always true on empty list
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN [] WHERE true) AS a, all(x IN [] WHERE false) AS b, all(x IN [] WHERE x) AS c
+      """
+    Then the result should be, in any order:
+      | a    | b    | c    |
+      | true | true | true |
+    And no side effects
+
+  Scenario Outline: [2] All quantifier on list literal
     Given any graph
     When executing query:
       """
@@ -53,7 +64,7 @@ Feature: Quantifier4 - All quantifier
       | [true, true, true]     | x         | true   |
       | [false, false, false]  | x         | false  |
 
-  Scenario Outline: [2] All quantifier on list literal containing integers
+  Scenario Outline: [3] All quantifier on list literal containing integers
     Given any graph
     When executing query:
       """
@@ -84,7 +95,7 @@ Feature: Quantifier4 - All quantifier
       | [200, -10, 36, 21, 10] | x < 10    | false  |
       | [200, 15, 36, 21, 10]  | x < 10    | false  |
 
-  Scenario Outline: [3] All quantifier on list literal containing floats
+  Scenario Outline: [4] All quantifier on list literal containing floats
     Given any graph
     When executing query:
       """
@@ -110,7 +121,7 @@ Feature: Quantifier4 - All quantifier
       | [3.5, 2.1, 3.5]            | x = 2.1   | false  |
       | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
 
-  Scenario Outline: [4] All quantifier on list literal containing strings
+  Scenario Outline: [5] All quantifier on list literal containing strings
     Given any graph
     When executing query:
       """
@@ -133,7 +144,7 @@ Feature: Quantifier4 - All quantifier
       | ['abc', 'abc', 'abc'] | size(x) = 3 | true   |
       | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
 
-  Scenario Outline: [5] All quantifier on list literal containing lists
+  Scenario Outline: [6] All quantifier on list literal containing lists
     Given any graph
     When executing query:
       """
@@ -156,7 +167,7 @@ Feature: Quantifier4 - All quantifier
       | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | true   |
       | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
 
-  Scenario Outline: [6] All quantifier on list literal containing maps
+  Scenario Outline: [7] All quantifier on list literal containing maps
     Given any graph
     When executing query:
       """
@@ -179,7 +190,7 @@ Feature: Quantifier4 - All quantifier
       | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | true   |
       | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
 
-  Scenario: [7] All quantifier on list containing nodes
+  Scenario: [8] All quantifier on list containing nodes
     Given an empty graph
     And having executed:
       """
@@ -225,7 +236,7 @@ Feature: Quantifier4 - All quantifier
       | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
     And no side effects
 
-  Scenario: [8] All quantifier on list containing relationships
+  Scenario: [9] All quantifier on list containing relationships
     Given an empty graph
     And having executed:
       """
@@ -271,7 +282,7 @@ Feature: Quantifier4 - All quantifier
       | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
     And no side effects
 
-  Scenario Outline: [9] All quantifier on lists containing nulls
+  Scenario Outline: [10] All quantifier on lists containing nulls
     Given any graph
     When executing query:
       """
@@ -293,7 +304,7 @@ Feature: Quantifier4 - All quantifier
       | [34, 10, null, 15, 900] | x < 10    | false  |
       | [4, 0, null, -15, 9]    | x < 10    | null   |
 
-  Scenario Outline: [10] All quantifier with IS NULL predicate
+  Scenario Outline: [11] All quantifier with IS NULL predicate
     Given any graph
     When executing query:
       """
@@ -319,7 +330,7 @@ Feature: Quantifier4 - All quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | true   |
 
-  Scenario Outline: [11] All quantifier with IS NOT NULL predicate
+  Scenario Outline: [12] All quantifier with IS NOT NULL predicate
     Given any graph
     When executing query:
       """
@@ -345,7 +356,7 @@ Feature: Quantifier4 - All quantifier
       | [null, 123, null, null]  | false  |
       | [null, null, null, null] | false  |
 
-  Scenario Outline: [12] All quantifier can nest itself and other quantifiers
+  Scenario Outline: [13] All quantifier can nest itself and other quantifiers
     Given any graph
     When executing query:
       """
@@ -367,7 +378,7 @@ Feature: Quantifier4 - All quantifier
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y <> 'ghi')   | true   |
       | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
 
-  Scenario: [13] All quantifier is always false if the predicate is statically false and the list is not empty
+  Scenario: [14] All quantifier is always false if the predicate is statically false and the list is not empty
     Given any graph
     When executing query:
       """
@@ -390,7 +401,7 @@ Feature: Quantifier4 - All quantifier
       | false  |
     And no side effects
 
-  Scenario: [14] All quantifier is always true if the predicate is statically true and the list is not empty
+  Scenario: [15] All quantifier is always true if the predicate is statically true and the list is not empty
     Given any graph
     When executing query:
       """
@@ -413,7 +424,7 @@ Feature: Quantifier4 - All quantifier
       | true   |
     And no side effects
 
-  Scenario Outline: [15] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+  Scenario Outline: [16] All quantifier is always equal the none quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -443,7 +454,7 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [16] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
+  Scenario Outline: [17] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
     Given any graph
     When executing query:
       """
@@ -473,7 +484,7 @@ Feature: Quantifier4 - All quantifier
       | x < 7     |
       | x >= 3    |
 
-  Scenario Outline: [16] Fail all quantifier on type mismatch between list elements and predicate
+  Scenario Outline: [18] Fail all quantifier on type mismatch between list elements and predicate
     Given any graph
     When executing query:
       """

--- a/tck/features/expressions/quantifier/Quantifier4.feature
+++ b/tck/features/expressions/quantifier/Quantifier4.feature
@@ -30,3 +30,460 @@
 
 Feature: Quantifier4 - All quantifier
 
+  Scenario Outline: [1] All quantifier on list literal
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x         | true   |
+      | [true]                 | x         | true   |
+      | [false]                | x         | false  |
+      | [true, false]          | x         | false  |
+      | [false, true]          | x         | false  |
+      | [true, false, true]    | x         | false  |
+      | [false, true, false]   | x         | false  |
+      | [true, true, true]     | x         | true   |
+      | [false, false, false]  | x         | false  |
+
+  Scenario Outline: [2] All quantifier on list literal containing integers
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                   | condition | result |
+      | []                     | x = 2     | true   |
+      | [1]                    | x = 2     | false  |
+      | [1, 3]                 | x = 2     | false  |
+      | [1, 3, 20, 5000]       | x = 2     | false  |
+      | [20, 3, 5000, -2]      | x = 2     | false  |
+      | [2]                    | x = 2     | true   |
+      | [1, 2]                 | x = 2     | false  |
+      | [1, 2, 3]              | x = 2     | false  |
+      | [2, 2]                 | x = 2     | true   |
+      | [2, 3]                 | x = 2     | false  |
+      | [3, 2, 3]              | x = 2     | false  |
+      | [2, 3, 2]              | x = 2     | false  |
+      | [2, -10, 3, 9, 0]      | x < 10    | true   |
+      | [2, -10, 3, 2, 10]     | x < 10    | false  |
+      | [2, -10, 3, 21, 10]    | x < 10    | false  |
+      | [200, -10, 36, 21, 10] | x < 10    | false  |
+      | [200, 15, 36, 21, 10]  | x < 10    | false  |
+
+  Scenario Outline: [3] All quantifier on list literal containing floats
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                       | condition | result |
+      | []                         | x = 2.1   | true   |
+      | [1.1]                      | x = 2.1   | false  |
+      | [1.1, 3.5]                 | x = 2.1   | false  |
+      | [1.1, 3.5, 20.0, 50.42435] | x = 2.1   | false  |
+      | [20.0, 3.4, 50.2, -2.1]    | x = 2.1   | false  |
+      | [2.1]                      | x = 2.1   | true   |
+      | [1.43, 2.1]                | x = 2.1   | false  |
+      | [1.43, 2.1, 3.5]           | x = 2.1   | false  |
+      | [2.1, 2.1]                 | x = 2.1   | true   |
+      | [2.1, 3.5]                 | x = 2.1   | false  |
+      | [3.5, 2.1, 3.5]            | x = 2.1   | false  |
+      | [2.1, 3.5, 2.1]            | x = 2.1   | false  |
+
+  Scenario Outline: [4] All quantifier on list literal containing strings
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                  | condition   | result |
+      | []                    | size(x) = 3 | true   |
+      | ['abc']               | size(x) = 3 | true   |
+      | ['ef']                | size(x) = 3 | false  |
+      | ['abc', 'ef']         | size(x) = 3 | false  |
+      | ['ef', 'abc']         | size(x) = 3 | false  |
+      | ['abc', 'ef', 'abc']  | size(x) = 3 | false  |
+      | ['ef', 'abc', 'ef']   | size(x) = 3 | false  |
+      | ['abc', 'abc', 'abc'] | size(x) = 3 | true   |
+      | ['ef', 'ef', 'ef']    | size(x) = 3 | false  |
+
+  Scenario Outline: [5] All quantifier on list literal containing lists
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                              | condition   | result |
+      | []                                | size(x) = 3 | true   |
+      | [[1, 2, 3]]                       | size(x) = 3 | true   |
+      | [['a']]                           | size(x) = 3 | false  |
+      | [[1, 2, 3], ['a']]                | size(x) = 3 | false  |
+      | [['a'], [1, 2, 3]]                | size(x) = 3 | false  |
+      | [[1, 2, 3], ['a'], [1, 2, 3]]     | size(x) = 3 | false  |
+      | [['a'], [1, 2, 3], ['a']]         | size(x) = 3 | false  |
+      | [[1, 2, 3], [1, 2, 3], [1, 2, 3]] | size(x) = 3 | true   |
+      | [['a'], ['a'], ['a']]             | size(x) = 3 | false  |
+
+  Scenario Outline: [6] All quantifier on list literal containing maps
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                                       | condition | result |
+      | []                                         | x.a = 2   | true   |
+      | [{a: 2, b: 5}]                             | x.a = 2   | true   |
+      | [{a: 4}]                                   | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 4}]                     | x.a = 2   | false  |
+      | [{a: 4}, {a: 2, b: 5}]                     | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 4}, {a: 2, b: 5}]       | x.a = 2   | false  |
+      | [{a: 4}, {a: 2, b: 5}, {a: 4}]             | x.a = 2   | false  |
+      | [{a: 2, b: 5}, {a: 2, b: 5}, {a: 2, b: 5}] | x.a = 2   | true   |
+      | [{a: 4}, {a: 4}, {a: 4}]                   | x.a = 2   | false  |
+
+  Scenario: [7] All quantifier on list containing nodes
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (s1:SRelationships), (s2:SNodes)
+      CREATE (a:A {name: 'a'}), (b:B {name: 'b'})
+      CREATE (aa:A {name: 'a'}), (ab:B {name: 'b'}),
+             (ba:A {name: 'a'}), (bb:B {name: 'b'})
+      CREATE (aaa:A {name: 'a'}), (aab:B {name: 'b'}),
+             (aba:A {name: 'a'}), (abb:B {name: 'b'}),
+             (baa:A {name: 'a'}), (bab:B {name: 'b'}),
+             (bba:A {name: 'a'}), (bbb:B {name: 'b'})
+      CREATE (s1)-[:I]->(s2),
+             (s2)-[:RA {name: 'a'}]->(a), (s2)-[:RB {name: 'b'}]->(b)
+      CREATE (a)-[:RA {name: 'a'}]->(aa), (a)-[:RB {name: 'b'}]->(ab),
+             (b)-[:RA {name: 'a'}]->(ba), (b)-[:RB {name: 'b'}]->(bb)
+      CREATE (aa)-[:RA {name: 'a'}]->(aaa), (aa)-[:RB {name: 'b'}]->(aab),
+             (ab)-[:RA {name: 'a'}]->(aba), (ab)-[:RB {name: 'b'}]->(abb),
+             (ba)-[:RA {name: 'a'}]->(baa), (ba)-[:RB {name: 'b'}]->(bab),
+             (bb)-[:RA {name: 'a'}]->(bba), (bb)-[:RB {name: 'b'}]->(bbb)
+      """
+    When executing query:
+      """
+      MATCH p = (:SNodes)-[*0..3]->(x)
+      WITH tail(nodes(p)) AS nodes
+      RETURN nodes, all(x IN nodes WHERE x.name = 'a') AS result
+      """
+    Then the result should be, in any order:
+      | nodes                                                  | result |
+      | []                                                     | true   |
+      | [(:A {name: 'a'})]                                     | true   |
+      | [(:A {name: 'a'}), (:A {name: 'a'})]                   | true   |
+      | [(:A {name: 'a'}), (:A {name: 'a'}), (:A {name: 'a'})] | true   |
+      | [(:A {name: 'a'}), (:A {name: 'a'}), (:B {name: 'b'})] | false  |
+      | [(:A {name: 'a'}), (:B {name: 'b'})]                   | false  |
+      | [(:A {name: 'a'}), (:B {name: 'b'}), (:A {name: 'a'})] | false  |
+      | [(:A {name: 'a'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
+      | [(:B {name: 'b'})]                                     | false  |
+      | [(:B {name: 'b'}), (:A {name: 'a'})]                   | false  |
+      | [(:B {name: 'b'}), (:A {name: 'a'}), (:A {name: 'a'})] | false  |
+      | [(:B {name: 'b'}), (:A {name: 'a'}), (:B {name: 'b'})] | false  |
+      | [(:B {name: 'b'}), (:B {name: 'b'})]                   | false  |
+      | [(:B {name: 'b'}), (:B {name: 'b'}), (:A {name: 'a'})] | false  |
+      | [(:B {name: 'b'}), (:B {name: 'b'}), (:B {name: 'b'})] | false  |
+    And no side effects
+
+  Scenario: [8] All quantifier on list containing relationships
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (s1:SRelationships), (s2:SNodes)
+      CREATE (a:A {name: 'a'}), (b:B {name: 'b'})
+      CREATE (aa:A {name: 'a'}), (ab:B {name: 'b'}),
+             (ba:A {name: 'a'}), (bb:B {name: 'b'})
+      CREATE (aaa:A {name: 'a'}), (aab:B {name: 'b'}),
+             (aba:A {name: 'a'}), (abb:B {name: 'b'}),
+             (baa:A {name: 'a'}), (bab:B {name: 'b'}),
+             (bba:A {name: 'a'}), (bbb:B {name: 'b'})
+      CREATE (s1)-[:I]->(s2),
+             (s2)-[:RA {name: 'a'}]->(a), (s2)-[:RB {name: 'b'}]->(b)
+      CREATE (a)-[:RA {name: 'a'}]->(aa), (a)-[:RB {name: 'b'}]->(ab),
+             (b)-[:RA {name: 'a'}]->(ba), (b)-[:RB {name: 'b'}]->(bb)
+      CREATE (aa)-[:RA {name: 'a'}]->(aaa), (aa)-[:RB {name: 'b'}]->(aab),
+             (ab)-[:RA {name: 'a'}]->(aba), (ab)-[:RB {name: 'b'}]->(abb),
+             (ba)-[:RA {name: 'a'}]->(baa), (ba)-[:RB {name: 'b'}]->(bab),
+             (bb)-[:RA {name: 'a'}]->(bba), (bb)-[:RB {name: 'b'}]->(bbb)
+      """
+    When executing query:
+      """
+      MATCH p = (:SRelationships)-[*0..4]->(x)
+      WITH tail(relationships(p)) AS relationships, COUNT(*) AS c
+      RETURN relationships, all(x IN relationships WHERE x.name = 'a') AS result
+      """
+    Then the result should be, in any order:
+      | relationships                                             | result |
+      | []                                                        | true   |
+      | [[:RA {name: 'a'}]]                                       | true   |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}]]                    | true   |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}], [:RA {name: 'a'}]] | true   |
+      | [[:RA {name: 'a'}], [:RA {name: 'a'}], [:RB {name: 'b'}]] | false  |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}]]                    | false  |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}], [:RA {name: 'a'}]] | false  |
+      | [[:RA {name: 'a'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
+      | [[:RB {name: 'b'}]]                                       | false  |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}]]                    | false  |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}], [:RA {name: 'a'}]] | false  |
+      | [[:RB {name: 'b'}], [:RA {name: 'a'}], [:RB {name: 'b'}]] | false  |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}]]                    | false  |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RA {name: 'a'}]] | false  |
+      | [[:RB {name: 'b'}], [:RB {name: 'b'}], [:RB {name: 'b'}]] | false  |
+    And no side effects
+
+  Scenario Outline: [9] All quantifier on lists containing nulls
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                    | condition | result |
+      | [null]                  | x = 2     | null   |
+      | [null, null]            | x = 2     | null   |
+      | [0, null]               | x = 2     | false  |
+      | [2, null]               | x = 2     | null   |
+      | [null, 2]               | x = 2     | null   |
+      | [34, 0, null, 5, 900]   | x < 10    | false  |
+      | [34, 10, null, 15, 900] | x < 10    | false  |
+      | [4, 0, null, -15, 9]    | x < 10    | null   |
+
+  Scenario Outline: [10] All quantifier with IS NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE x IS NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | true   |
+      | [0]                      | false  |
+      | [34, 0, 8, 900]          | false  |
+      | [null]                   | true   |
+      | [null, null]             | true   |
+      | [0, null]                | false  |
+      | [2, null]                | false  |
+      | [null, 2]                | false  |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | true   |
+
+  Scenario Outline: [11] All quantifier with IS NOT NULL predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE x IS NOT NULL) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                     | result |
+      | []                       | true   |
+      | [0]                      | true   |
+      | [34, 0, 8, 900]          | true   |
+      | [null]                   | false  |
+      | [null, null]             | false  |
+      | [0, null]                | false  |
+      | [2, null]                | false  |
+      | [null, 2]                | false  |
+      | [34, 0, null, 8, 900]    | false  |
+      | [34, 0, null, 8, null]   | false  |
+      | [null, 123, null, null]  | false  |
+      | [null, null, null, null] | false  |
+
+  Scenario Outline: [12] All quantifier can nest itself and other quantifiers
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | list                      | condition                      | result |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'ghi')   | true   |
+      | [['abc'], ['abc', 'def']] | none(y IN x WHERE y = 'def')   | false  |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'abc') | true   |
+      | [['abc'], ['abc', 'def']] | single(y IN x WHERE y = 'ghi') | false  |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'abc')    | true   |
+      | [['abc'], ['abc', 'def']] | any(y IN x WHERE y = 'ghi')    | false  |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y <> 'ghi')   | true   |
+      | [['abc'], ['abc', 'def']] | all(y IN x WHERE y = 'abc')    | false  |
+
+  Scenario: [13] All quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH all(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [14] All quantifier is always true if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH all(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [15] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH all(x IN list WHERE <predicate>) = none(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [16] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH all(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [16] Fail all quantifier on type mismatch between list elements and predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN <list> WHERE <condition>) AS result
+      """
+    Then a SyntaxError should be raised at compile time: InvalidArgumentType
+
+    Examples:
+      | list                              | condition |
+      | ['Clara']                         | x % 2 = 0 |
+      | [false, true]                     | x % 2 = 0 |
+      | ['Clara', 'Bob', 'Dave', 'Alice'] | x % 2 = 0 |
+      # add examples with heterogeneously-typed lists

--- a/tck/features/expressions/quantifier/Quantifier5.feature
+++ b/tck/features/expressions/quantifier/Quantifier5.feature
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier1 - None quantifier interop
+
+  Scenario Outline: [1] None quantifier can nest itself and other quantifiers on nested lists
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                      | result |
+      | none(y IN x WHERE y = 'abc')   | true   |
+      | none(y IN x WHERE y = 'ghi')   | false  |
+      | single(y IN x WHERE y = 'ghi') | true   |
+      | single(y IN x WHERE y = 'abc') | false  |
+      | any(y IN x WHERE y = 'ghi')    | true   |
+      | any(y IN x WHERE y = 'abc')    | false  |
+      | all(y IN x WHERE y = 'def')    | true   |
+      | all(y IN x WHERE y = 'abc')    | false  |
+
+  Scenario Outline: [2] None quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN none(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                              | result |
+      | none(y IN list WHERE x <= y)           | true   |
+      | none(y IN list WHERE x < y)            | false  |
+      | single(y IN list WHERE abs(x - y) < 3) | true   |
+      | single(y IN list WHERE x + y = 15)     | false  |
+      | any(y IN list WHERE x + y < 2)         | true   |
+      | any(y IN list WHERE x + y <= 3)        | false  |
+      | all(y IN list WHERE x < y)             | true   |
+      | all(y IN list WHERE x <= y)            | false  |
+
+  Scenario Outline: [3] None quantifier is equal the boolean negative of the any quantifier
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>)) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [4] None quantifier is equal the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] None quantifier is equal whether the size of the list filtered with same the predicate is zero
+    Given any graph
+    When executing query:
+      """
+      RETURN none([1, 2, 3, 4, 5, 6, 7, 8, 9] IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier5.feature
+++ b/tck/features/expressions/quantifier/Quantifier5.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Quantifier1 - None quantifier interop
+Feature: Quantifier5 - None quantifier interop
 
   Scenario Outline: [1] None quantifier can nest itself and other quantifiers on nested lists
     Given any graph
@@ -117,7 +117,7 @@ Feature: Quantifier1 - None quantifier interop
     Given any graph
     When executing query:
       """
-      RETURN none([1, 2, 3, 4, 5, 6, 7, 8, 9] IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result
+      RETURN none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = 0) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier5.feature
+++ b/tck/features/expressions/quantifier/Quantifier5.feature
@@ -1,0 +1,173 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier5 - None quantifier invariants
+
+  Scenario: [1] None quantifier is always true if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH none(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario: [2] None quantifier is always false if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH none(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario Outline: [3] None quantifier is always equal the boolean negative of the any quantifier
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH none(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [4] None quantifier is always equal the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH none(x IN list WHERE <predicate>) = all(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] None quantifier is always equal whether the size of the list filtered with same the predicate is zero
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH none(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 0) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier6.feature
+++ b/tck/features/expressions/quantifier/Quantifier6.feature
@@ -1,0 +1,127 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier6 - Single quantifier invariants
+
+  Scenario: [1] Single quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH single(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [2] Single quantifier is always false if the predicate is statically true and the list has more than one element
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 1
+      WITH single(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [3] Single quantifier is always true if the predicate is statically true and the list has exactly one non-null element
+    Given any graph
+    When executing query:
+      """
+      WITH [1, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS element
+      WITH single(x IN [element] WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [4] Single quantifier is always equal whether the size of the list filtered with same the predicate is one
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH single(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = 1) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier6.feature
+++ b/tck/features/expressions/quantifier/Quantifier6.feature
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier6 - Single quantifier interop
+
+  Scenario Outline: [1] Single quantifier can nest itself and other quantifiers on nested lists
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                      | result |
+      | none(y IN x WHERE y = 'def')   | true   |
+      | none(y IN x WHERE y = 'ghi')   | false  |
+      | single(y IN x WHERE y = 'def') | true   |
+      | single(y IN x WHERE y = 'abc') | false  |
+      | any(y IN x WHERE y = 'def')    | true   |
+      | any(y IN x WHERE y = 'abc')    | false  |
+      | all(y IN x WHERE y = 'abc')    | true   |
+      | all(y IN x WHERE y = 'def')    | false  |
+
+  Scenario Outline: [2] Single quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN single(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                           | result |
+      | none(y IN list WHERE x < y)         | true   |
+      | none(y IN list WHERE x % y = 0)     | false  |
+      | single(y IN list WHERE x + y < 5)   | true   |
+      | single(y IN list WHERE x % y = 1)   | false  |
+      | any(y IN list WHERE 2 * x + y > 25) | true   |
+      | any(y IN list WHERE x < y)          | false  |
+      | all(y IN list WHERE x <= y)         | true   |
+      | all(y IN list WHERE x <= y + 1)     | false  |
+
+  Scenario Outline: [3] Single quantifier is equal whether the size of the list filtered with same the predicate is one
+    Given any graph
+    When executing query:
+      """
+      RETURN single(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = 1) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier7.feature
+++ b/tck/features/expressions/quantifier/Quantifier7.feature
@@ -1,0 +1,153 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier7 - Any quantifier interop
+
+  Scenario Outline: [1] Any quantifier can nest itself and other quantifiers on nested lists
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                      | result |
+      | none(y IN x WHERE y = 'def')   | true   |
+      | none(y IN x WHERE y = 'abc')   | false  |
+      | single(y IN x WHERE y = 'def') | true   |
+      | single(y IN x WHERE y = 'ghi') | false  |
+      | any(y IN x WHERE y = 'abc')    | true   |
+      | any(y IN x WHERE y = 'ghi')    | false  |
+      | all(y IN x WHERE y = 'abc')    | true   |
+      | all(y IN x WHERE y = 'def')    | false  |
+
+  Scenario Outline: [2] Any quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN any(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                         | result |
+      | none(y IN list WHERE x = y * y)   | true   |
+      | none(y IN list WHERE x % y = 0)   | false  |
+      | single(y IN list WHERE x = y * y) | true   |
+      | single(y IN list WHERE x < y * y) | false  |
+      | any(y IN list WHERE x = y)        | true   |
+      | any(y IN list WHERE x = 10 * y)   | false  |
+      | all(y IN list WHERE x <= y)       | true   |
+      | all(y IN list WHERE x < y)        | false  |
+
+  Scenario Outline: [3] Any quantifier is true if the single or the all quantifier is true
+    Given any graph
+    When executing query:
+      """
+      RETURN (single(<operands>) OR all(<operands>)) <= any(<operands>) AS result
+      """
+    # Note that FALSE is less than TRUE, hence A <= B is effectively equivalent to the implication A -> B
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | operands                                         |
+      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x = 2     |
+      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x % 2 = 0 |
+      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x % 3 = 0 |
+      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x < 7     |
+      | x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE x >= 3    |
+
+  Scenario Outline: [4] Any quantifier is equal the boolean negative of the none quantifier
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>)) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] Any quantifier is equal the boolean negative of the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>))) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [6] Any quantifier is equal whether the size of the list filtered with same the predicate is grater zero
+    Given any graph
+    When executing query:
+      """
+      RETURN any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) > 0) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier7.feature
+++ b/tck/features/expressions/quantifier/Quantifier7.feature
@@ -1,0 +1,209 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier7 - Any quantifier invariants
+
+  Scenario: [1] Any quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH any(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [2] Any quantifier is always true if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH any(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [3] Any quantifier is always true if the single or the all quantifier is true
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH list WHERE single(<operands>) OR all(<operands>)
+      WITH any(<operands>) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | operands                  |
+      | x IN list WHERE x = 2     |
+      | x IN list WHERE x % 2 = 0 |
+      | x IN list WHERE x % 3 = 0 |
+      | x IN list WHERE x < 7     |
+      | x IN list WHERE x >= 3    |
+
+  Scenario Outline: [4] Any quantifier is always equal the boolean negative of the none quantifier
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT none(x IN list WHERE <predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] Any quantifier is always equal the boolean negative of the all quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH any(x IN list WHERE <predicate>) = (NOT all(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [6] Any quantifier is always equal whether the size of the list filtered with same the predicate is grater zero
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH any(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) > 0) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier8.feature
+++ b/tck/features/expressions/quantifier/Quantifier8.feature
@@ -1,0 +1,173 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier8 - All quantifier invariants
+
+  Scenario: [1] All quantifier is always false if the predicate is statically false and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH all(x IN list WHERE false) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | false  |
+    And no side effects
+
+  Scenario: [2] All quantifier is always true if the predicate is statically true and the list is not empty
+    Given any graph
+    When executing query:
+      """
+      WITH [1, null, true, 4.5, 'abc', false, '', [234, false], {a: null, b: true, c: 15.2}, {}, [], [null], [[{b: [null]}]]] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH list WHERE size(list) > 0
+      WITH all(x IN list WHERE true) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+  Scenario Outline: [3] All quantifier is always equal the none quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH all(x IN list WHERE <predicate>) = none(x IN list WHERE NOT (<predicate>)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [4] All quantifier is always equal the boolean negative of the any quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS inputList
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH all(x IN list WHERE <predicate>) = (NOT any(x IN list WHERE NOT (<predicate>))) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] All quantifier is always equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
+    Given any graph
+    When executing query:
+      """
+      UNWIND [{list: [2], fixed: true},
+              {list: [6], fixed: true},
+              {list: [7], fixed: true},
+              {list: [1, 2, 3, 4, 5, 6, 7, 8, 9], fixed: false}] AS input
+      WITH CASE WHEN input.fixed THEN input.list ELSE null END AS fixedList,
+           CASE WHEN NOT input.fixed THEN input.list ELSE [1] END AS inputList
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      UNWIND inputList AS x
+      WITH fixedList, inputList, x, [ y IN inputList WHERE rand() > 0.5 | y] AS list
+      WITH fixedList, inputList, CASE WHEN rand() < 0.5 THEN reverse(list) ELSE list END + x AS list
+      WITH coalesce(fixedList, list) AS list
+      WITH all(x IN list WHERE <predicate>) = (size([x IN list WHERE <predicate> | x]) = size(list)) AS result, count(*) AS cnt
+      RETURN result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier8.feature
+++ b/tck/features/expressions/quantifier/Quantifier8.feature
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2015-2021 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: Quantifier8 - All quantifier interop
+
+  Scenario Outline: [1] All quantifier can nest itself and other quantifiers on nested lists
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN [['abc'], ['abc', 'def']] WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                      | result |
+      | none(y IN x WHERE y = 'ghi')   | true   |
+      | none(y IN x WHERE y = 'def')   | false  |
+      | single(y IN x WHERE y = 'abc') | true   |
+      | single(y IN x WHERE y = 'ghi') | false  |
+      | any(y IN x WHERE y = 'abc')    | true   |
+      | any(y IN x WHERE y = 'ghi')    | false  |
+      | all(y IN x WHERE y <> 'ghi')   | true   |
+      | all(y IN x WHERE y = 'abc')    | false  |
+
+  Scenario Outline: [2] All quantifier can nest itself and other quantifiers on the same list
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5, 6, 7, 8, 9] AS list
+      RETURN all(x IN list WHERE <condition>) AS result
+      """
+    Then the result should be, in any order:
+      | result   |
+      | <result> |
+    And no side effects
+
+    Examples:
+      | condition                            | result |
+      | none(y IN list WHERE x = 10 * y)     | true   |
+      | none(y IN list WHERE x = y)          | false  |
+      | single(y IN list WHERE x = y)        | true   |
+      | single(y IN list WHERE x < y)        | false  |
+      | any(y IN list WHERE x % y = 0)       | true   |
+      | any(y IN list WHERE x < y)           | false  |
+      | all(y IN list WHERE abs(x - y) < 10) | true   |
+      | all(y IN list WHERE x < y + 7)       | false  |
+
+  Scenario Outline: [3] All quantifier is equal the none quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = none(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>)) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [4] All quantifier is equal the boolean negative of the any quantifier on the boolean negative of the predicate
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (NOT any(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE NOT (<predicate>))) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |
+
+  Scenario Outline: [5] All quantifier is equal whether the size of the list filtered with same the predicate is equal the size of the unfiltered list
+    Given any graph
+    When executing query:
+      """
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = size(list)) AS result
+      """
+    Then the result should be, in any order:
+      | result |
+      | true   |
+    And no side effects
+
+    Examples:
+      | predicate |
+      | x = 2     |
+      | x % 2 = 0 |
+      | x % 3 = 0 |
+      | x < 7     |
+      | x >= 3    |

--- a/tck/features/expressions/quantifier/Quantifier8.feature
+++ b/tck/features/expressions/quantifier/Quantifier8.feature
@@ -117,7 +117,7 @@ Feature: Quantifier8 - All quantifier interop
     Given any graph
     When executing query:
       """
-      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = size(list)) AS result
+      RETURN all(x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate>) = (size([x IN [1, 2, 3, 4, 5, 6, 7, 8, 9] WHERE <predicate> | x]) = size([1, 2, 3, 4, 5, 6, 7, 8, 9])) AS result
       """
     Then the result should be, in any order:
       | result |

--- a/tck/features/expressions/quantifier/Quantifier9.feature
+++ b/tck/features/expressions/quantifier/Quantifier9.feature
@@ -28,7 +28,7 @@
 
 #encoding: utf-8
 
-Feature: Quantifier5 - None quantifier invariants
+Feature: Quantifier9 - None quantifier invariants
 
   Scenario: [1] None quantifier is always true if the predicate is statically false and the list is not empty
     Given any graph


### PR DESCRIPTION
This PR adds scenarios for quantifier expressions to the respective features, specifically:

- scenarios for `none(...)` to `expression/quantifier/Quantifier1`,
- scenarios for `single(...)` to `expression/quantifier/Quantifier2`,
- scenarios for `any(...)` to `expression/quantifier/Quantifier3`, and
- scenarios for `all(...)` to `expression/quantifier/Quantifier4`.

For each quantifier, the scenarios test:

- quantifier behavior on empty list
- quantifier behavior on list containing booleans
- quantifier behavior on list containing integers
- quantifier behavior on list containing floats
- quantifier behavior on list containing strings
- quantifier behavior on list containing lists
- quantifier behavior on list containing maps
- quantifier behavior on list containing nodes
- quantifier behavior on list containing relationships
- quantifier behavior on list containing nulls
- quantifier behavior with `IS [NOT] NULL` predicate
- quantifier behavior with predicate containing also a quantifier on nested lists
- quantifier behavior with predicate containing also a quantifier on the same list
- quantifier behavior if predicate is statically `true`/`false`
- quantifier invariants with regard to other quantifiers (e.g. ∃ _x_ ∈ _list_ : _pred_(_x_) = ¬∀ _x_ ∈ _list_ : ¬ _pred_(_x_))
- quantifier invariants with regard to cardinality of the list filter by the predicate (e.g. (∀ _x_ ∈ _list_ : _pred_(_x_)) = (card([_x_ ∈ _list_ | _pred_(_x_) ]) = card(|_list_|))
- quantifier error on type mismatch between list elements and predicate

