### PR TITLE
Fixing YIELD grammar

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -262,16 +262,14 @@
   </production>
 
   <production name="StringOperatorExpression" rr:inline="true">
-    <seq>
-      <alt>
-        <non-terminal ref="RegularExpression"/>
-        <seq>&SP; STARTS &SP; WITH</seq>
-        <seq>&SP; ENDS &SP; WITH</seq>
-        <seq>&SP; CONTAINS</seq>
-      </alt>
-      &WS;
-      <non-terminal ref="PropertyOrLabelsExpression"/>
-    </seq>
+    <alt>
+      <non-terminal ref="RegularExpression"/>
+      <seq>&SP; STARTS &SP; WITH</seq>
+      <seq>&SP; ENDS &SP; WITH</seq>
+      <seq>&SP; CONTAINS</seq>
+    </alt>
+    &WS;
+    <non-terminal ref="PropertyOrLabelsExpression"/>
   </production>
 
   <production name="NullOperatorExpression" rr:inline="true">
@@ -282,7 +280,7 @@
   </production>
 
   <production name="RegularExpression" oc:legacy="true">
-    <seq>&WS; =~</seq>
+    &WS; =~
   </production>
 
   <production name="PropertyOrLabelsExpression" rr:inline="true">
@@ -336,7 +334,7 @@
   </production>
 
   <production name="ListLiteral">
-    <seq> [ &WS; <opt> &expr; &WS; <repeat> , &WS; &expr; &WS; </repeat> </opt> ] </seq>
+    [ &WS; <opt> &expr; &WS; <repeat> , &WS; &expr; &WS; </repeat> </opt> ]
   </production>
 
   <production name="Reduce" rr:inline="true" oc:legacy="true">
@@ -570,10 +568,8 @@
   </production>
 
   <production name="OctalInteger" oc:lexer="true">
-    <seq>
-      <non-terminal ref="ZeroDigit"/>
-      <repeat min="1"><non-terminal ref="OctDigit"/></repeat>
-    </seq>
+    <non-terminal ref="ZeroDigit"/>
+    <repeat min="1"><non-terminal ref="OctDigit"/></repeat>
   </production>
 
   <production name="HexLetter" oc:lexer="true">
@@ -640,11 +636,9 @@
   </production>
 
   <production name="RegularDecimalReal" oc:lexer="true">
-    <seq>
-      <repeat><non-terminal ref="Digit"/></repeat>
-      .
-      <repeat min="1"><non-terminal ref="Digit"/></repeat>
-    </seq>
+    <repeat><non-terminal ref="Digit"/></repeat>
+    .
+    <repeat min="1"><non-terminal ref="Digit"/></repeat>
   </production>
 
   <!-- \ EXPRESSIONS / -->

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -206,11 +206,11 @@
   </production>
 
   <production name="Create">
-    <seq>CREATE &WS; <non-terminal ref="Pattern"/></seq>
+    CREATE &WS; <non-terminal ref="Pattern"/>
   </production>
 
   <production name="CreateUnique" oc:legacy="true">
-    <seq>CREATE &SP; UNIQUE &WS; <non-terminal ref="Pattern"/></seq>
+    CREATE &SP; UNIQUE &WS; <non-terminal ref="Pattern"/>
   </production>
 
   <production name="Set">
@@ -230,11 +230,9 @@
   </production>
 
   <production name="Delete">
-    <seq>
-      <opt>DETACH &SP;</opt>
-      DELETE &WS; &expr;
-      <repeat>&WS; , &WS; &expr;</repeat>
-    </seq>
+    <opt>DETACH &SP;</opt>
+    DELETE &WS; &expr;
+    <repeat>&WS; , &WS; &expr;</repeat>
   </production>
 
   <production name="Remove">
@@ -287,18 +285,14 @@
 
 
   <production name="With" scope:rule="new">
-    <seq>
-      WITH
-      <non-terminal ref="ProjectionBody"/>
-      <opt>&WS;<non-terminal ref="Where"/></opt>
-    </seq>
+    WITH
+    <non-terminal ref="ProjectionBody"/>
+    <opt>&WS;<non-terminal ref="Where"/></opt>
   </production>
 
   <production name="Return">
-    <seq>
-      RETURN
-      <non-terminal ref="ProjectionBody"/>
-    </seq>
+    RETURN
+    <non-terminal ref="ProjectionBody"/>
   </production>
 
   <production name="ProjectionBody">
@@ -337,7 +331,7 @@
   </production>
 
   <production name="SortItem" rr:inline="true">
-    <seq>&expr; <opt>&WS; <alt>ASCENDING ASC DESCENDING DESC</alt></opt></seq>
+    &expr; <opt>&WS; <alt>ASCENDING ASC DESCENDING DESC</alt></opt>
   </production>
 
   <production name="Hint" oc:legacy="true">

--- a/grammar/cypher.xml
+++ b/grammar/cypher.xml
@@ -254,39 +254,35 @@
   </production>
 
   <production name="InQueryCall">
-    <seq>
-      CALL &SP;
-      <non-terminal ref="ExplicitProcedureInvocation"/>
-      <opt>&WS; YIELD &SP; <non-terminal ref="YieldItems"/></opt>
-    </seq>
+    CALL &SP;
+    <non-terminal ref="ExplicitProcedureInvocation"/>
+    <opt>&WS; YIELD &SP; <non-terminal ref="YieldItems"/></opt>
   </production>
 
   <production name="StandaloneCall">
-    <seq>
-      CALL &SP;
+    CALL &SP;
+    <alt>
+      <non-terminal ref="ExplicitProcedureInvocation"/>
+      <non-terminal ref="ImplicitProcedureInvocation"/>
+    </alt>
+    <opt>
+      &WS; YIELD &SP;
       <alt>
-        <non-terminal ref="ExplicitProcedureInvocation"/>
-        <non-terminal ref="ImplicitProcedureInvocation"/>
+        *
+        <non-terminal ref="YieldItems"/>
       </alt>
-      <opt>&SP; YIELD &SP; <non-terminal ref="YieldItems"/></opt>
-    </seq>
+    </opt>
   </production>
 
   <production name="YieldItems" rr:inline="true">
-    <seq>
-      <alt>
-        *
-        <seq>
-          <non-terminal ref="YieldItem"/>
-          <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat>
-        </seq>
-      </alt>
-      <opt>&WS; <non-terminal ref="Where"/></opt>
-    </seq>
+    <non-terminal ref="YieldItem"/>
+    <repeat>&WS; , &WS;<non-terminal ref="YieldItem"/></repeat>
+    <opt>&WS; <non-terminal ref="Where"/></opt>
   </production>
 
   <production name="YieldItem" rr:inline="true">
-    <seq><opt><non-terminal ref="ProcedureResultField"/> &SP; AS &SP;</opt> &var;</seq>
+    <opt><non-terminal ref="ProcedureResultField"/> &SP; AS &SP;</opt>
+    &var;
   </production>
 
 

--- a/tck/features/clauses/call/Call5.feature
+++ b/tck/features/clauses/call/Call5.feature
@@ -133,3 +133,40 @@ Feature: Call5 - Results projection
       RETURN c
       """
     Then a SyntaxError should be raised at compile time: VariableAlreadyBound
+
+  @skipGrammarCheck
+  Scenario: [7] Fail on in-query call to procedure with YIELD *
+    Given an empty graph
+    And there exists a procedure test.my.proc(name :: STRING?, id :: INTEGER?) :: (city :: STRING?, country_code :: INTEGER?):
+      | name     | id | city      | country_code |
+      | 'Andres' | 1  | 'Malmö'   | 46           |
+      | 'Tobias' | 1  | 'Malmö'   | 46           |
+      | 'Mats'   | 1  | 'Malmö'   | 46           |
+      | 'Stefan' | 1  | 'Berlin'  | 49           |
+      | 'Stefan' | 2  | 'München' | 49           |
+      | 'Petra'  | 1  | 'London'  | 44           |
+    When executing query:
+      """
+      CALL test.my.proc('Stefan', 1) YIELD *
+      RETURN city, country_code
+      """
+    Then a SyntaxError should be raised at compile time: UnexpectedSyntax
+
+  Scenario: [8] Allow standalone call to procedure with YIELD *
+    Given an empty graph
+    And there exists a procedure test.my.proc(name :: STRING?, id :: INTEGER?) :: (city :: STRING?, country_code :: INTEGER?):
+      | name     | id | city      | country_code |
+      | 'Andres' | 1  | 'Malmö'   | 46           |
+      | 'Tobias' | 1  | 'Malmö'   | 46           |
+      | 'Mats'   | 1  | 'Malmö'   | 46           |
+      | 'Stefan' | 1  | 'Berlin'  | 49           |
+      | 'Stefan' | 2  | 'München' | 49           |
+      | 'Petra'  | 1  | 'London'  | 44           |
+    When executing query:
+      """
+      CALL test.my.proc('Stefan', 1) YIELD *
+      """
+    Then the result should be, in order:
+      | city     | country_code |
+      | 'Berlin' | 49           |
+    And no side effects

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -308,7 +308,4 @@ RETURN count(label) AS numLabels§
 CALL db.labels() YIELD label, foo, bar
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
-CALL db.labels() YIELD *
-WHERE label CONTAINS 'User' AND foo + bar = foo
-RETURN count(label) AS numLabels§
 CALL db.labels() YIELD x WHERE label CONTAINS 'User' AND foo + bar = foo RETURN count(label) AS numLabels§


### PR DESCRIPTION
PR this is a reaction to #460.

According to the [CIP on CALL](https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2015-06-24-call-procedures.adoc) standalone procedure calls allow `YIELD *` while in-query procedure calls do not allow it.

This PR encodes this rule for `YIELD *` in the grammar. It also adds two scenarios to the TCK that test the two cases of the rule.

In passing, the PR removes `<seq> ... </seq>` tags that are immediately contained in `<production ...> ... </production>` tags. Productions imply a sequence, hence, such `<seq> ... </seq>` tags are superfluous.

