### PR TITLE
CIP on grouping keys and aggregation expressions

### DIFF
--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -133,7 +133,7 @@ projects each row in the driving table to `b` minus `a` (as `x`) and the product
 
 The WITH and the RETURN clauses also allow ordering and truncating the driving table, but let's ignore these aspects in this CIP.
 
-=== Beyond baseline semantics -- simple rewrite semantics[[simpleRewrite]]
+=== Simple rewrite semantics[[simpleRewrite]]
 
 Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics.
 In particular, they allow mixing aggregation and projection rather freely.
@@ -223,7 +223,7 @@ RETURN x AS x, SUM(sumBC) AS sumBC
 ----
 ====
 
-=== Beyond simple rewrite semantics
+=== Limits of simple rewrite semantics
 
 While this solution works nicely for the considered examples, it is limited.
 Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -10,18 +10,17 @@
 [abstract]
 .Abstract
 --
-
+This CIP clarifies the semantics of grouping and aggregation functionality in the WITH and the RETURN clause of Cypher.
 --
 
 toc::[]
 
 == Background
 
-=== Problem
-
 In this CIP we assume the following baseline semantics as a given and well-defined.
+Further, we consider a simple rewrite semantics for grouping and aggregation, that lays the foundation for the rewrite semantics that is proposed in the <<Proposal>> section of this CIP.
 
-We also assume following driving table in examples:
+We also use following driving table in most of the CIP's examples:
 
 .Example driving table
 |===
@@ -32,7 +31,7 @@ We also assume following driving table in examples:
 |2|3|5
 |===
 
-==== Baseline aggregation
+=== Baseline aggregation
 
 Cypher allows grouping and aggregating (form here on just referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
 
@@ -83,7 +82,7 @@ Grouped the driving table by `a` and computes the sum of all `c` as `sumC` for e
 |===
 ====
 
-==== Baseline projection
+=== Baseline projection
 
 The WITH and the RETURN clause also allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
 
@@ -134,7 +133,7 @@ projects each row in the driving table to `b` minus `a` (as `x`) and the product
 
 The WITH and the RETURN clauses also allow ordering and truncating the driving table, but let's ignore these aspects in this CIP.
 
-==== Beyond baseline semantics -- simple rewrite semantics[[simpleRewrite]]
+=== Beyond baseline semantics -- simple rewrite semantics[[simpleRewrite]]
 
 Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics.
 In particular, they allow mixing aggregation and projection rather freely.
@@ -188,7 +187,7 @@ Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
 * Let `PROJ(_L_)` be `PROJ(_p_~1~), PROJ(_p_~2~), ..., PROJ(_p~N~_)` and
 * Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`
 
-With this the semantics of `RETURN _L_` can be defined as effectively equivalent to
+With this, `RETURN _L_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -196,7 +195,7 @@ WITH PROJ(_L_)
 RETURN AGGR(_L_)
 ----
 
-Analogously, the semantics of `WITH _L_` can be defined as effectively equivalent to
+Analogously, `WITH _L_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -204,16 +203,18 @@ WITH PROJ(_L_)
 WITH AGGR(_L_)
 ----
 
+Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
+
 .Simple rewrite semantics
 ====
-With this semantics, the RETURN clause in <<Q3>>
+With the simple rewrite semantics, the RETURN clause in <<Q3>>
 
 [source, cypher]
 ----
 RETURN b-a AS x, SUM(b*c) AS sumBC`)
 ----
 
-is defined as effectively equivalent to
+is effectively equivalent to
 
 [source, cypher]
 ----
@@ -222,9 +223,7 @@ RETURN x AS x, SUM(sumBC) AS sumBC
 ----
 ====
 
-Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
-
-==== Beyond simple rewrite semantics
+=== Beyond simple rewrite semantics
 
 While this solution works nicely for the considered examples, it is limited.
 Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.
@@ -293,13 +292,15 @@ _None. -- This proposal does not propose and net-new syntax._
 
 === Semantics
 
-The proposed semantics defined as a rewrite to the baseline semantics (similar to <<simpleRewrite,simple rewrite semantics>> discussed above).
+The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<simpleRewrite,simple rewrite semantics>> discussed above).
 The proposed semantics does not cover all queries and hence implies a syntax restriction to rule out queries that are not covered.
 We discuss the rewrite and the syntax restriction in the follow two subsections.
 
 ==== Rewrite
 
-For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_).
+For an expression _ex_, let _AGG_(_ex_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_).
+
+For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_), i.e. _AGG_(_p_) = _AGG_(_postEx_).
 
 The set of <ProjectionItem>s _L_ is split according to _AGG_(_p_) in two cases
 
@@ -323,7 +324,10 @@ Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
 * Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`, and
 * Let `POST_PROJ(_L_)` be `POST_PROJ(_p_~1~), POST_PROJ(_p_~2~), ..., POST_PROJ(_p~N~_)`.
 
-With this the semantics of `RETURN _L_` can be defined as effectively equivalent to
+[IMPORTANT]
+.Rewrite semantics
+====
+`RETURN _L_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -332,7 +336,7 @@ WITH AGGR(_L_)
 RETURN POST_PROJ(_L_)
 ----
 
-Analogously, the semantics of `WITH _L_` can be defined as effectively equivalent to
+Analogously, `WITH _L_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -340,17 +344,18 @@ WITH PRE_PROJ(_L_)
 WITH AGGR(_L_)
 WITH POST_PROJ(_L_)
 ----
+====
 
 .Rewrite semantics
 ====
-With this semantics, the RETURN clause in <<Q4>>
+The RETURN clause in <<Q4>>
 
 [source, cypher]
 ----
 RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
 ----
 
-is defined as effectively equivalent to
+is effectively equivalent to
 
 [source, cypher]
 ----
@@ -360,7 +365,7 @@ RETURN a AS a, (a + foo_1 - foo_2) * 2 AS foo
 ----
 ====
 
-Note that the semantics proposed here also provides for the mixing of projection and aggregation that the <<simpleRewrite,simple rewrite semantics>> covers, i.e. it is a generalization of the simple rewrite semantics.
+Note that the grouping and aggregation semantics also provides for the mixing of projection and aggregation that the <<simpleRewrite,simple rewrite semantics>> covers, i.e. it is a generalization of the simple rewrite semantics.
 
 .Rewrite semantics on simple mixing of projection and aggregation
 ====
@@ -371,7 +376,7 @@ The RETURN clause in <<Q3>>
 RETURN b-a AS x, SUM(b*c) AS sumBC
 ----
 
-is defined as effectively equivalent to
+is effectively equivalent to
 
 [source, cypher]
 ----
@@ -384,11 +389,19 @@ RETURN x AS x, sumBC_1 AS sumBC
 ==== Syntax restriction
 
 The rewrite does not cover all syntactically possible queries.
+Specifically, any <ProjectItems> containing
+
+* an aggregation function and
+* a sub-expression that is
+** outside any contained aggregation function and
+** not constant under the grouping keys
+
+is not rewritten to valid query.
 
 .Aggregation *not* covered by the rewrite
 ====
 
-By the proposed semantics, the RETURN clause
+By the grouping and aggregation semantics, the RETURN clause
 
 .[[Q6]]Q6
 [source, cypher]
@@ -396,7 +409,7 @@ By the proposed semantics, the RETURN clause
 RETURN a AS a, b + SUM(c) * 2 AS foo
 ----
 
-is defined as effectively equivalent to
+is effectively equivalent to
 
 [source, cypher]
 ----
@@ -410,24 +423,181 @@ However, variable `b` has already by removed from the driving table by the previ
 In other words, the proposed rewrite produce invalid query text for <<Q6>>.
 ====
 
+To prevent such invalid rewrites, this CIP imposes a syntax restriction on RETURN and WITH clauses.
 
+Given a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_}, let GROUPING_KEYS(_L_) be the set of all expressions and _ex_ and aliases _a_ in <ProjectionItem>s _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is empty.
 
-// TODO syntactic restriction implied by this semantics
-// - as in https://trello-attachments.s3.amazonaws.com/5b484b125e3c6d756d136739/5ff70a2eb9fa9c57a9dbdc1e/dd4878f225c6facb6e40d700a3bbde7b/Implementation_report.pdf
-// -> The non-aggregating sub-expressions of an expression that contains an aggregation MUST be garanteed to be constant under the grouping key.
-// An implementation expected to detect by any of following situation
-// - The whole sub-expression is part of the explicitly projected grouping key (under left-associative parsing)
-// - Each operand in the sub-expression is either:
-//   - Part of the grouping key from being projected explicitly
-//   - A constant
-//   - A parameter
+For an expression _ex_ and projection list _L_, let CONSTANT(_ex_) hold
 
+* If _ex_ is either
+** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
+** A grouping key (either expression or alias), i.e. _o_ ∈ GROUPING_KEYS(_L_),
+** A constant,
+** A parameter
+* or if _ex_ comprises of sub-expression, it only comprises sub-expression _subEx_ for which CONSTANT(_subEx_) holds.
+
+[IMPORTANT]
+.Syntax restriction
+====
+For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is not empty, CONSTANT(_ex_) shall hold.
+====
+
+.Effect of the restriction
+====
+Under this restriction, <<Q6>> is invalid.
+For sub-expression `b` in <ProjectionItem> `b + foo_1 * 2 AS foo`, _CONSTANT_(`b`) does not hold, since `b` is neither a aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
+====
+
+==== Column order
+
+The rewrite of grouping and aggregation semantics is defined based on sets.
+In the RETURN clause the _L_ is not a set but a list, though.
+However, _L_ is always a list of distinct <ProjectionItem>s since Cypher does not allow repeating the same alias within a list of <ProjectionItem>s.
+As it is straightforward and obvious how to correctly maintain the column order in the rewrite, it is not further elaborated here.
+
+==== Row ordering and pagination
+
+The WITH and the RETURN clause allow to
+
+* order the rows of the result table with the ORDER BY sub-clause and
+* paginate the result table with the SKIP and LIMIT sub-clauses.
+
+Assuming, the baseline semantics includes ORDER BY, SKIP, and LIMIT capabilities, the grouping and aggregation semantics extends a follows:
+
+[IMPORTANT]
+====
+`RETURN _L_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PRE_PROJ(_L_)
+WITH AGGR(_L_)
+RETURN POST_PROJ(_L_) _ORDER-SKIP-LIMIT_
+----
+
+Analogously, `WITH _L_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PRE_PROJ(_L_)
+WITH AGGR(_L_)
+WITH POST_PROJ(_L_) _ORDER-SKIP-LIMIT_
+----
+====
+
+The https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=SortItem[<SortItem>]s in ORDER BY clause contain an expression.
+Since these expressions are effectively evaluate at the same time as all POST_PROJ(_L_) expressions, the syntax restrictions applies.
+
+[IMPORTANT]
+====
+For `WITH _L_ ORDER BY _SI_` and `RETURN _L_ ORDER BY _SI_` and every _ex_ directly contained in a <SortItem> in _SI_, CONSTANT(_ex_) shall hold.
+====
+
+==== Aliasing
+
+This proposal considers all projects have user-given alias.
+Cypher allows to omit the aliases, particularly in the RETURN clause, though.
+However, the alias omission rules are based on the assumptions that an implementation will infer a more or less reasonable alias if the alias is omitted.
+Hence, it is safe for this proposal to assume that all <ProjectionItem>s have an alias.
 
 === Examples
 
+==== Queries valid under the grouping and aggregation semantics
+
+The following clauses are valid under the grouping and aggregation semantics and the syntax restriction it includes.
+For each example we list why it is valid.
+
+. `RETURN 1 + count(*)`
+* The sub-expression `1` is a constant.
+
+. `RETURN 1, 1 + count(*)`
+* The sub-expression `1` is a constant.
+
+. `RETURN $x + count($x)`
+* The sub-expression `$x` is a parameter.
+
+. `RETURN count($x) + $x`
+* The sub-expression `$x` is a parameter.
+
+. `RETURN 1 + count($x) + $x * 7 + sum($x) + 'cake'`
+* The sub-expressions `1`, `2`, and `'cake'` are constants.
+* The sub-expression `$x` is a parameter.
+
+. `MATCH (a) RETURN a.x, 1 + count(a.x)`
+* The sub-expression `1` is a constant.
+
+. `MATCH (a) RETURN a.x, a.x + count(a.x)`
+* The sub-expression `a.x` is a grouping key.
+
+. `MATCH (a) WITH a.x AS ax RETURN ax, ax + count(ax)`
+* The sub-expression `ax` is a grouping key.
+
+. `MATCH (x) RETURN x.a, x.b, x.c, x.a + x.b + count(x) + x.c`
+* The sub-expressions `x.a`, `x.b`, and `x.c` are grouping keys.
+
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x)`
+* The sub-expression `a.x + 1` is a grouping key.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax)`
+* The sub-expression `ax` is a grouping key.
+* The sub-expression `1` is a constant.
+
+. `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b)`
+* The sub-expression `map.a` is a grouping key.
+
+. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x)`
+* The sub-expression `x.a + x.b + x.c` is a grouping key.
+
+. `MATCH (x) WITH x.a + x.b + x.c AS sum RETURN sum, sum + count(*) + sum`
+* The sub-expression `sum` is a grouping key.
+
+==== Queries invalid under the grouping and aggregation semantics
+
+The following clauses are invalid under the grouping and aggregation semantics and the syntax restriction it includes.
+For each example we list why it is invalid.
+
+. `MATCH (a) RETURN a.x + count(*)`
+* The sub-expression `a.x` is not a grouping key.
+
+. `MATCH (a) RETURN a.x + a.y + count(*) + a.z`
+* The sub-expressions `a.x + a.y` and `a.z` are not grouping keys.
+
+. `MATCH (a) WITH a.x AS ax, a.y AS ay RETURN ax, count(ax) + ay`
+* The sub-expression `ay` is not a grouping key.
+
+. `MATCH path=(a)-[*]-() RETURN length(path) + count(a)`
+* The sub-expression `length(path)` is not a grouping key.
+
+. `WITH {a:1, b:2} AS map RETURN map.a, map.b + count(map.b)`
+* The sub-expression `map.b` is not a grouping key.
+
+. `MATCH (a) RETURN a.x + a.y, a.x + collect(a.x)`
+* The sub-expression `a.x` is not a grouping key.
+
+. `MATCH (a) RETURN a.x * a.x, a.x + collect(a.x)`
+* The sub-expression `a.x` is not a grouping key.
 
 == What others do
 
+All other major query language explicitly delineate grouping key expressions.
+
+For instance, SQL does so by requiring users to list all grouping key expressions in the GROUP BY clause.
+If the GROUP BY clause is present in a query, the projection in the SELECT clause have to fulfill a similar syntax restriction as defined by this CIP.
+The SQL-equivalent of <<Q6>>
+
+[source, sql]
+----
+SELECT a AS a, b + SUM(c) * 2 AS foo
+FROM A
+GROUP BY a
+----
+
+is invalid in SQL as well.
+For instance, PostgreSQL v13 rejects this query with
+
+----
+error: column "a.b" must appear in the GROUP BY clause or be used in an aggregate function
+----
 
 == Benefits to this proposal
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -621,7 +621,7 @@ RETURN a AS a, (b - b) + SUM(c) AS foo
 ----
 
 is ruled out by the syntax restriction, although sub-expression `(b - b)` is effectively constant.
-It is imaginable that an semantic analyser may figure that `(b - b)` can be simplified to `0` if `b` is know to be numeric, so that the clause effectively is equivalent to
+It is imaginable that a semantic analyser may figure that `(b - b)` can be simplified to `0` if `b` is know to be numeric, so that the clause effectively is equivalent to
 
 [source, cypher]
 ----

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -601,6 +601,36 @@ error: column "a.b" must appear in the GROUP BY clause or be used in an aggregat
 
 == Benefits to this proposal
 
+The main advantage of this proposal is, that is clarifies the semantics of grouping and aggregation in the WITH and the RETURN clause and removes imprecision of the previously existing semantics (cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]).
 
 == Caveats to this proposal
 
+From a pure logical standpoint, the syntax restriction only has to rule out sub-expressions of aggregating projection items, which are not constant under the grouping keys.
+However, statically inferring all possible constant sub-expressions is not necessarily easy.
+To this effect, the proposed rules of the syntax restriction are a heuristic, which safely identifies sub-expression that are constant under the grouping keys, but can not identify all such expression theoretically possible.
+
+.Logically correct aggregation ruled out by the syntax restriction
+====
+
+The RETURN clause
+
+.[[Q7]]Q7
+[source, cypher]
+----
+RETURN a AS a, (b - b) + SUM(c) AS foo
+----
+
+is ruled out by the syntax restriction, although sub-expression `(b - b)` is effectively constant.
+It is imaginable that an semantic analyser may figure that `(b - b)` can be simplified to `0` if `b` is know to be numeric, so that the clause effectively is equivalent to
+
+[source, cypher]
+----
+RETURN a AS a, SUM(c) AS foo
+----
+
+which is perfectly valid.
+====
+
+The proposal tries to strike a balance between allowing good number of useful queries while keeping the rules of the syntax restrict reasonable simple.
+
+Also note: For queries that are logically possible but rejected by the syntax restriction, users can always manually rewrite the query with additional explicit projections to make the query syntactically valid while it still produces the desired result.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -183,8 +183,10 @@ should produce a result that is grouped by `a` and `agg` should be computed for 
 |===
 |a|agg
 
-|1|32 //(1 + (2*3 + 3*4) - 3) * 2
-|2|24 //(2 + (3*5) - 5) * 2
+|1|32
+//(1 + (2*3 + 3*4) - 3) * 2
+|2|24
+//(2 + (3*5) - 5) * 2
 |===
 
 // TODO extend rewrite semantics

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -301,8 +301,8 @@ This proposal does not propose any net-new syntax.
 The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<Simple rewrite semantics>> discussed above).
 The proposed semantics does not cover all syntactically possible queries and hence requires a syntax restriction to prohibit queries that are not covered.
 We discuss the <<Rewrite>> and the <<Syntax restriction>> in the follow two subsections.
-We simplify this discussion by ignoring column order, row ordering and pagination, and omitted aliases.
-Subsequently, we give a separate and brief consideration of how to these aspects fit into the proposal, cf. <<Column order>>, <<Row ordering and pagination>>, and <<Omitted aliases>>, respectively.
+We simplify this discussion by ignoring row ordering and pagination as well as omitted aliases.
+Subsequently, we give a separate and brief consideration of how to these aspects fit into the proposal, cf. <<Row ordering and pagination>> and <<Omitted aliases>>, respectively.
 
 ==== Rewrite
 
@@ -448,13 +448,6 @@ For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ whe
 Under this restriction, <<Q5>> is invalid.
 For sub-expression `b` in <ProjectionItem> `b + foo_1 * 2 AS foo`, _CONSTANT_(`b`) does not hold, since `b` is neither a aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
 ====
-
-==== Column order
-
-The rewrite of grouping and aggregation semantics is defined based on sets.
-In the RETURN clause the _L_ is not a set but a list, though.
-However, _L_ is always a list of distinct <ProjectionItem>s since Cypher does not allow repeating the same alias within a list of <ProjectionItem>s.
-As it is straightforward and obvious how to correctly maintain the column order in the rewrite, it is not further elaborated here.
 
 ==== Row ordering and pagination
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -194,7 +194,7 @@ For a <ProjectionItem> _p_,
 ** Let `_PROJ_(_p_)` be `_ex_ AS _al_` and
 ** Let `_AGGR_(_p_)` be `_agg_(_al_) AS _al_`
 
-With this, `RETURN _p_~1~, _p_~2~, ... _p~N~_` can be defined as effectively equivalent to
+With this, `RETURN _p_~1~, _p_~2~, ..., _p~N~_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -202,7 +202,7 @@ WITH _PROJ_(_p_~1~), _PROJ_(_p_~2~), ..., _PROJ_(_p~N~_)
 RETURN _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
 ----
 
-Analogously, `WITH _p_~1~, _p_~2~, ... _p~N~_` can be defined as effectively equivalent to
+Analogously, `WITH _p_~1~, _p_~2~, ..., _p~N~_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -268,7 +268,7 @@ should produce a result that is grouped by `a` and `foo` should be computed for 
 
 [NOTE]
 ====
-A less artificial example is calculating the total gross of an order as the discounted sum of the net values –– product price multiplied by amount –– of the order's line items in query such as:
+A less artificial example is calculating the total gross of an order as the discounted sum of the net values –– product price multiplied by amount –– of the order's line items in a query such as:
 
 [source, cypher]
 ----
@@ -329,7 +329,7 @@ For a <ProjectionItem> _p_ = `_ex_ AS _al_`,
 [IMPORTANT]
 .Rewrite semantics
 ====
-`RETURN _p_~1~, _p_~2~, ... _p~N~_` is effectively equivalent to
+`RETURN _p_~1~, _p_~2~, ..., _p~N~_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -338,7 +338,7 @@ WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
 RETURN _POST_PROJ_(_p_~1~), _POST_PROJ_(_p_~2~), ..., _POST_PROJ_(_p~N~_)
 ----
 
-Analogously, `WITH _p_~1~, _p_~2~, ... _p~N~_` is effectively equivalent to
+Analogously, `WITH _p_~1~, _p_~2~, ..., _p~N~_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -354,7 +354,7 @@ The RETURN clause in <<Q4>>
 
 [source, cypher]
 ----
-RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
+RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS foo
 ----
 
 is effectively equivalent to
@@ -395,12 +395,12 @@ Specifically, any <ProjectItems> containing
 
 * an aggregation function and
 * a sub-expression that is
-** outside any contained aggregation function and
+** outside any of the contained aggregation functions and
 ** not constant under the grouping keys
 
 is not rewritten to valid query.
 
-.aggregation *not* covered by the rewrite
+.Aggregation *not* covered by the rewrite
 ====
 By the grouping and aggregation semantics, the RETURN clause
 
@@ -420,33 +420,53 @@ RETURN a AS a, b + foo_1 * 2 AS foo
 ----
 
 Note that variable `b` appears in the <ProjectionItem> `b + foo_1 * 2 AS foo` in the RETURN clause.
-However, variable `b` has already by removed from the driving table by the previous projections.
-In other words, the proposed rewrite produce invalid query text for <<Q5>>.
+However, variable `b` has already been removed from the driving table by the previous projections.
+In other words, the proposed rewrite produces an invalid query for <<Q5>>.
 ====
 
-To prevent such invalid rewrites, this CIP imposes a syntax restriction on RETURN and WITH clauses.
+To prevent such invalid rewrites, this proposal includes a syntax restriction to be imposed on RETURN and WITH clauses.
 
-Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_}, let _GROUPING_KEYS_(_L_) be the set of all expressions and _ex_ and aliases _a_ in <ProjectionItem>s _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is empty.
+Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _GROUPING_KEYS_(_L_) be the set of all expressions _ex_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_ where _AGG_(_p_) is empty.
 
-For an expression _ex_ and projection list _L_, let _CONSTANT_(_ex_) hold
+.Grouping keys
+====
+For the RETURN clause
+
+.[[Q6]]Q6
+[source, cypher]
+----
+RETURN b-a AS x, c AS c, c + SUM(b) AS sumBC
+----
+
+_GROUPING_KEYS_(_L_) is {`b-a`, `x`, `c`}.
+
+====
+
+For an expression _ex_ and a projection list _L_, let _CONSTANT_(_ex_, _L_) hold
 
 * If _ex_ is either
 ** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
-** A grouping key (either expression or alias), i.e. _o_ ∈ _GROUPING_KEYS_(_L_),
-** A constant,
+** A grouping key, i.e. _ex_ ∈ _GROUPING_KEYS_(_L_),
+** A constant, or
 ** A parameter,
-* or if _ex_ comprises of sub-expression, it only comprises sub-expression _subEx_ for which _CONSTANT_(_subEx_) holds.
+* or if _ex_ comprises of sub-expressions, it only comprises sub-expressions _subEx_ for which _CONSTANT_(_subEx_, _L_) holds.
 
 [IMPORTANT]
 .Syntax restriction
 ====
-For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is not empty, _CONSTANT_(_ex_) shall hold.
+For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is not empty, _CONSTANT_(_ex_, _L_) shall hold.
 ====
 
-.Effect of the restriction
+.Effect of the syntax restriction
 ====
 Under this restriction, <<Q5>> is invalid.
-For sub-expression `b` in <ProjectionItem> `b + foo_1 * 2 AS foo`, _CONSTANT_(`b`) does not hold, since `b` is neither a aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
+For sub-expression `b`
+
+* in <ProjectionItem> `b + foo_1 * 2 AS foo`
+* in _L_ = `a AS a, b + foo_1 * 2 AS foo`,
+
+_CONSTANT_(`b`, _L_) does not hold.
+`b` is neither an aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
 ====
 
 ==== Row ordering and pagination
@@ -456,49 +476,65 @@ The WITH and the RETURN clause allow to
 * order the rows of the result table with the ORDER BY sub-clause and
 * paginate the result table with the SKIP and LIMIT sub-clauses.
 
-Assuming, the baseline semantics includes ORDER BY, SKIP, and LIMIT capabilities, the grouping and aggregation semantics extends a follows:
+Assuming the baseline semantics includes ORDER BY, SKIP, and LIMIT capabilities, the grouping and aggregation semantics extends as follows:
 
 [IMPORTANT]
 ====
-`RETURN _L_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
+`RETURN _p_~1~, _p_~2~, ..., _p~N~_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH _PRE_PROJ_(_L_)
-WITH _AGGR_(_L_)
-RETURN _POST_PROJ_(_L_) _ORDER-SKIP-LIMIT_
+WITH _PRE_PROJ_(_p_~1~), _PRE_PROJ_(_p_~2~), ..., _PRE_PROJ_(_p~N~_)
+WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
+RETURN _POST_PROJ_(_p_~1~), _POST_PROJ_(_p_~2~), ..., _POST_PROJ_(_p~N~_) _ORDER-SKIP-LIMIT_
 ----
 
-Analogously, `WITH _L_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
+Analogously, `WITH _p_~1~, _p_~2~, ..., _p~N~_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH _PRE_PROJ_(_L_)
-WITH _AGGR_(_L_)
-WITH _POST_PROJ_(_L_) _ORDER-SKIP-LIMIT_
+WITH _PRE_PROJ_(_p_~1~), _PRE_PROJ_(_p_~2~), ..., _PRE_PROJ_(_p~N~_)
+WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
+WITH _POST_PROJ_(_p_~1~), _POST_PROJ_(_p_~2~), ..., _POST_PROJ_(_p~N~_) _ORDER-SKIP-LIMIT_
 ----
 ====
 
-The https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=SortItem[<SortItem>]s in ORDER BY clause contain an expression.
-Since these expressions are effectively evaluate at the same time as all _POST_PROJ_(_L_) expressions, the syntax restrictions applies.
+Every https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=SortItem[<SortItem>] listed in the ORDER BY clause contains an expression.
+Since these expressions are effectively evaluate after all _POST_PROJ_(_p~i~_) expressions, a similar syntax restrictions applies to the <SortItem>s.
+
+However, <SortItem>s can refer to aliases introduced by _POST_PROJ_(_p~i~_).
+
+Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _GROUPING_KEYS_AND_ALIASES_(_L_) be the set of
+
+* all expressions _ex_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_ where _AGG_(_p_) is empty and
+* all aliases _al_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_.
+
+For an expression _ex_ and a projection list _L_, let _AVAILABLE_TO_ORDER_(_ex_, _L_) hold
+
+* If _ex_ is either
+** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
+** A grouping key, i.e. _ex_ ∈ _GROUPING_KEYS_AND_ALIASES_(_L_),
+** A constant, or
+** A parameter,
+* or if _ex_ comprises of sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.
 
 [IMPORTANT]
 ====
-For `WITH _L_ ORDER BY _SI_` and `RETURN _L_ ORDER BY _SI_` and every _ex_ directly contained in a <SortItem> in _SI_, _CONSTANT_(_ex_) shall hold.
+For `WITH _L_ ORDER BY _SI_` and `RETURN _L_ ORDER BY _SI_` and every _ex_ contained in a <SortItem> in _SI_, _AVAILABLE_TO_ORDER_(_ex_, _L_) shall hold.
 ====
 
 ==== Omitted aliases
 
-This proposal considers all projects have user-given alias.
+This proposal considers all <ProjectionItem>s have user-given alias.
 Cypher allows to omit the aliases, particularly in the RETURN clause, though.
-However, the alias omission rules are based on the assumptions that an implementation will infer a more or less reasonable alias if the alias is omitted.
+However, the alias omission rules are based on the assumption that an implementation will infer a more or less reasonable alias if an alias is omitted by the user.
 Hence, it is safe for this proposal to assume that all <ProjectionItem>s have an alias.
 
 === Examples
 
-==== Queries valid under the grouping and aggregation semantics
+==== Valid aggregations
 
-The following clauses are valid under the grouping and aggregation semantics and the syntax restriction it includes.
+The following clauses exhibit valid aggregations under the grouping and aggregation semantics and the syntax restriction it includes.
 For each example we list why it is valid.
 
 . `RETURN 1 + count(*)`
@@ -526,6 +562,12 @@ For each example we list why it is valid.
 . `MATCH (a) WITH a.x AS ax RETURN ax, ax + count(ax)`
 * The sub-expression `ax` is a grouping key.
 
+. `MATCH (a)-[]->(b) RETURN a, a.x + count(b.y)`
+* The sub-expression `a` is a grouping key.
+
+. `MATCH (a)-[]->(b) RETURN a, size(keys(a)) + count(b.y)`
+* The sub-expression `a` is a grouping key.
+
 . `MATCH (x) RETURN x.a, x.b, x.c, x.a + x.b + count(x) + x.c`
 * The sub-expressions `x.a`, `x.b`, and `x.c` are grouping keys.
 
@@ -545,9 +587,9 @@ For each example we list why it is valid.
 . `MATCH (x) WITH x.a + x.b + x.c AS sum RETURN sum, sum + count(*) + sum`
 * The sub-expression `sum` is a grouping key.
 
-==== Queries invalid under the grouping and aggregation semantics
+==== Invalid aggregations
 
-The following clauses are invalid under the grouping and aggregation semantics and the syntax restriction it includes.
+The following clauses exhibit invalid aggregations under the grouping and aggregation semantics and the syntax restriction it includes.
 For each example we list why it is invalid.
 
 . `MATCH (a) RETURN a.x + count(*)`
@@ -570,6 +612,12 @@ For each example we list why it is invalid.
 
 . `MATCH (a) RETURN a.x * a.x, a.x + collect(a.x)`
 * The sub-expression `a.x` is not a grouping key.
+
+. `MATCH (a)-[]->(b) RETURN a AS x, x.x + count(b.y)`
+* The sub-expression `x` is not a grouping key; it is the alias of a grouping key, which are not visible to <ProjectionItem>s within the same clause.
+
+. `MATCH (a)-[]->(b) RETURN a AS x, size(keys(x)) + count(b.y)`
+* The sub-expression `x` is not a grouping key; it is the alias of a grouping key, which are not visible to <ProjectionItem>s within the same clause.
 
 == What others do
 
@@ -599,6 +647,8 @@ The main advantage of this proposal is, that is clarifies the semantics of group
 
 == Caveats to this proposal
 
+=== Rules are heuristic
+
 From a pure logical standpoint, the syntax restriction only has to rule out sub-expressions of aggregating projection items, which are not constant under the grouping keys.
 However, statically inferring all possible constant sub-expressions is not necessarily easy.
 To this effect, the proposed rules of the syntax restriction are a heuristic, which safely identifies sub-expression that are constant under the grouping keys, but can not identify all such expression theoretically possible.
@@ -608,7 +658,7 @@ To this effect, the proposed rules of the syntax restriction are a heuristic, wh
 
 The RETURN clause
 
-.[[Q6]]Q6
+.[[Q7]]Q7
 [source, cypher]
 ----
 RETURN a AS a, (b - b) + SUM(c) AS foo
@@ -628,3 +678,29 @@ which is perfectly valid.
 The proposal tries to strike a balance between allowing good number of useful queries while keeping the rules of the syntax restrict reasonable simple.
 
 Also note: For queries that are logically possible but rejected by the syntax restriction, users can always manually rewrite the query with additional explicit projections to make the query syntactically valid while it still produces the desired result.
+
+=== Containment is imprecise
+
+The openCypher grammar does not encode left- or right-deep precedence for chainable operations, cf.
+
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=OrExpression[<OrExpression>],
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=XorExpression[<XorExpression>],
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=AndExpression[<AndExpression>],
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ComparisonExpression[<ComparisonExpression>],
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=AddOrSubtractExpression[<AddOrSubtractExpression>],
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=MultiplyDivideModuloExpression[<MultiplyDivideModuloExpression>],
+* etc.
+
+The rules of this proposal just refer to "contained sub-expressions".
+Currently, openCypher lacks a clear reference point of what this precisely means.
+
+Most parser technologies result in left- or right-deep parse trees.
+For instance an expression `a+b+c` is typically parsed as `(a+b)+c` or `a+(b+c)`.
+
+Typically, an implementation will decide containment according to its parse tree.
+Hence, one implementation may find `a+b` be contained in `a+b+c` while it finds `b+c` not to be contained in `a+b+c`.
+Another implementation may reach the opposite conclusion w.r.t. containment.
+
+SQL's and GQL's definition of containment does not define containment within repetition, too.
+However, their grammar does not encode chainable operations grammatically with repetition.
+Rather, SQL and GQL use head-recursive grammar productions, which result in a left-deep containment, i.e. `a+b+c` is considered as `(a+b)+c` in these standards.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -4,7 +4,7 @@
 :toc-placement: macro
 :source-highlighter: codemirror
 
-*Authors:* Andrés Taylor <andres@neotechnology.com>, Hannes Voigt <hannes.voigt@neo4j.com>
+*Authors:* Hannes Voigt <hannes.voigt@neo4j.com>
 
 
 [abstract]

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -19,37 +19,9 @@ toc::[]
 
 === Problem
 
-Cypher allows grouping and aggregating (form here on just referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
+In this CIP we assume the following baseline semantics as a given and well-defined.
 
-Formally, the aggregation of a driving table _D_ can be described formally as
-pass:q[γ<sub>_K_, _A_</sub>(D)] where
-
-* _K_ is a (possibly empty) set of grouping keys _k_ and every _k_ is a variable in the driving table _D_, and
-* _A_ is a non-empty set of aggregation functions _agg_(_x_)_ where _x_ being a variable in the driving table _D_
-
-The WITH and the RETURN clause also allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
-
-The projection of a driving table _D_ can be described formally as pass:q[π<sub>_P_</sub>(D)] where
-
-* _P_ is a nonempty set of pair _(ex, al)_ where
-** _ex_ is a tree of operations of the expression sub-language where each of the leaves is either
-*** a constant (such as a value literal or a label),
-*** a parameter, or
-*** a variable in the driving table _D_; and
-** _al_ is variable name -- also called in _alias_ in this context -- that different from all other variables _x_ with (·, _x_) ∈ _P_.
-
-The WITH and the RETURN clauses also allow renaming, ordering and truncating the driving table, but let's ignore these aspects for now.
-
-The WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty list _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>] `_ex_ AS _al_` where _ex_ is an expression and _al_ is an alias.
-The expression of an <ProjectionItem> is allowed to contain aggregation functions.
-Consequently, the semantics of both clause has to specify how _P_, _K_, and _A_ are defined for a given _L_.
-
-It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) the existing semantics or Cypher is imprecise how _P_, _K_, and _A_ are defined for a given _L_.
-This proposal provides a precise semantics.
-
-=== Analysis
-
-Consider a driving table
+We also assume following driving table in examples:
 
 .Example driving table
 |===
@@ -60,15 +32,46 @@ Consider a driving table
 |2|3|5
 |===
 
-and the RETURN clause
+==== Baseline aggregation
 
-.Q1
+Cypher allows grouping and aggregating (form here on just referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
+
+Formally, the aggregation of a driving table _D_ can be described formally as
+pass:q[γ<sub>_K_, _A_</sub>(_D_)] where
+
+* _K_ is a (possibly empty) set of pairs (_k_, _al_) where
+** _k_ is a variable -- called a _grouping key_ -- in the driving table _D_,
+** _al_ is variable name -- also called an _alias_ -- that different from all other aliases _x_ with (·, _x_) ∈ _K_., and
+* _A_ is a non-empty set of triple (_agg_, _x_, _al_) where
+** _agg_ is an aggregation function and
+** _x_ is a variable in the driving table _D_
+** _al_ is variable name -- also called an _alias_ -- that different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ or _x_ with (·, _x_) ∈ _K_.
+
+Assuming _K_ = {(_k_~1~, _ka_~1~), (_k_~2~, _ka_~1~), ..., (_k~N~_, _ka~N~_)} and _A_ = {(_agg_~1~, _x_~1~, _al_~1~), (_agg_~2~, _x_~2~, _al_~2~), ..., (_agg~M~_, _x~M~_, _al~M~_)}, the Cypher equivalent of pass:q[γ<sub>_K_, _A_</sub>(_D_)] is
+
+[source, cypher, subs="quotes"]
+----
+WITH _k_~1~ AS _ka_~1~, _k_~2~ AS _ka_~2~, ..., _k~N~_ AS _ka~N~_,
+     _agg_~1~(_x_~1~) AS _al_~1~, _agg_~2~(_x_~2~) AS _al_~2~, ..., _agg~M~_(_x~M~_) AS _al~M~_
+----
+
+and
+
+[source, cypher, subs="quotes"]
+----
+RETURN _k_~1~ AS _k_~1~, _k_~2~ AS _k_~2~, ..., _k~N~_ AS _k~N~_,
+       _agg_~1~(_x_~1~) AS _al_~1~, _agg_~2~(_x_~2~) AS _al_~2~, ..., _agg~M~_(_x~M~_) AS _al~M~_
+----
+
+Accordingly
+
+.[[Q1]]Q1
 [source, cypher]
 ----
 RETURN a AS a, SUM(c) AS sumC
 ----
 
-Intuitively, it seems clear that the result should be grouped by `a` and the sum of all `c` should be computed as `sumC` for each group, so that result would be:
+Grouped the driving table by `a` and computes the sum of all `c` as `sumC` for each group, so that result is:
 
 .Result Q1
 |===
@@ -78,34 +81,71 @@ Intuitively, it seems clear that the result should be grouped by `a` and the sum
 |2|5
 |===
 
-The RETURN clause
+==== Baseline projection
 
-.Q2
+The WITH and the RETURN clause also allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
+
+The projection of a driving table _D_ can be described formally as π__~P~__(_D_) where
+
+* _P_ is a nonempty set of pairs (_ex_, _al_) where
+** _ex_ is a tree of operations of the expression sub-language where each of the leaves is either
+*** a constant (such as a value literal or a label),
+*** a parameter, or
+*** a variable in the driving table _D_; and
+** _al_ is an _alias_ that different from all other aliases _x_ with (·, _x_) ∈ _P_.
+
+Assuming _P_ = {(_ex_~1~, _al_~1~), (_ex_~2~, _al_~2~), ..., (_ex~N~_, _al~N~_)}, the Cypher equivalent of π__~P~__(_D_) is
+
+[source, cypher, subs="quotes"]
+----
+WITH _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
+----
+
+and
+
+[source, cypher, subs="quotes"]
+----
+RETURN _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
+----
+
+Accordingly, the RETURN clause
+
+.[[Q2]]Q2
 [source, cypher]
 ----
-RETURN a AS a, SUM(b*c) AS sumBC
+RETURN b-a AS x, b*c AS y
 ----
 
-is intuitively clear in the same way.
-The result should be grouped by `a` and the sum of all products of `b` and `c` should be computed as `sumBC` for each group, so that result would be:
+projects each row in the driving table to `b` minus `a` (as `x`) and the product of `b` and `c` (as `y`), so that result is:
 
 .Result Q2
 |===
-|a|sumBC
+|x|y
 
-|1|18
-|2|15
+|1|6
+|2|12
+|1|15
 |===
 
-Similarly, the RETURN clause
+The WITH and the RETURN clauses also allow ordering and truncating the driving table, but let's ignore these aspects in this CIP.
 
-.Q3
+==== Beyond baseline semantics -- simple rewrite semantics
+
+Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics. In particular, they allow mixing aggregation and projection rather freely.
+Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty set _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
+
+* _ex_ is an expression that is allowed to contain aggregation functions and
+* _al_ is an alias.
+
+For instance, the RETURN clause
+
+.[[Q3]]Q3
 [source, cypher]
 ----
 RETURN b-a AS x, SUM(b*c) AS sumBC
 ----
 
-should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of all products of `b` and `c` should be computed as `sumBC` for each group, so that result would be:
+should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of all products of `b` and `c` should be computed as `sumBC` for each group, so that result is:
 
 .Result Q3
 |===
@@ -115,24 +155,29 @@ should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of
 |2|12
 |===
 
-In all three cases, the semantics can be described as follows.
-The set of <ProjectionItem>s _L_ is split in two set _LK_ and _LA_, so that
+The semantics of such an RETURN (and WITH) clause can be described as a rewrite to the two baseline semantics combined by Cypher's linear composition.
 
-* _LA_ are all <ProjectionItem>s `_aggex_ AS _al_` in _L_ that contain an aggregation function, i.e. where _aggex_ is of the form _agg_(_ex_) and _ex_ is a valid expression
-* _LK_ are all remaining <ProjectionItem>s in _L_ but no _LA_, i.e. _LK_ = _L_ - _LA_
+For this purpose, the <ProjectionItem>s in _L_ can be spilt into _aggregates_ and _grouping keys_:
 
-Further
+* A <ProjectionItem> _p_ is an aggregate if it is of the form `_agg_(_ex_) AS _al_`, where
+** _agg_ is an aggregation function,
+** _ex_ is a valid expression, and
+** _al_ is an alias; and
+* A <ProjectionItem> _p_ is a grouping key if is not an aggregate
 
-* For a <ProjectionItem> _p_ = `_ex_ AS _al_`,
-** If _p_ ∈ _LK_
-*** Let `PROJ(_p_)` be `_ex_ AS _al_` and
-*** Let `AGGR(_p_)` be `_al_ AS _al_`
-** If _p_ ∈ _LA_ and _ex_ = _agg_(_x_)
-*** Let `PROJ(_p_)` be `_x_ AS _al_` and
-*** Let `AGGR(_p_)` be `_agg_(_al_) AS _al_`
-* For a set of <ProjectionItem>s _L_ = {_p1_, _p2_, ... _pn_},
-** Let `PROJ(_L_)` be `PROJ(_p1_), PROJ(_p2_), ..., PROJ(_pn_)` and
-** Let `AGGR(_L_)` be `AGGR(_p1_), AGGR(_p2_), ..., AGGR(_pn_)`
+Hence, for a <ProjectionItem> _p_
+
+* If _p_ is of the form `_ex_ AS _al_`
+** Let `PROJ(_p_)` be `_ex_ AS _al_` and
+** Let `AGGR(_p_)` be `_al_ AS _al_`
+* If _p_ is of the form `_agg_(_ex_) AS _al_`
+** Let `PROJ(_p_)` be `_x_ AS _al_` and
+** Let `AGGR(_p_)` be `_agg_(_al_) AS _al_`
+
+Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
+
+* Let `PROJ(_L_)` be `PROJ(_p_~1~), PROJ(_p_~2~), ..., PROJ(_p~N~_)` and
+* Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`
 
 With this the semantics of `RETURN _L_` can be defined as effectively equivalent to
 
@@ -142,7 +187,7 @@ WITH PROJ(_L_)
 RETURN AGGR(_L_)
 ----
 
-Analoguously, the semantics of `WITH _L_` can be defined as effectively equivalent to
+Analogously, the semantics of `WITH _L_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
@@ -150,7 +195,7 @@ WITH PROJ(_L_)
 WITH AGGR(_L_)
 ----
 
-For instance, Q3 from above (`RETURN b-a AS x, SUM(b*c) AS sumBC`) can be defined as effectively equivalent to
+For instance, <<Q3>> from above (`RETURN b-a AS x, SUM(b*c) AS sumBC`) can be defined as effectively equivalent to
 
 [source, cypher]
 ----
@@ -158,20 +203,24 @@ WITH b-a AS x, b*c AS sumBC
 RETURN x AS x, SUM(sumBC) AS sumBC
 ----
 
+Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
+
+==== Beyond simple rewrite semantics
+
 While this solution works nicely for the considered examples, it is limited.
 Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.
 
 Cypher, however, also allows aggregation functions in expressions of the form, such as
 
-* `_ex1_ + _agg_(_ex2_)`
-* `_agg_(_ex2_) + _ex1_`
-* `_agg1_(_ex2_) + _ex1_ * _agg1_(_ex3_)`
+* `_ex_~1~ + _agg_(_ex_~2~)`
+* `_agg_(_ex_~1~) + _ex_~2~`
+* `_agg_~1~(_ex_~1~) + _ex~2~_ * _agg_~2~(_ex_~3~)`
 
 However, such expressions may still be sensible and useful.
 
 Consider the RETURN clause
 
-.Q4
+.[[Q4]]Q4
 [source, cypher]
 ----
 RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
@@ -189,9 +238,61 @@ should produce a result that is grouped by `a` and `agg` should be computed for 
 //(2 + (3*5) - 5) * 2
 |===
 
-// TODO extend rewrite semantics
+It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) the existing semantics or Cypher is imprecise on such queries.
 
-For instance, Q4 from above (`RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg`) can be defined as effectively equivalent to
+This proposal provides a precise semantics.
+
+== Proposal
+
+=== Syntax
+
+_None. -- This proposal does not propose and net-new syntax._
+
+=== Semantics
+
+For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_).
+
+The set of <ProjectionItem>s _L_ is split according to _AGG_(_p_) in two cases
+
+* <ProjectionItem>s _p_ in _L_ where _AGG_(_p_) is non-empty
+* <ProjectionItem>s _p_ in _L_ where _AGG_(_p_) is empty
+
+Hence, for a <ProjectionItem> _p_ = `_ex_ AS _al_`,
+
+* If _AGG_(_p_) = ∅
+** Let `PRE_PROJ(_p_)` be `_ex_ AS _al_`,
+** Let `AGGR(_p_)` be `_al_ AS _al_`, and
+** Let `POST_PROJ(_p_)` be `_al_ AS _al_`
+* If _AGG_(_p_) = {`_agg_~1~(_preEx_~1~)`, `_agg_~2~(_preEx_~2~)`, ..., `_aggN_(_preEx_~N~)`} with _N_ > 0
+** Let `PRE_PROJ(_p_)` be `_preEx_~1~ AS _al_+++_+++1, _preEx_~2~ AS _al_+++_+++2, ..., _preEx~N~_ AS _al_+++_+++_N_`,
+** Let `AGGR(_p_)` be `_agg_~1~(_al_+++_+++1) AS _al_+++_+++1, _agg_~2~(_al_+++_+++2) AS _al_+++_+++2, ..., _agg~N~_(_al_+++_+++_N_ AS _al_+++_+++_N_`, and
+** Let `POST_PROJ(_p_)` be `_postEx_ AS _al_` where _postEx_ is _ex_ with each `_agg~i~_(_preEx~i~_)` in _AGG_(_p_) being replaced by `_al_+++_+++_i_` for 1 ≤ _i_ ≤ _N_.
+
+Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
+
+* Let `PRE_PROJ(_L_)` be `PRE_PROJ(_p_~1~), PRE_PROJ(_p_~2~), ..., PRE_PROJ(_p~N~_)`,
+* Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`, and
+* Let `POST_PROJ(_L_)` be `POST_PROJ(_p_~1~), POST_PROJ(_p_~2~), ..., POST_PROJ(_p~N~_)`.
+
+With this the semantics of `RETURN _L_` can be defined as effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PRE_PROJ(_L_)
+WITH AGGR(_L_)
+RETURN POST_PROJ(_L_)
+----
+
+Analogously, the semantics of `WITH _L_` can be defined as effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PRE_PROJ(_L_)
+WITH AGGR(_L_)
+WITH POST_PROJ(_L_)
+----
+
+For instance, <<Q4>> from above (`RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg`) can be defined as effectively equivalent to
 
 [source, cypher]
 ----
@@ -200,22 +301,7 @@ WITH a AS a, SUM(agg_1) AS agg_1, MIN(agg_2) AS agg_2
 RETURN a AS a, (a + agg_1 - agg_2) * 2 AS agg
 ----
 
-== Proposal
-
-
-
-
-=== Syntax
-
-
-==== Grammar
-
-
-==== Syntax Rules
-
-
-=== Semantics
-
+// TODO syntactic restriction implied by this semantics
 
 === Examples
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -270,7 +270,6 @@ should produce a result that is grouped by `a` and `foo` should be computed for 
 ====
 A less artificial example is calculating the total gross of an order as the discounted sum of the net values –– product price multiplied by amount –– of the order's line items in query such as:
 
-.[[Q5]]Q5
 [source, cypher]
 ----
 MATCH
@@ -405,7 +404,7 @@ is not rewritten to valid query.
 ====
 By the grouping and aggregation semantics, the RETURN clause
 
-.[[Q6]]Q6
+.[[Q5]]Q5
 [source, cypher]
 ----
 RETURN a AS a, b + SUM(c) * 2 AS foo
@@ -422,7 +421,7 @@ RETURN a AS a, b + foo_1 * 2 AS foo
 
 Note that variable `b` appears in the <ProjectionItem> `b + foo_1 * 2 AS foo` in the RETURN clause.
 However, variable `b` has already by removed from the driving table by the previous projections.
-In other words, the proposed rewrite produce invalid query text for <<Q6>>.
+In other words, the proposed rewrite produce invalid query text for <<Q5>>.
 ====
 
 To prevent such invalid rewrites, this CIP imposes a syntax restriction on RETURN and WITH clauses.
@@ -446,7 +445,7 @@ For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ whe
 
 .Effect of the restriction
 ====
-Under this restriction, <<Q6>> is invalid.
+Under this restriction, <<Q5>> is invalid.
 For sub-expression `b` in <ProjectionItem> `b + foo_1 * 2 AS foo`, _CONSTANT_(`b`) does not hold, since `b` is neither a aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
 ====
 
@@ -585,7 +584,7 @@ All other major query language explicitly delineate grouping key expressions.
 
 For instance, SQL does so by requiring users to list all grouping key expressions in the GROUP BY clause.
 If the GROUP BY clause is present in a query, the projection in the SELECT clause have to fulfill a similar syntax restriction as defined by this CIP.
-The SQL-equivalent of <<Q6>>
+The SQL-equivalent of <<Q5>>
 
 [source, sql]
 ----
@@ -616,7 +615,7 @@ To this effect, the proposed rules of the syntax restriction are a heuristic, wh
 
 The RETURN clause
 
-.[[Q7]]Q7
+.[[Q6]]Q6
 [source, cypher]
 ----
 RETURN a AS a, (b - b) + SUM(c) AS foo

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -1,0 +1,46 @@
+= CIP2015-05-13 Existential subqueries
+:numbered:
+:toc:
+:toc-placement: macro
+:source-highlighter: codemirror
+
+*Authors:* Andrés Taylor <andres@neotechnology.com>, Hannes Voigt <hannes.voigt@neo4j.com>
+
+
+[abstract]
+.Abstract
+--
+
+--
+
+toc::[]
+
+== Background
+
+
+== Proposal
+
+
+=== Syntax
+
+
+==== Grammar
+
+
+==== Syntax Rules
+
+
+=== Semantics
+
+
+=== Examples
+
+
+== What others do
+
+
+== Benefits to this proposal
+
+
+== Caveats to this proposal
+

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -17,10 +17,21 @@ toc::[]
 
 == Background
 
-In this CIP we assume the following baseline semantics as a given and well-defined.
-Further, we consider a simple rewrite semantics for grouping and aggregation, that lays the foundation for the rewrite semantics that is proposed in the <<Proposal>> section of this CIP.
+In this CIP we assume two baseline semantics as a given and well-defined.
+Each baseline semantics captures on capability of the WITH and the RETURN clause in isolation -- similar to https://en.wikipedia.org/wiki/Relational_algebra[relational algebra operators].
 
-We also use following driving table in most of the CIP's examples:
+_<<Baseline projection>>_ :: Describes the projection of binding table
+_<<Baseline aggregation>>_ :: Describes grouping and aggregation of binding table
+
+The WITH and the RETURN clause also allow ordering and truncating the driving table, but we ignore these aspects in the background considerations.
+
+We define a <<Simple rewrite semantics>> for grouping and aggregation.
+As its name suggests, the simple rewrite semantics is defined as a syntax transformation to a linear composition of the baseline semantics.
+The simple rewrite semantics lays the foundation for the rewrite semantics that is proposed in the <<Proposal>> section of this CIP.
+
+We briefly demonstrate the <<Limits of the simple rewrite semantics>> to motivate the proposed semantics.
+
+Further, we use following driving table in most of the CIP's examples:
 
 .Example driving table
 |===
@@ -31,20 +42,69 @@ We also use following driving table in most of the CIP's examples:
 |2|3|5
 |===
 
+=== Baseline projection
+
+The WITH and the RETURN clause allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
+
+The projection of a driving table _D_ can be described formally as π__~P~__(_D_) where
+
+* _P_ is a nonempty set of pairs (_ex_, _al_) where
+** _ex_ is a tree of operations of the expression sub-language where each of the leaves is either
+*** a constant (such as a value literal or a label),
+*** a parameter, or
+*** a variable in the driving table _D_; and
+** _al_ is a variable name -- called an _alias_ -- that is different from all other aliases _x_ with (·, _x_) ∈ _P_.
+
+Assuming _P_ = {(_ex_~1~, _al_~1~), (_ex_~2~, _al_~2~), ..., (_ex~N~_, _al~N~_)}, the Cypher equivalent of π__~P~__(_D_) is
+
+[source, cypher, subs="quotes"]
+----
+WITH _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
+----
+
+and
+
+[source, cypher, subs="quotes"]
+----
+RETURN _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
+----
+
+.Baseline projection
+====
+The RETURN clause
+
+.[[Q1]]Q1
+[source, cypher]
+----
+RETURN b-a AS x, b*c AS y
+----
+
+projects each row in the driving table to `b` minus `a` (as `x`) and the product of `b` and `c` (as `y`), so that the result is:
+
+.Result Q1
+|===
+|x|y
+
+|1|6
+|2|12
+|1|15
+|===
+====
+
 === Baseline aggregation
 
-Cypher allows grouping and aggregating (form here on just referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
+Cypher allows grouping and aggregating (often simply referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
 
 Formally, the aggregation of a driving table _D_ can be described formally as
 pass:q[γ<sub>_K_, _A_</sub>(_D_)] where
 
 * _K_ is a (possibly empty) set of pairs (_k_, _al_) where
 ** _k_ is a variable -- called a _grouping key_ -- in the driving table _D_,
-** _al_ is variable name -- also called an _alias_ -- that different from all other aliases _x_ with (·, _x_) ∈ _K_., and
+** _al_ is an _alias_ that different from all other aliases _x_ with (·, _x_) ∈ _K_., and
 * _A_ is a non-empty set of triple (_agg_, _x_, _al_) where
 ** _agg_ is an aggregation function and
 ** _x_ is a variable in the driving table _D_
-** _al_ is variable name -- also called an _alias_ -- that different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ or _x_ with (·, _x_) ∈ _K_.
+** _al_ is an alias that different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ and _x_ with (·, _x_) ∈ _K_.
 
 Assuming _K_ = {(_k_~1~, _ka_~1~), (_k_~2~, _ka_~1~), ..., (_k~N~_, _ka~N~_)} and _A_ = {(_agg_~1~, _x_~1~, _al_~1~), (_agg_~2~, _x_~2~, _al_~2~), ..., (_agg~M~_, _x~M~_, _al~M~_)}, the Cypher equivalent of pass:q[γ<sub>_K_, _A_</sub>(_D_)] is
 
@@ -65,15 +125,17 @@ RETURN _k_~1~ AS _k_~1~, _k_~2~ AS _k_~2~, ..., _k~N~_ AS _k~N~_,
 .Baseline aggregation
 ====
 
-.[[Q1]]Q1
+The RETURN clause
+
+.[[Q2]]Q2
 [source, cypher]
 ----
 RETURN a AS a, SUM(c) AS sumC
 ----
 
-Grouped the driving table by `a` and computes the sum of all `c` as `sumC` for each group, so that result is:
+groups the driving table by `a` and computes the sum of all `c` as `sumC` for each group, so that result is:
 
-.Result Q1
+.Result Q2
 |===
 |a|sumC
 
@@ -82,61 +144,11 @@ Grouped the driving table by `a` and computes the sum of all `c` as `sumC` for e
 |===
 ====
 
-=== Baseline projection
+=== Simple rewrite semantics
 
-The WITH and the RETURN clause also allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
-
-The projection of a driving table _D_ can be described formally as π__~P~__(_D_) where
-
-* _P_ is a nonempty set of pairs (_ex_, _al_) where
-** _ex_ is a tree of operations of the expression sub-language where each of the leaves is either
-*** a constant (such as a value literal or a label),
-*** a parameter, or
-*** a variable in the driving table _D_; and
-** _al_ is an _alias_ that different from all other aliases _x_ with (·, _x_) ∈ _P_.
-
-Assuming _P_ = {(_ex_~1~, _al_~1~), (_ex_~2~, _al_~2~), ..., (_ex~N~_, _al~N~_)}, the Cypher equivalent of π__~P~__(_D_) is
-
-[source, cypher, subs="quotes"]
-----
-WITH _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
-----
-
-and
-
-[source, cypher, subs="quotes"]
-----
-RETURN _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
-----
-
-.Baseline projection
-====
-The RETURN clause
-
-.[[Q2]]Q2
-[source, cypher]
-----
-RETURN b-a AS x, b*c AS y
-----
-
-projects each row in the driving table to `b` minus `a` (as `x`) and the product of `b` and `c` (as `y`), so that result is:
-
-.Result Q2
-|===
-|x|y
-
-|1|6
-|2|12
-|1|15
-|===
-====
-
-The WITH and the RETURN clauses also allow ordering and truncating the driving table, but let's ignore these aspects in this CIP.
-
-=== Simple rewrite semantics[[simpleRewrite]]
-
-Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics.
+Cypher's WITH and RETURN clause are syntactically more flexible than the two baseline semantics.
 In particular, they allow mixing aggregation and projection rather freely.
+
 Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty set _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
 
 * _ex_ is an expression that is allowed to contain aggregation functions and
@@ -163,23 +175,23 @@ should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of
 |===
 ====
 
-The semantics of such an RETURN (and WITH) clause can be described as a rewrite to the two baseline semantics combined by Cypher's linear composition.
+The semantics of such RETURN and WITH clauses can be described as a rewrite to the two baseline semantics combined by Cypher's linear composition.
 
 For this purpose, the <ProjectionItem>s in _L_ can be spilt into _aggregates_ and _grouping keys_:
 
 * A <ProjectionItem> _p_ is an aggregate if it is of the form `_agg_(_ex_) AS _al_`, where
 ** _agg_ is an aggregation function,
-** _ex_ is a valid expression, and
+** _ex_ is an expression, and
 ** _al_ is an alias; and
 * A <ProjectionItem> _p_ is a grouping key if is not an aggregate
 
-Hence, for a <ProjectionItem> _p_
+For a <ProjectionItem> _p_,
 
-* If _p_ is of the form `_ex_ AS _al_`
+* If _p_ is a grouping key of the form `_ex_ AS _al_`
 ** Let `PROJ(_p_)` be `_ex_ AS _al_` and
 ** Let `AGGR(_p_)` be `_al_ AS _al_`
-* If _p_ is of the form `_agg_(_ex_) AS _al_`
-** Let `PROJ(_p_)` be `_x_ AS _al_` and
+* If _p_ is an aggregate of the form `_agg_(_ex_) AS _al_`
+** Let `PROJ(_p_)` be `_ex_ AS _al_` and
 ** Let `AGGR(_p_)` be `_agg_(_al_) AS _al_`
 
 Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
@@ -203,7 +215,7 @@ WITH PROJ(_L_)
 WITH AGGR(_L_)
 ----
 
-Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
+We call this the _simple rewrite semantics_ for the WITH and RETURN clause.
 
 .Simple rewrite semantics
 ====
@@ -211,7 +223,7 @@ With the simple rewrite semantics, the RETURN clause in <<Q3>>
 
 [source, cypher]
 ----
-RETURN b-a AS x, SUM(b*c) AS sumBC`)
+RETURN b-a AS x, SUM(b*c) AS sumBC
 ----
 
 is effectively equivalent to
@@ -223,15 +235,15 @@ RETURN x AS x, SUM(sumBC) AS sumBC
 ----
 ====
 
-=== Limits of simple rewrite semantics
+=== Limits of the simple rewrite semantics
 
-While this solution works nicely for the considered examples, it is limited.
-Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.
+While the simple rewrite semantics works nicely for the considered examples, it is limited.
+Specifically, it only supports aggregation expressions of the form `_agg_(_ex_)`.
 
 Cypher, however, also allows aggregation functions to appear as sub-expression of <ProjectionItem>s, i.e. Cypher allows <ProjectionItem>s with expressions of forms, such as
 
-* `_ex_~1~ + _agg_(_ex_~2~)`
-* `_agg_(_ex_~1~) + _ex_~2~`
+* `_ex_~1~ + _agg_(_ex_~2~)`,
+* `_agg_(_ex_~1~) + _ex_~2~`, and
 * `_agg_~1~(_ex_~1~) + _ex~2~_ * _agg_~2~(_ex_~3~)`
 
 Such expressions can still be sensible and useful.
@@ -246,7 +258,7 @@ The RETURN clause
 RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS foo
 ----
 
-should produce a result that is grouped by `a` and `foo` should be computed for each group as the sum of all products of `b` and `c` added to the value `a` and multiplied by two, so that result would be:
+should produce a result that is grouped by `a` and `foo` should be computed for each group as the value `a` plus the sum of all products of `b` and `c` minus the smallest value of `c` multiplied by two, so that result is:
 
 .Result Q4
 |===
@@ -261,26 +273,26 @@ should produce a result that is grouped by `a` and `foo` should be computed for 
 
 [NOTE]
 ====
-A less artificial example is calculating the total gross of an order as the discounted sum of line item net values (product price multiplied by amount) in query such as:
+A less artificial example is calculating the total gross of an order as the discounted sum of the net values –– product price multiplied by amount –– of the order's line items in query such as:
 
 .[[Q5]]Q5
 [source, cypher]
 ----
 MATCH
-(c:Customer)-[:LOCATED_IN]->(s:State)
-(c)-[:ORDERED]->(o:Order)
+(c:Customer)-[:LOCATED_IN]->(s:State),
+(c)-[:ORDERED]->(o:Order),
 (o)-[:INCLUDES]->(li:LineItem)-->(p:Product)
 RETURN s AS state, c AS customer, o AS order,
-       SUM(li.amount * p.price) * c.discount * j.vat AS totalGross
+       SUM(li.amount * p.price) * c.discount * s.vat AS totalGross
 ----
 ====
 
-It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) the existing semantics or Cypher is imprecise on such queries.
+It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) that the existing semantics of Cypher is imprecise on such queries.
 
 A precise semantics on such queries has to provide
 
 * A clear definition which <ProjectionItem>s constitute the grouping keys
-* Clear rules for which sub-expressions are allowed in <ProjectionItem>s containing aggregation functions
+* Clear rules which sub-expressions are allowed in <ProjectionItem>s containing aggregation functions
 
 This proposal provides a such precise semantics.
 
@@ -292,7 +304,7 @@ _None. -- This proposal does not propose and net-new syntax._
 
 === Semantics
 
-The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<simpleRewrite,simple rewrite semantics>> discussed above).
+The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<Simple rewrite semantics>> discussed above).
 The proposed semantics does not cover all queries and hence implies a syntax restriction to rule out queries that are not covered.
 We discuss the rewrite and the syntax restriction in the follow two subsections.
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -149,7 +149,7 @@ groups the driving table by `a` and computes the sum of all `c` as `sumC` for ea
 Cypher's WITH and RETURN clause are syntactically more flexible than the two baseline semantics.
 In particular, they allow mixing aggregation and projection rather freely.
 
-Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty set _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
+Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty duplicate-free list _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
 
 * _ex_ is an expression that is allowed to contain aggregation functions and
 * _al_ is an alias.
@@ -188,31 +188,26 @@ For this purpose, the <ProjectionItem>s in _L_ can be spilt into _aggregates_ an
 For a <ProjectionItem> _p_,
 
 * If _p_ is a grouping key of the form `_ex_ AS _al_`
-** Let `PROJ(_p_)` be `_ex_ AS _al_` and
-** Let `AGGR(_p_)` be `_al_ AS _al_`
+** Let `_PROJ_(_p_)` be `_ex_ AS _al_` and
+** Let `_AGGR_(_p_)` be `_al_ AS _al_`
 * If _p_ is an aggregate of the form `_agg_(_ex_) AS _al_`
-** Let `PROJ(_p_)` be `_ex_ AS _al_` and
-** Let `AGGR(_p_)` be `_agg_(_al_) AS _al_`
+** Let `_PROJ_(_p_)` be `_ex_ AS _al_` and
+** Let `_AGGR_(_p_)` be `_agg_(_al_) AS _al_`
 
-Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
-
-* Let `PROJ(_L_)` be `PROJ(_p_~1~), PROJ(_p_~2~), ..., PROJ(_p~N~_)` and
-* Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`
-
-With this, `RETURN _L_` can be defined as effectively equivalent to
+With this, `RETURN _p_~1~, _p_~2~, ... _p~N~_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH PROJ(_L_)
-RETURN AGGR(_L_)
+WITH _PROJ_(_p_~1~), _PROJ_(_p_~2~), ..., _PROJ_(_p~N~_)
+RETURN _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
 ----
 
-Analogously, `WITH _L_` can be defined as effectively equivalent to
+Analogously, `WITH _p_~1~, _p_~2~, ... _p~N~_` can be defined as effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH PROJ(_L_)
-WITH AGGR(_L_)
+WITH _PROJ_(_p_~1~), _PROJ_(_p_~2~), ..., _PROJ_(_p~N~_)
+WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
 ----
 
 We call this the _simple rewrite semantics_ for the WITH and RETURN clause.
@@ -248,7 +243,7 @@ Cypher, however, also allows aggregation functions to appear as sub-expression o
 
 Such expressions can still be sensible and useful.
 
-.Aggregation functions a sub-expressions
+.aggregation functions a sub-expressions
 ====
 The RETURN clause
 
@@ -300,13 +295,15 @@ This proposal provides a such precise semantics.
 
 === Syntax
 
-_None. -- This proposal does not propose and net-new syntax._
+This proposal does not propose any net-new syntax.
 
 === Semantics
 
 The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<Simple rewrite semantics>> discussed above).
-The proposed semantics does not cover all queries and hence implies a syntax restriction to rule out queries that are not covered.
-We discuss the rewrite and the syntax restriction in the follow two subsections.
+The proposed semantics does not cover all syntactically possible queries and hence requires a syntax restriction to prohibit queries that are not covered.
+We discuss the <<Rewrite>> and the <<Syntax restriction>> in the follow two subsections.
+We simplify this discussion by ignoring column order, row ordering and pagination, and omitted aliases.
+Subsequently, we give a separate and brief consideration of how to these aspects fit into the proposal, cf. <<Column order>>, <<Row ordering and pagination>>, and <<Omitted aliases>>, respectively.
 
 ==== Rewrite
 
@@ -314,47 +311,41 @@ For an expression _ex_, let _AGG_(_ex_) be the set of (sub-)expressions _aggex_ 
 
 For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_), i.e. _AGG_(_p_) = _AGG_(_postEx_).
 
-The set of <ProjectionItem>s _L_ is split according to _AGG_(_p_) in two cases
+The <ProjectionItem>s in _L_ is split according to _AGG_(_p_) in two cases
 
-* <ProjectionItem>s _p_ in _L_ where _AGG_(_p_) is non-empty
-* <ProjectionItem>s _p_ in _L_ where _AGG_(_p_) is empty
+* <ProjectionItem>s _p_ in _L_ is an aggregate if _AGG_(_p_) is non-empty
+* <ProjectionItem>s _p_ in _L_ is a grouping key if _AGG_(_p_) is empty
 
-Hence, for a <ProjectionItem> _p_ = `_ex_ AS _al_`,
+For a <ProjectionItem> _p_ = `_ex_ AS _al_`,
 
 * If _AGG_(_p_) = ∅
-** Let `PRE_PROJ(_p_)` be `_ex_ AS _al_`,
-** Let `AGGR(_p_)` be `_al_ AS _al_`, and
-** Let `POST_PROJ(_p_)` be `_al_ AS _al_`
-* If _AGG_(_p_) = {`_agg_~1~(_preEx_~1~)`, `_agg_~2~(_preEx_~2~)`, ..., `_aggN_(_preEx_~N~)`} with _N_ > 0
-** Let `PRE_PROJ(_p_)` be `_preEx_~1~ AS _al_+++_+++1, _preEx_~2~ AS _al_+++_+++2, ..., _preEx~N~_ AS _al_+++_+++_N_`,
-** Let `AGGR(_p_)` be `_agg_~1~(_al_+++_+++1) AS _al_+++_+++1, _agg_~2~(_al_+++_+++2) AS _al_+++_+++2, ..., _agg~N~_(_al_+++_+++_N_ AS _al_+++_+++_N_`, and
-** Let `POST_PROJ(_p_)` be `_postEx_ AS _al_` where _postEx_ is _ex_ with each `_agg~i~_(_preEx~i~_)` in _AGG_(_p_) being replaced by `_al_+++_+++_i_` for 1 ≤ _i_ ≤ _N_.
-
-Further, for a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_},
-
-* Let `PRE_PROJ(_L_)` be `PRE_PROJ(_p_~1~), PRE_PROJ(_p_~2~), ..., PRE_PROJ(_p~N~_)`,
-* Let `AGGR(_L_)` be `AGGR(_p_~1~), AGGR(_p_~2~), ..., AGGR(_p~N~_)`, and
-* Let `POST_PROJ(_L_)` be `POST_PROJ(_p_~1~), POST_PROJ(_p_~2~), ..., POST_PROJ(_p~N~_)`.
+** Let `_PRE_PROJ_(_p_)` be `_ex_ AS _al_`,
+** Let `_AGGR_(_p_)` be `_al_ AS _al_`, and
+** Let `_POST_PROJ_(_p_)` be `_al_ AS _al_`
+* If _AGG_(_p_) = {`_agg_~1~(_preEx_~1~)`, `_agg_~2~(_preEx_~2~)`, ..., `_agg~N~_(_preEx~N~_)`} with _N_ > 0
+** Let `_PRE_PROJ_(_p_)` be `_preEx_~1~ AS _al_+++_+++1, _preEx_~2~ AS _al_+++_+++2, ..., _preEx~N~_ AS _al_+++_+++_N_`,
+** Let `_AGGR_(_p_)` be `_agg_~1~(_al_+++_+++1) AS _al_+++_+++1, _agg_~2~(_al_+++_+++2) AS _al_+++_+++2, ..., _agg~N~_(_al_+++_+++_N_) AS _al_+++_+++_N_`, and
+** Let `_POST_PROJ_(_p_)` be `_postEx_ AS _al_` where _postEx_ is _ex_ with each `_agg~i~_(_preEx~i~_)` in _AGG_(_p_) being replaced by `_al_+++_+++_i_` for 1 ≤ _i_ ≤ _N_.
 
 [IMPORTANT]
 .Rewrite semantics
 ====
-`RETURN _L_` is effectively equivalent to
+`RETURN _p_~1~, _p_~2~, ... _p~N~_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH PRE_PROJ(_L_)
-WITH AGGR(_L_)
-RETURN POST_PROJ(_L_)
+WITH _PRE_PROJ_(_p_~1~), _PRE_PROJ_(_p_~2~), ..., _PRE_PROJ_(_p~N~_)
+WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
+RETURN _POST_PROJ_(_p_~1~), _POST_PROJ_(_p_~2~), ..., _POST_PROJ_(_p~N~_)
 ----
 
-Analogously, `WITH _L_` is effectively equivalent to
+Analogously, `WITH _p_~1~, _p_~2~, ... _p~N~_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH PRE_PROJ(_L_)
-WITH AGGR(_L_)
-WITH POST_PROJ(_L_)
+WITH _PRE_PROJ_(_p_~1~), _PRE_PROJ_(_p_~2~), ..., _PRE_PROJ_(_p~N~_)
+WITH _AGGR_(_p_~1~), _AGGR_(_p_~2~), ..., _AGGR_(_p~N~_)
+WITH _POST_PROJ_(_p_~1~), _POST_PROJ_(_p_~2~), ..., _POST_PROJ_(_p~N~_)
 ----
 ====
 
@@ -377,7 +368,7 @@ RETURN a AS a, (a + foo_1 - foo_2) * 2 AS foo
 ----
 ====
 
-Note that the grouping and aggregation semantics also provides for the mixing of projection and aggregation that the <<simpleRewrite,simple rewrite semantics>> covers, i.e. it is a generalization of the simple rewrite semantics.
+Note that the grouping and aggregation semantics also provides for the mixing of projection and aggregation that the <<Simple rewrite semantics>> covers, i.e. it is a generalization of the simple rewrite semantics.
 
 .Rewrite semantics on simple mixing of projection and aggregation
 ====
@@ -410,9 +401,8 @@ Specifically, any <ProjectItems> containing
 
 is not rewritten to valid query.
 
-.Aggregation *not* covered by the rewrite
+.aggregation *not* covered by the rewrite
 ====
-
 By the grouping and aggregation semantics, the RETURN clause
 
 .[[Q6]]Q6
@@ -437,21 +427,21 @@ In other words, the proposed rewrite produce invalid query text for <<Q6>>.
 
 To prevent such invalid rewrites, this CIP imposes a syntax restriction on RETURN and WITH clauses.
 
-Given a set of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_}, let GROUPING_KEYS(_L_) be the set of all expressions and _ex_ and aliases _a_ in <ProjectionItem>s _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is empty.
+Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ... _p~N~_}, let _GROUPING_KEYS_(_L_) be the set of all expressions and _ex_ and aliases _a_ in <ProjectionItem>s _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is empty.
 
-For an expression _ex_ and projection list _L_, let CONSTANT(_ex_) hold
+For an expression _ex_ and projection list _L_, let _CONSTANT_(_ex_) hold
 
 * If _ex_ is either
 ** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
-** A grouping key (either expression or alias), i.e. _o_ ∈ GROUPING_KEYS(_L_),
+** A grouping key (either expression or alias), i.e. _o_ ∈ _GROUPING_KEYS_(_L_),
 ** A constant,
-** A parameter
-* or if _ex_ comprises of sub-expression, it only comprises sub-expression _subEx_ for which CONSTANT(_subEx_) holds.
+** A parameter,
+* or if _ex_ comprises of sub-expression, it only comprises sub-expression _subEx_ for which _CONSTANT_(_subEx_) holds.
 
 [IMPORTANT]
 .Syntax restriction
 ====
-For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is not empty, CONSTANT(_ex_) shall hold.
+For clauses `WITH _L_` and `RETURN _L_` and every _p_ = `_ex_ AS _a_` in _L_ where _AGG_(_p_) is not empty, _CONSTANT_(_ex_) shall hold.
 ====
 
 .Effect of the restriction
@@ -482,30 +472,30 @@ Assuming, the baseline semantics includes ORDER BY, SKIP, and LIMIT capabilities
 
 [source, cypher, subs="quotes"]
 ----
-WITH PRE_PROJ(_L_)
-WITH AGGR(_L_)
-RETURN POST_PROJ(_L_) _ORDER-SKIP-LIMIT_
+WITH _PRE_PROJ_(_L_)
+WITH _AGGR_(_L_)
+RETURN _POST_PROJ_(_L_) _ORDER-SKIP-LIMIT_
 ----
 
 Analogously, `WITH _L_ _ORDER-SKIP-LIMIT_` is effectively equivalent to
 
 [source, cypher, subs="quotes"]
 ----
-WITH PRE_PROJ(_L_)
-WITH AGGR(_L_)
-WITH POST_PROJ(_L_) _ORDER-SKIP-LIMIT_
+WITH _PRE_PROJ_(_L_)
+WITH _AGGR_(_L_)
+WITH _POST_PROJ_(_L_) _ORDER-SKIP-LIMIT_
 ----
 ====
 
 The https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=SortItem[<SortItem>]s in ORDER BY clause contain an expression.
-Since these expressions are effectively evaluate at the same time as all POST_PROJ(_L_) expressions, the syntax restrictions applies.
+Since these expressions are effectively evaluate at the same time as all _POST_PROJ_(_L_) expressions, the syntax restrictions applies.
 
 [IMPORTANT]
 ====
-For `WITH _L_ ORDER BY _SI_` and `RETURN _L_ ORDER BY _SI_` and every _ex_ directly contained in a <SortItem> in _SI_, CONSTANT(_ex_) shall hold.
+For `WITH _L_ ORDER BY _SI_` and `RETURN _L_ ORDER BY _SI_` and every _ex_ directly contained in a <SortItem> in _SI_, _CONSTANT_(_ex_) shall hold.
 ====
 
-==== Aliasing
+==== Omitted aliases
 
 This proposal considers all projects have user-given alias.
 Cypher allows to omit the aliases, particularly in the RETURN clause, though.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -63,7 +63,8 @@ RETURN _k_~1~ AS _k_~1~, _k_~2~ AS _k_~2~, ..., _k~N~_ AS _k~N~_,
        _agg_~1~(_x_~1~) AS _al_~1~, _agg_~2~(_x_~2~) AS _al_~2~, ..., _agg~M~_(_x~M~_) AS _al~M~_
 ----
 
-Accordingly
+.Baseline aggregation
+====
 
 .[[Q1]]Q1
 [source, cypher]
@@ -80,6 +81,7 @@ Grouped the driving table by `a` and computes the sum of all `c` as `sumC` for e
 |1|7
 |2|5
 |===
+====
 
 ==== Baseline projection
 
@@ -108,7 +110,9 @@ and
 RETURN _ex_~1~ AS _al_~1~, _ex_~2~ AS _al_~2~, ..., _ex~N~_ AS _al~N~_
 ----
 
-Accordingly, the RETURN clause
+.Baseline projection
+====
+The RETURN clause
 
 .[[Q2]]Q2
 [source, cypher]
@@ -126,18 +130,22 @@ projects each row in the driving table to `b` minus `a` (as `x`) and the product
 |2|12
 |1|15
 |===
+====
 
 The WITH and the RETURN clauses also allow ordering and truncating the driving table, but let's ignore these aspects in this CIP.
 
-==== Beyond baseline semantics -- simple rewrite semantics
+==== Beyond baseline semantics -- simple rewrite semantics[[simpleRewrite]]
 
-Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics. In particular, they allow mixing aggregation and projection rather freely.
+Cypher's WITH and the RETURN are syntactically more flexible when the two baseline semantics.
+In particular, they allow mixing aggregation and projection rather freely.
 Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty set _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
 
 * _ex_ is an expression that is allowed to contain aggregation functions and
 * _al_ is an alias.
 
-For instance, the RETURN clause
+.Mixing aggregation and projection
+====
+The RETURN clause
 
 .[[Q3]]Q3
 [source, cypher]
@@ -154,6 +162,7 @@ should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of
 |1|21
 |2|12
 |===
+====
 
 The semantics of such an RETURN (and WITH) clause can be described as a rewrite to the two baseline semantics combined by Cypher's linear composition.
 
@@ -195,13 +204,23 @@ WITH PROJ(_L_)
 WITH AGGR(_L_)
 ----
 
-For instance, <<Q3>> from above (`RETURN b-a AS x, SUM(b*c) AS sumBC`) can be defined as effectively equivalent to
+.Simple rewrite semantics
+====
+With this semantics, the RETURN clause in <<Q3>>
+
+[source, cypher]
+----
+RETURN b-a AS x, SUM(b*c) AS sumBC`)
+----
+
+is defined as effectively equivalent to
 
 [source, cypher]
 ----
 WITH b-a AS x, b*c AS sumBC
 RETURN x AS x, SUM(sumBC) AS sumBC
 ----
+====
 
 Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
 
@@ -210,37 +229,61 @@ Let's call this the _simple rewrite semantics_ for the WITH and RETURN clause.
 While this solution works nicely for the considered examples, it is limited.
 Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.
 
-Cypher, however, also allows aggregation functions in expressions of the form, such as
+Cypher, however, also allows aggregation functions to appear as sub-expression of <ProjectionItem>s, i.e. Cypher allows <ProjectionItem>s with expressions of forms, such as
 
 * `_ex_~1~ + _agg_(_ex_~2~)`
 * `_agg_(_ex_~1~) + _ex_~2~`
 * `_agg_~1~(_ex_~1~) + _ex~2~_ * _agg_~2~(_ex_~3~)`
 
-However, such expressions may still be sensible and useful.
+Such expressions can still be sensible and useful.
 
-Consider the RETURN clause
+.Aggregation functions a sub-expressions
+====
+The RETURN clause
 
 .[[Q4]]Q4
 [source, cypher]
 ----
-RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
+RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS foo
 ----
 
-should produce a result that is grouped by `a` and `agg` should be computed for each group as the sum of all products of `b` and `c` added to the value `a` and multiplied by two, so that result would be:
+should produce a result that is grouped by `a` and `foo` should be computed for each group as the sum of all products of `b` and `c` added to the value `a` and multiplied by two, so that result would be:
 
 .Result Q4
 |===
-|a|agg
+|a|foo
 
 |1|32
 //(1 + (2*3 + 3*4) - 3) * 2
 |2|24
 //(2 + (3*5) - 5) * 2
 |===
+====
+
+[NOTE]
+====
+A less artificial example is calculating the total gross of an order as the discounted sum of line item net values (product price multiplied by amount) in query such as:
+
+.[[Q5]]Q5
+[source, cypher]
+----
+MATCH
+(c:Customer)-[:LOCATED_IN]->(s:State)
+(c)-[:ORDERED]->(o:Order)
+(o)-[:INCLUDES]->(li:LineItem)-->(p:Product)
+RETURN s AS state, c AS customer, o AS order,
+       SUM(li.amount * p.price) * c.discount * j.vat AS totalGross
+----
+====
 
 It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) the existing semantics or Cypher is imprecise on such queries.
 
-This proposal provides a precise semantics.
+A precise semantics on such queries has to provide
+
+* A clear definition which <ProjectionItem>s constitute the grouping keys
+* Clear rules for which sub-expressions are allowed in <ProjectionItem>s containing aggregation functions
+
+This proposal provides a such precise semantics.
 
 == Proposal
 
@@ -249,6 +292,12 @@ This proposal provides a precise semantics.
 _None. -- This proposal does not propose and net-new syntax._
 
 === Semantics
+
+The proposed semantics defined as a rewrite to the baseline semantics (similar to <<simpleRewrite,simple rewrite semantics>> discussed above).
+The proposed semantics does not cover all queries and hence implies a syntax restriction to rule out queries that are not covered.
+We discuss the rewrite and the syntax restriction in the follow two subsections.
+
+==== Rewrite
 
 For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_).
 
@@ -292,16 +341,87 @@ WITH AGGR(_L_)
 WITH POST_PROJ(_L_)
 ----
 
-For instance, <<Q4>> from above (`RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg`) can be defined as effectively equivalent to
+.Rewrite semantics
+====
+With this semantics, the RETURN clause in <<Q4>>
 
 [source, cypher]
 ----
-WITH a AS a, b*c AS agg_1, c AS agg_2
-WITH a AS a, SUM(agg_1) AS agg_1, MIN(agg_2) AS agg_2
-RETURN a AS a, (a + agg_1 - agg_2) * 2 AS agg
+RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
 ----
 
+is defined as effectively equivalent to
+
+[source, cypher]
+----
+WITH a AS a, b*c AS foo_1, c AS foo_2
+WITH a AS a, SUM(foo_1) AS foo_1, MIN(foo_2) AS foo_2
+RETURN a AS a, (a + foo_1 - foo_2) * 2 AS foo
+----
+====
+
+Note that the semantics proposed here also provides for the mixing of projection and aggregation that the <<simpleRewrite,simple rewrite semantics>> covers, i.e. it is a generalization of the simple rewrite semantics.
+
+.Rewrite semantics on simple mixing of projection and aggregation
+====
+The RETURN clause in <<Q3>>
+
+[source, cypher]
+----
+RETURN b-a AS x, SUM(b*c) AS sumBC
+----
+
+is defined as effectively equivalent to
+
+[source, cypher]
+----
+WITH b-a AS x, b*c AS sumBC_1
+WITH x AS x, SUM(sumBC_1) AS sumBC_1
+RETURN x AS x, sumBC_1 AS sumBC
+----
+====
+
+==== Syntax restriction
+
+The rewrite does not cover all syntactically possible queries.
+
+.Aggregation *not* covered by the rewrite
+====
+
+By the proposed semantics, the RETURN clause
+
+.[[Q6]]Q6
+[source, cypher]
+----
+RETURN a AS a, b + SUM(c) * 2 AS foo
+----
+
+is defined as effectively equivalent to
+
+[source, cypher]
+----
+WITH a AS a, c AS foo_1
+WITH a AS a, SUM(foo_1) AS foo_1
+RETURN a AS a, b + foo_1 * 2 AS foo
+----
+
+Note that variable `b` appears in the <ProjectionItem> `b + foo_1 * 2 AS foo` in the RETURN clause.
+However, variable `b` has already by removed from the driving table by the previous projections.
+In other words, the proposed rewrite produce invalid query text for <<Q6>>.
+====
+
+
+
 // TODO syntactic restriction implied by this semantics
+// - as in https://trello-attachments.s3.amazonaws.com/5b484b125e3c6d756d136739/5ff70a2eb9fa9c57a9dbdc1e/dd4878f225c6facb6e40d700a3bbde7b/Implementation_report.pdf
+// -> The non-aggregating sub-expressions of an expression that contains an aggregation MUST be garanteed to be constant under the grouping key.
+// An implementation expected to detect by any of following situation
+// - The whole sub-expression is part of the explicitly projected grouping key (under left-associative parsing)
+// - Each operand in the sub-expression is either:
+//   - Part of the grouping key from being projected explicitly
+//   - A constant
+//   - A parameter
+
 
 === Examples
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -118,7 +118,7 @@ and
 
 [source, cypher, subs="quotes"]
 ----
-RETURN _k_~1~ AS _k_~1~, _k_~2~ AS _k_~2~, ..., _k~N~_ AS _k~N~_,
+RETURN _k_~1~ AS _ka_~1~, _k_~2~ AS _ka_~2~, ..., _k~N~_ AS _ka~N~_,
        _agg_~1~(_x_~1~) AS _al_~1~, _agg_~2~(_x_~2~) AS _al_~2~, ..., _agg~M~_(_x~M~_) AS _al~M~_
 ----
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -1,4 +1,4 @@
-= CIP2015-05-13 Existential subqueries
+= CIP2021-07-07 Grouping key and aggregation expressions
 :numbered:
 :toc:
 :toc-placement: macro
@@ -17,8 +17,190 @@ toc::[]
 
 == Background
 
+=== Problem
+
+Cypher allows grouping and aggregating (form here on just referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
+
+Formally, the aggregation of a driving table _D_ can be described formally as
+pass:q[γ<sub>_K_, _A_</sub>(D)] where
+
+* _K_ is a (possibly empty) set of grouping keys _k_ and every _k_ is a variable in the driving table _D_, and
+* _A_ is a non-empty set of aggregation functions _agg_(_x_)_ where _x_ being a variable in the driving table _D_
+
+The WITH and the RETURN clause also allow projecting the driving table including the computation of new columns (in database theory, this is called extended projection).
+
+The projection of a driving table _D_ can be described formally as pass:q[π<sub>_P_</sub>(D)] where
+
+* _P_ is a nonempty set of pair _(ex, al)_ where
+** _ex_ is a tree of operations of the expression sub-language where each of the leaves is either
+*** a constant (such as a value literal or a label),
+*** a parameter, or
+*** a variable in the driving table _D_; and
+** _al_ is variable name -- also called in _alias_ in this context -- that different from all other variables _x_ with (·, _x_) ∈ _P_.
+
+The WITH and the RETURN clauses also allow renaming, ordering and truncating the driving table, but let's ignore these aspects for now.
+
+The WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty list _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>] `_ex_ AS _al_` where _ex_ is an expression and _al_ is an alias.
+The expression of an <ProjectionItem> is allowed to contain aggregation functions.
+Consequently, the semantics of both clause has to specify how _P_, _K_, and _A_ are defined for a given _L_.
+
+It has been documented on multiple occasions (e.g. cf. http://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/[First oCIG Meeting]) the existing semantics or Cypher is imprecise how _P_, _K_, and _A_ are defined for a given _L_.
+This proposal provides a precise semantics.
+
+=== Analysis
+
+Consider a driving table
+
+.Example driving table
+|===
+|a|b|c
+
+|1|2|3
+|1|3|4
+|2|3|5
+|===
+
+and the RETURN clause
+
+.Q1
+[source, cypher]
+----
+RETURN a AS a, SUM(c) AS sumC
+----
+
+Intuitively, it seems clear that the result should be grouped by `a` and the sum of all `c` should be computed as `sumC` for each group, so that result would be:
+
+.Result Q1
+|===
+|a|sumC
+
+|1|7
+|2|5
+|===
+
+The RETURN clause
+
+.Q2
+[source, cypher]
+----
+RETURN a AS a, SUM(b*c) AS sumBC
+----
+
+is intuitively clear in the same way.
+The result should be grouped by `a` and the sum of all products of `b` and `c` should be computed as `sumBC` for each group, so that result would be:
+
+.Result Q2
+|===
+|a|sumBC
+
+|1|18
+|2|15
+|===
+
+Similarly, the RETURN clause
+
+.Q3
+[source, cypher]
+----
+RETURN b-a AS x, SUM(b*c) AS sumBC
+----
+
+should produce a result that is grouped by `b` minus `a` (as `x`) and the sum of all products of `b` and `c` should be computed as `sumBC` for each group, so that result would be:
+
+.Result Q3
+|===
+|x|sumBC
+
+|1|21
+|2|12
+|===
+
+In all three cases, the semantics can be described as follows.
+The set of <ProjectionItem>s _L_ is split in two set _LK_ and _LA_, so that
+
+* _LA_ are all <ProjectionItem>s `_aggex_ AS _al_` in _L_ that contain an aggregation function, i.e. where _aggex_ is of the form _agg_(_ex_) and _ex_ is a valid expression
+* _LK_ are all remaining <ProjectionItem>s in _L_ but no _LA_, i.e. _LK_ = _L_ - _LA_
+
+Further
+
+* For a <ProjectionItem> _p_ = `_ex_ AS _al_`,
+** If _p_ ∈ _LK_
+*** Let `PROJ(_p_)` be `_ex_ AS _al_` and
+*** Let `AGGR(_p_)` be `_al_ AS _al_`
+** If _p_ ∈ _LA_ and _ex_ = _agg_(_x_)
+*** Let `PROJ(_p_)` be `_x_ AS _al_` and
+*** Let `AGGR(_p_)` be `_agg_(_al_) AS _al_`
+* For a set of <ProjectionItem>s _L_ = {_p1_, _p2_, ... _pn_},
+** Let `PROJ(_L_)` be `PROJ(_p1_), PROJ(_p2_), ..., PROJ(_pn_)` and
+** Let `AGGR(_L_)` be `AGGR(_p1_), AGGR(_p2_), ..., AGGR(_pn_)`
+
+With this the semantics of `RETURN _L_` can be defined as effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PROJ(_L_)
+RETURN AGGR(_L_)
+----
+
+Analoguously, the semantics of `WITH _L_` can be defined as effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH PROJ(_L_)
+WITH AGGR(_L_)
+----
+
+For instance, Q3 from above (`RETURN b-a AS x, SUM(b*c) AS sumBC`) can be defined as effectively equivalent to
+
+[source, cypher]
+----
+WITH b-a AS x, b*c AS sumBC
+RETURN x AS x, SUM(sumBC) AS sumBC
+----
+
+While this solution works nicely for the considered examples, it is limited.
+Specifically, it only supports aggregation function in expressions of the form `_agg_(_ex_)`.
+
+Cypher, however, also allows aggregation functions in expressions of the form, such as
+
+* `_ex1_ + _agg_(_ex2_)`
+* `_agg_(_ex2_) + _ex1_`
+* `_agg1_(_ex2_) + _ex1_ * _agg1_(_ex3_)`
+
+However, such expressions may still be sensible and useful.
+
+Consider the RETURN clause
+
+.Q4
+[source, cypher]
+----
+RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg
+----
+
+should produce a result that is grouped by `a` and `agg` should be computed for each group as the sum of all products of `b` and `c` added to the value `a` and multiplied by two, so that result would be:
+
+.Result Q4
+|===
+|a|agg
+
+|1|32 //(1 + (2*3 + 3*4) - 3) * 2
+|2|24 //(2 + (3*5) - 5) * 2
+|===
+
+// TODO extend rewrite semantics
+
+For instance, Q4 from above (`RETURN a AS a, (a + SUM(b*c) - MIN(c)) * 2 AS agg`) can be defined as effectively equivalent to
+
+[source, cypher]
+----
+WITH a AS a, b*c AS agg_1, c AS agg_2
+WITH a AS a, SUM(agg_1) AS agg_1, MIN(agg_2) AS agg_2
+RETURN a AS a, (a + agg_1 - agg_2) * 2 AS agg
+----
 
 == Proposal
+
+
 
 
 === Syntax

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -512,8 +512,7 @@ Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _GROU
 For an expression _ex_ and a projection list _L_, let _AVAILABLE_TO_ORDER_(_ex_, _L_) hold
 
 * If _ex_ is either
-** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
-** A grouping key, i.e. _ex_ ∈ _GROUPING_KEYS_AND_ALIASES_(_L_),
+** A grouping key or an alias, i.e. _ex_ ∈ _GROUPING_KEYS_AND_ALIASES_(_L_),
 ** A constant, or
 ** A parameter,
 * or if _ex_ comprises of sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.
@@ -618,6 +617,80 @@ For each example we list why it is invalid.
 
 . `MATCH (a)-[]->(b) RETURN a AS x, size(keys(x)) + count(b.y)`
 * The sub-expression `x` is not a grouping key; it is the alias of a grouping key, which are not visible to <ProjectionItem>s within the same clause.
+
+=== Valid orderings
+
+The following clauses exhibit valid row orderings.
+For each example we list why it is valid.
+
+. `RETURN 1 + count(\*) AS x ORDER BY x`
+* The expression `x` is an alias.
+
+. `RETURN 1, 1 + count(*) ORDER BY 2`
+* The expression `1` is a constant.
+
+. `RETURN $x + count($x) ORDER BY $x`
+* The expression `$x` is a parameter.
+
+. `MATCH (a) RETURN a.x, 1 + count(a.x) ORDER BY a.x % 2`
+* The sub-expression `a.x` is a grouping key.
+* The sub-expression `2` is a constant.
+
+. `MATCH (a) WITH a.x AS ax RETURN ax, ax + count(ax) ORDER BY ax`
+* The expression `ax` is a grouping key.
+
+. `MATCH (a)-[]->(b) RETURN a, a.x + count(b.y) ORDER BY a.y`
+* The sub-expression `a` is a grouping key.
+
+. `MATCH (a)-[]->(b) RETURN a, count(b.y) ORDER BY size(keys(a))`
+* The sub-expression `a` is a grouping key.
+
+. `MATCH (x) RETURN x.a, x.b, x.c, x.a + x.b + count(x) + x.c ORDER BY x.a + x.c`
+* The sub-expressions `x.a` and `x.c` are grouping keys.
+
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1`
+* The sub-expression `a.x + 1` is a grouping key.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax)`
+* The sub-expression `ax` is a grouping key.
+* The sub-expression `1` is a constant.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax) ORDER BY ax + 2`
+* The sub-expression `ax` is a grouping key.
+* The sub-expression `2` is a constant.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) ORDER BY x + 2`
+* The sub-expression `x` is an alias.
+* The sub-expression `2` is a constant.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) AS y ORDER BY x + 2 - y`
+* The sub-expressions `x` and `y` are aliases.
+* The sub-expression `2` is a constant.
+
+. `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b) ORDER BY map.a`
+* The expression `map.a` is a grouping key.
+
+. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x) ORDER BY x.a + x.b + x.c`
+* The expression `x.a + x.b + x.c` is a grouping key.
+
+=== Invalid orderings
+
+The following clauses exhibit invalid row orderings.
+For each example we list why it is invalid.
+
+. `RETURN 1 + count(\*) ORDER BY 1 + count(*)`
+* The expression `1 + count(*)` is not a grouping key.
+
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 2`
+* The expression `a.x + 2` is not a grouping key.
+* The sub-expression `2` is a constant, but sub-expression `a.x` is not a grouping key.
+
+. `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b) ORDER BY map.b`
+* The sub-expression `map.b` is not a grouping key.
+
+. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x) ORDER BY x.a + x.c`
+* The expression `x.a + x.c` is not a grouping key.
+* The sub-expressions `x.a` and `x.c` and `x` are not grouping keys, either.
 
 == What others do
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -10,7 +10,7 @@
 [abstract]
 .Abstract
 --
-This CIP clarifies the semantics of grouping and aggregation functionality in the WITH and the RETURN clause of Cypher.
+This CIP defines the semantics of grouping and aggregation functionality in the WITH and the RETURN clause of Cypher.
 --
 
 toc::[]

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -556,6 +556,7 @@ For an expression _ex_ and a projection list _L_, let _AVAILABLE_TO_ORDER_(_ex_,
 * If _ex_ is either
 ** A constant,
 ** A parameter,
+** An aggregation function, i.e. of the form `_agg_(_subEx_)`,
 ** A grouping key, i.e. _ex_ ∈ _RECOGNIZED_GROUPING_KEYS_(_L_), or
 ** An alias, i.e. _ex_ ∈ _RECOGNIZED_ALIASES_(_L_),
 * or if _ex_ comprises sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -672,7 +672,7 @@ For each example we list why it is invalid.
 . `MATCH (a)-[c]->(b) WITH a, c, {dim: properties(b)} AS b RETURN a, b.dim.x, sum(c.p) + b.dim.x`
 * The sub-expression `b.dim.x` is not a recognized grouping key.
 
-=== Valid orderings
+==== Valid orderings
 
 The following clauses exhibit valid row orderings.
 For each example we list why it is valid.
@@ -721,7 +721,7 @@ For each example we list why it is valid.
 . `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b) ORDER BY map.a`
 * The expression `map.a` is a recognized grouping key.
 
-=== Invalid orderings
+==== Invalid orderings
 
 The following clauses exhibit invalid row orderings.
 For each example we list why it is invalid.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -687,6 +687,10 @@ For each example we list why it is valid.
 . `RETURN $x + count($x) ORDER BY $x`
 * The expression `$x` is a parameter.
 
+. `RETURN 1 + count(\*) ORDER BY 1 + count(*)`
+* The expression `1` is a constant.
+* The expression `count(*)` is an aggregation function.
+
 . `MATCH (a) RETURN a.x, 1 + count(a.x) ORDER BY a.x % 2`
 * The sub-expression `a.x` is a recognized grouping key.
 * The sub-expression `2` is a constant.
@@ -711,9 +715,19 @@ For each example we list why it is valid.
 * The sub-expression `ax` is a recognized grouping key.
 * The sub-expression `2` is a constant.
 
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax) ORDER BY ax + 2 - count(ax)`
+* The sub-expression `ax` is a recognized grouping key.
+* The sub-expression `2` is a constant.
+* The sub-expression `count(ax)` is an aggregation function.
+
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) ORDER BY x + 2`
 * The sub-expression `x` is an recognized alias.
 * The sub-expression `2` is a constant.
+
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) ORDER BY x + 2 - count(ax)`
+* The sub-expression `x` is an recognized alias.
+* The sub-expression `2` is a constant.
+* The sub-expression `count(ax)` is an aggregation function.
 
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) AS y ORDER BY x + 2 - y`
 * The sub-expressions `x` and `y` are recognized aliases.
@@ -727,10 +741,10 @@ For each example we list why it is valid.
 The following clauses exhibit invalid row orderings.
 For each example we list why it is invalid.
 
-. `RETURN 1 + count(\*) ORDER BY 1 + count(*)`
-* The expression `1 + count(*)` is not a grouping key.
-
 . `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1`
+* The sub-expression `a.x + 1` is not a recognized grouping key.
+
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1 + count(a.x)`
 * The sub-expression `a.x + 1` is not a recognized grouping key.
 
 . `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 2`

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 == Background
 
-In this CIP we assume two baseline semantics as a given and well-defined.
+In this CIP we assume two baseline semantics as a given and as well-defined.
 Each baseline semantics captures on capability of the WITH and the RETURN clause in isolation -- similar to https://en.wikipedia.org/wiki/Relational_algebra[relational algebra operators].
 
 _<<Baseline projection>>_ :: Describes the projection of binding table
@@ -95,7 +95,7 @@ projects each row in the driving table to `b` minus `a` (as `x`) and the product
 
 Cypher allows grouping and aggregating (often simply referred to as _aggregation_) the driving table in the WITH and in the RETURN clause.
 
-Formally, the aggregation of a driving table _D_ can be described formally as
+Formally, the aggregation of a driving table _D_ can be described as
 pass:q[γ<sub>_K_, _A_</sub>(_D_)] where
 
 * _K_ is a (possibly empty) set of pairs (_k_, _al_) where
@@ -104,7 +104,7 @@ pass:q[γ<sub>_K_, _A_</sub>(_D_)] where
 * _A_ is a non-empty set of triple (_agg_, _x_, _al_) where
 ** _agg_ is an aggregation function and
 ** _x_ is a variable in the driving table _D_
-** _al_ is an alias that different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ and _x_ with (·, _x_) ∈ _K_.
+** _al_ is an alias that is different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ and _x_ with (·, _x_) ∈ _K_.
 
 Assuming _K_ = {(_k_~1~, _ka_~1~), (_k_~2~, _ka_~1~), ..., (_k~N~_, _ka~N~_)} and _A_ = {(_agg_~1~, _x_~1~, _al_~1~), (_agg_~2~, _x_~2~, _al_~2~), ..., (_agg~M~_, _x~M~_, _al~M~_)}, the Cypher equivalent of pass:q[γ<sub>_K_, _A_</sub>(_D_)] is
 
@@ -285,10 +285,10 @@ It has been documented on multiple occasions (e.g. cf. http://opencypher.org/art
 
 A precise semantics on such queries has to provide
 
-* A clear definition which <ProjectionItem>s constitute the grouping keys
-* Clear rules which sub-expressions are allowed in <ProjectionItem>s containing aggregation functions
+* A clear definition of which <ProjectionItem>s constitute the grouping keys
+* Clear rules of which sub-expressions are allowed in <ProjectionItem>s containing aggregation functions
 
-This proposal provides a such precise semantics.
+This proposal provides such a precise semantics.
 
 == Proposal
 
@@ -466,7 +466,7 @@ For sub-expression `b`
 * in _L_ = `a AS a, b + foo_1 * 2 AS foo`,
 
 _CONSTANT_(`b`, _L_) does not hold.
-`b` is neither an aggregation function, a grouping key, a constant, a parameter, nor has it any sub-expressions.
+`b` is neither an aggregation function, a grouping key, a constant, a parameter, nor does it have any sub-expressions.
 ====
 
 ==== Row ordering and pagination

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -730,7 +730,7 @@ For each example we list why it is invalid.
 * The expression `1 + count(*)` is not a grouping key.
 
 . `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1`
-* The sub-expression `a.x + 1` is a recognized grouping key.
+* The sub-expression `a.x + 1` is not a recognized grouping key.
 
 . `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 2`
 * The expression `a.x + 2` is not a grouping key.

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -573,6 +573,81 @@ Cypher allows to omit the aliases, particularly in the RETURN clause, though.
 However, the alias omission rules are based on the assumption that an implementation will infer a more or less reasonable alias if an alias is omitted by the user.
 Hence, it is safe for this proposal to assume that all <ProjectionItem>s have an alias.
 
+==== Project wildcard `*`
+
+Cypher support `*` as projection wildcard.
+The wildcard can appear before the list of <ProjectionItem>s _L_, i.e. `RETURN *`, `WITH *`, `RETURN *, _L_` and `WITH *, _L_` valid clauses, cf. https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItems[<ProjectionItems>].
+The semantics of the wildcard is the projection of all columns of the driving table.
+
+This semantics can be defined by a rewrite to the baseline semantics, which removes the wildcard _before_ the actual projection and aggregation semantics, including the semantics discussed in Section "<<Rewrite>>".
+Likewise, the <<Syntax restriction>> applies _after_ the wildcard effectively been removed.
+
+Given a driving table _D_, let {_VAR~1~_(_D_), _VAR~2~_(_D_), ..., _VAR~N~_(_D_)} be the set of all variables in _D_.
+
+[IMPORTANT]
+====
+`RETURN _DISTINCT_ * _X_` with an incoming driving table _D_ is effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+RETURN _DISTINCT_ _VAR~1~_(_D_), _VAR~2~_(_D_), ..., _VAR~N~_(_D_) _X_
+----
+
+Analogously, `WITH _DISTINCT_ * _X_` is effectively equivalent to
+
+[source, cypher, subs="quotes"]
+----
+WITH _DISTINCT_ _VAR~1~_(_D_), _VAR~2~_(_D_), ..., _VAR~N~_(_D_) _X_
+----
+====
+
+Note that _X_ is anything valid syntax in a https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=Return[<Return>] or https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=With[<With>] after `*` specified by the query, respectively.
+_DISTINCT_ is the optional keyword `DISTINCT` if specified by the query or otherwise empty.
+
+.Semantics of projection wildcard `*`
+====
+
+Assume the following driving table:
+
+|===
+|a|b
+
+|1|2
+|1|2
+|2|3
+|===
+
+[source, cypher]
+----
+RETURN *, b * SUM(a) AS x ORDER BY x
+----
+is effectively equivalent to
+
+[source, cypher]
+----
+RETURN a, b, b * SUM(a) AS x ORDER BY x
+----
+
+and, hence, valid under the <<Syntax restriction>>.
+Further, it is effectively equivalent to
+
+[source, cypher]
+----
+WITH a, b, a AS x_1
+WITH a, b, SUM(x_1) AS x_1
+RETURN a, b, b * x_1 AS x ORDER BY x
+----
+
+by the <<Rewrite>> semantics, so that it results in:
+
+|===
+|a|b|x
+
+|1|2|4
+|2|3|6
+|===
+====
+
 === Examples
 
 ==== Valid aggregations

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -306,7 +306,7 @@ Subsequently, we give a separate and brief consideration of how to these aspects
 
 ==== Rewrite
 
-For an expression _ex_, let _AGG_(_ex_) be the set of aggregating (sub-)expressions, i.e. (sub-)expressions _aggex_ of the form _agg_(_preEx_).
+For an expression _ex_, let _AGG_(_ex_) be the set of aggregating (sub-)expressions, i.e. (sub-)expressions of the form _agg_(_preEx_).
 
 For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of aggregating (sub-)expressions, i.e. _AGG_(_p_) = _AGG_(_postEx_).
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -677,7 +677,7 @@ For each example we list why it is invalid.
 The following clauses exhibit valid row orderings.
 For each example we list why it is valid.
 
-. `RETURN 1 + count(\*) AS x ORDER BY x`
+. `RETURN 1 + count(*) AS x ORDER BY x`
 * The expression `x` is a recognized alias.
 
 . `RETURN 1, 1 + count(*) ORDER BY 2`

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -31,7 +31,7 @@ The simple rewrite semantics lays the foundation for the rewrite semantics that 
 
 We briefly demonstrate the <<Limits of the simple rewrite semantics>> to motivate the proposed semantics.
 
-Further, we use following driving table in most of the CIP's examples:
+Further, we use the following driving table in most of the CIP's examples:
 
 .Example driving table
 |===
@@ -100,13 +100,13 @@ pass:q[γ<sub>_K_, _A_</sub>(_D_)] where
 
 * _K_ is a (possibly empty) set of pairs (_k_, _al_) where
 ** _k_ is a variable -- called a _grouping key_ -- in the driving table _D_,
-** _al_ is an _alias_ that different from all other aliases _x_ with (·, _x_) ∈ _K_., and
+** _al_ is an _alias_ that is different from all other aliases _x_ with (·, _x_) ∈ _K_., and
 * _A_ is a non-empty set of triple (_agg_, _x_, _al_) where
 ** _agg_ is an aggregation function and
 ** _x_ is a variable in the driving table _D_
 ** _al_ is an alias that is different from all other aliases _x_ with (·, ·, _x_) ∈ _A_ and _x_ with (·, _x_) ∈ _K_.
 
-Assuming _K_ = {(_k_~1~, _ka_~1~), (_k_~2~, _ka_~1~), ..., (_k~N~_, _ka~N~_)} and _A_ = {(_agg_~1~, _x_~1~, _al_~1~), (_agg_~2~, _x_~2~, _al_~2~), ..., (_agg~M~_, _x~M~_, _al~M~_)}, the Cypher equivalent of pass:q[γ<sub>_K_, _A_</sub>(_D_)] is
+Assuming _K_ = {(_k_~1~, _ka_~1~), (_k_~2~, _ka_~2~), ..., (_k~N~_, _ka~N~_)} and _A_ = {(_agg_~1~, _x_~1~, _al_~1~), (_agg_~2~, _x_~2~, _al_~2~), ..., (_agg~M~_, _x~M~_, _al~M~_)}, the Cypher equivalent of pass:q[γ<sub>_K_, _A_</sub>(_D_)] is
 
 [source, cypher, subs="quotes"]
 ----
@@ -149,7 +149,7 @@ groups the driving table by `a` and computes the sum of all `c` as `sumC` for ea
 Cypher's WITH and RETURN clause are syntactically more flexible than the two baseline semantics.
 In particular, they allow mixing aggregation and projection rather freely.
 
-Specifically, the WITH and the RETURN clause denoted the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty duplicate-free list _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
+Specifically, the WITH and the RETURN clause denote the parameters for projection (_P_) and aggregation (_K_ and _A_) with a single nonempty duplicate-free list _L_ of https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ProjectionItem[<ProjectionItem>]s `_ex_ AS _al_` where
 
 * _ex_ is an expression that is allowed to contain aggregation functions and
 * _al_ is an alias.
@@ -243,7 +243,7 @@ Cypher, however, also allows aggregation functions to appear as sub-expression o
 
 Such expressions can still be sensible and useful.
 
-.aggregation functions a sub-expressions
+.Aggregation functions as sub-expressions
 ====
 The RETURN clause
 
@@ -300,28 +300,35 @@ This proposal does not propose any net-new syntax.
 
 The proposed grouping and aggregation semantics is defined as a rewrite to the baseline semantics (similar to <<Simple rewrite semantics>> discussed above).
 The proposed semantics does not cover all syntactically possible queries and hence requires a syntax restriction to prohibit queries that are not covered.
-We discuss the <<Rewrite>> and the <<Syntax restriction>> in the follow two subsections.
+We discuss the <<Rewrite>> and the <<Syntax restriction>> in the following two subsections.
 We simplify this discussion by ignoring row ordering and pagination as well as omitted aliases.
 Subsequently, we give a separate and brief consideration of how to these aspects fit into the proposal, cf. <<Row ordering and pagination>> and <<Omitted aliases>>, respectively.
 
 ==== Rewrite
 
-For an expression _ex_, let _AGG_(_ex_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_).
+For an expression _ex_, let _AGG_(_ex_) be the set of aggregating (sub-)expressions, i.e. (sub-)expressions _aggex_ of the form _agg_(_preEx_).
 
-For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of (sub-)expressions _aggex_ of the form _agg_(_preEx_), i.e. _AGG_(_p_) = _AGG_(_postEx_).
+For a <ProjectionItem> _p_ = `_postEx_ AS _al_`, let _AGG_(_p_) be the set of aggregating (sub-)expressions, i.e. _AGG_(_p_) = _AGG_(_postEx_).
 
-The <ProjectionItem>s in _L_ is split according to _AGG_(_p_) in two cases
+.Set of aggregating (sub-)expressions
+====
+_AGG_( `(a + SUM(b*c) - MIN(c)) * 2 AS foo` ) +
+ = _AGG_( `(a + SUM(b*c) - MIN(c)) * 2` ) +
+ = { `SUM(b*c)`, `MIN(c)` }
+====
 
-* <ProjectionItem>s _p_ in _L_ is an aggregate if _AGG_(_p_) is non-empty
-* <ProjectionItem>s _p_ in _L_ is a grouping key if _AGG_(_p_) is empty
+The <ProjectionItem>s in _L_ are split according to _AGG_(_p_) in two cases
+
+* A <ProjectionItem> _p_ in _L_ is an aggregate if _AGG_(_p_) is non-empty
+* A <ProjectionItem> _p_ in _L_ is a grouping key if _AGG_(_p_) is empty
 
 For a <ProjectionItem> _p_ = `_ex_ AS _al_`,
 
-* If _AGG_(_p_) = ∅
+* If _AGG_(_p_) = ∅ (i.e. _p_ is a grouping key)
 ** Let `_PRE_PROJ_(_p_)` be `_ex_ AS _al_`,
 ** Let `_AGGR_(_p_)` be `_al_ AS _al_`, and
 ** Let `_POST_PROJ_(_p_)` be `_al_ AS _al_`
-* If _AGG_(_p_) = {`_agg_~1~(_preEx_~1~)`, `_agg_~2~(_preEx_~2~)`, ..., `_agg~N~_(_preEx~N~_)`} with _N_ > 0
+* If _AGG_(_p_) = {`_agg_~1~(_preEx_~1~)`, `_agg_~2~(_preEx_~2~)`, ..., `_agg~N~_(_preEx~N~_)`} with _N_ > 0 (i.e. _p_ is an aggregate)
 ** Let `_PRE_PROJ_(_p_)` be `_preEx_~1~ AS _al_+++_+++1, _preEx_~2~ AS _al_+++_+++2, ..., _preEx~N~_ AS _al_+++_+++_N_`,
 ** Let `_AGGR_(_p_)` be `_agg_~1~(_al_+++_+++1) AS _al_+++_+++1, _agg_~2~(_al_+++_+++2) AS _al_+++_+++2, ..., _agg~N~_(_al_+++_+++_N_) AS _al_+++_+++_N_`, and
 ** Let `_POST_PROJ_(_p_)` be `_postEx_ AS _al_` where _postEx_ is _ex_ with each `_agg~i~_(_preEx~i~_)` in _AGG_(_p_) being replaced by `_al_+++_+++_i_` for 1 ≤ _i_ ≤ _N_.
@@ -391,7 +398,7 @@ RETURN x AS x, sumBC_1 AS sumBC
 ==== Syntax restriction
 
 The rewrite does not cover all syntactically possible queries.
-Specifically, any <ProjectItems> containing
+Specifically, any <ProjectItem> containing
 
 * an aggregation function and
 * a sub-expression that is
@@ -425,8 +432,19 @@ In other words, the proposed rewrite produces an invalid query for <<Q5>>.
 ====
 
 To prevent such invalid rewrites, this proposal includes a syntax restriction to be imposed on RETURN and WITH clauses.
+The definition of the syntax restriction happens in three steps:
 
-Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _GROUPING_KEYS_(_L_) be the set of all expressions _ex_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_ where _AGG_(_p_) is empty.
+. Definition of grouping keys that are recognized as constant sub-expressions
+. Definition of constant sub-expressions
+. Definition of the syntax restriction
+
+Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _RECOGNIZED_GROUPING_KEYS_(_L_) be the set of all expressions _ex_
+
+* For which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_ where _AGG_(_p_) is empty and
+* Which are either
+** A variable
+** Element property access on a variable
+** Static map access on a variable
 
 .Grouping keys
 ====
@@ -435,21 +453,48 @@ For the RETURN clause
 .[[Q6]]Q6
 [source, cypher]
 ----
-RETURN b-a AS x, c AS c, c + SUM(b) AS sumBC
+RETURN b-a AS x, c AS c, d.prop AS d, c + SUM(b) AS sum
 ----
 
-_GROUPING_KEYS_(_L_) is {`b-a`, `x`, `c`}.
+_RECOGNIZED_GROUPING_KEYS_( `b-a AS x, c AS c, d.prop AS d, c + SUM(b) AS sum` ) +
+ = { `c`, `d.prop` }.
 
+Note that `b-a` is grouping key since _AGG_(`b-a`) is empty. However, it is not a grouping key that needs to be recognized as such for propose of identifying constant sub-expressions. Hence, `b-a` is not in _RECOGNIZED_GROUPING_KEYS_( `b-a AS x, c AS c, d.prop AS d, c + SUM(b) AS sum` ).
 ====
 
 For an expression _ex_ and a projection list _L_, let _CONSTANT_(_ex_, _L_) hold
 
 * If _ex_ is either
-** A aggregation function, i.e. of the form `_agg_(_subEx_)`,
-** A grouping key, i.e. _ex_ ∈ _GROUPING_KEYS_(_L_),
-** A constant, or
+** A constant,
 ** A parameter,
-* or if _ex_ comprises of sub-expressions, it only comprises sub-expressions _subEx_ for which _CONSTANT_(_subEx_, _L_) holds.
+** An aggregation function, i.e. of the form `_agg_(_subEx_)`, or
+** A grouping key, i.e. _ex_ ∈ _RECOGNIZED_GROUPING_KEYS_(_L_),
+* or if _ex_ comprises sub-expressions, it only comprises sub-expressions _subEx_ for which _CONSTANT_(_subEx_, _L_) holds.
+
+.Constant expressions
+====
+For the RETURN clause
+
+.[[Q7]]Q7
+[source, cypher]
+----
+RETURN b-a AS x, c AS c, d.prop AS d, (2*c + SUM(b) + d.prop) / $pi AS val
+----
+
+_CONSTANT_( `(2*c + SUM(b) + d.prop) / $pi`, _L_) = { +
+  `2`, // a constant +
+  `c`, // a grouping key +
+  `2*c`, // only comprises constant sub-expressions +
+  `SUM(b)`, // an aggregation function +
+  `d.prop`, // a grouping key +
+  `(2*c + SUM(b) + d.prop)`, // only comprises constant sub-expressions +
+  `$pi`, // a parameter +
+  `(2*c + SUM(b) + d.prop) / $pi` // only comprises constant sub-expressions +
+}.
+
+====
+
+Based on the notion of constant expression, the syntax restriction is defined as:
 
 [IMPORTANT]
 .Syntax restriction
@@ -473,8 +518,8 @@ _CONSTANT_(`b`, _L_) does not hold.
 
 The WITH and the RETURN clause allow to
 
-* order the rows of the result table with the ORDER BY sub-clause and
-* paginate the result table with the SKIP and LIMIT sub-clauses.
+* Order the rows of the result table with the ORDER BY sub-clause and
+* Paginate the result table with the SKIP and LIMIT sub-clauses.
 
 Assuming the baseline semantics includes ORDER BY, SKIP, and LIMIT capabilities, the grouping and aggregation semantics extends as follows:
 
@@ -504,18 +549,16 @@ Since these expressions are effectively evaluate after all _POST_PROJ_(_p~i~_) e
 
 However, <SortItem>s can refer to aliases introduced by _POST_PROJ_(_p~i~_).
 
-Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _GROUPING_KEYS_AND_ALIASES_(_L_) be the set of
-
-* all expressions _ex_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_ where _AGG_(_p_) is empty and
-* all aliases _al_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_.
+Given a list of <ProjectionItem>s _L_ = {_p_~1~, _p_~2~, ..., _p~N~_}, let _RECOGNIZED_ALIASES_(_L_) be the set of all aliases _al_ for which there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_.
 
 For an expression _ex_ and a projection list _L_, let _AVAILABLE_TO_ORDER_(_ex_, _L_) hold
 
 * If _ex_ is either
-** A grouping key or an alias, i.e. _ex_ ∈ _GROUPING_KEYS_AND_ALIASES_(_L_),
-** A constant, or
+** A constant,
 ** A parameter,
-* or if _ex_ comprises of sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.
+** A grouping key, i.e. _ex_ ∈ _RECOGNIZED_GROUPING_KEYS_(_L_), or
+** An alias, i.e. _ex_ ∈ _RECOGNIZED_ALIASES_(_L_),
+* or if _ex_ comprises sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.
 
 [IMPORTANT]
 ====
@@ -556,35 +599,37 @@ For each example we list why it is valid.
 * The sub-expression `1` is a constant.
 
 . `MATCH (a) RETURN a.x, a.x + count(a.x)`
-* The sub-expression `a.x` is a grouping key.
+* The sub-expression `a.x` is a recognized grouping key.
 
 . `MATCH (a) WITH a.x AS ax RETURN ax, ax + count(ax)`
-* The sub-expression `ax` is a grouping key.
+* The sub-expression `ax` is a recognized grouping key.
 
 . `MATCH (a)-[]->(b) RETURN a, a.x + count(b.y)`
-* The sub-expression `a` is a grouping key.
+* The sub-expression `a` is a recognized grouping key.
 
 . `MATCH (a)-[]->(b) RETURN a, size(keys(a)) + count(b.y)`
-* The sub-expression `a` is a grouping key.
+* The sub-expression `a` is a recognized grouping key.
 
 . `MATCH (x) RETURN x.a, x.b, x.c, x.a + x.b + count(x) + x.c`
-* The sub-expressions `x.a`, `x.b`, and `x.c` are grouping keys.
-
-. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x)`
-* The sub-expression `a.x + 1` is a grouping key.
+* The sub-expressions `x.a`, `x.b`, and `x.c` are recognized grouping keys.
 
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax)`
-* The sub-expression `ax` is a grouping key.
+* The sub-expression `ax` is a recognized grouping key.
 * The sub-expression `1` is a constant.
 
 . `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b)`
-* The sub-expression `map.a` is a grouping key.
-
-. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x)`
-* The sub-expression `x.a + x.b + x.c` is a grouping key.
+* The sub-expression `map.a` is a recognized grouping key.
 
 . `MATCH (x) WITH x.a + x.b + x.c AS sum RETURN sum, sum + count(*) + sum`
-* The sub-expression `sum` is a grouping key.
+* The sub-expression `sum` is a recognized grouping key.
+
+. `MATCH (x)-[]->(y) WITH x.a AS a, collect(y) AS b RETURN a, b, a.x[2] + sum(a.c) + -(b[3].x)*3`
+* The sub-expressions `a` and `b` are a recognized grouping key.
+* The sub-expressions `2` and `3` are a constant.
+
+. `MATCH (a)-[b]->(c) WITH x.a AS a, collect(y) AS b RETURN a, b.y, a.x + sum(c.z) + b.y*3`
+* The sub-expressions `a` and `b.y` are a recognized grouping key.
+* The sub-expression `3` is a constant.
 
 ==== Invalid aggregations
 
@@ -612,11 +657,20 @@ For each example we list why it is invalid.
 . `MATCH (a) RETURN a.x * a.x, a.x + collect(a.x)`
 * The sub-expression `a.x` is not a grouping key.
 
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x)`
+* The sub-expression `a.x + 1` is not a recognized grouping key.
+
+. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x)`
+* The sub-expression `x.a + x.b + x.c` is not a recognized grouping key.
+
 . `MATCH (a)-[]->(b) RETURN a AS x, x.x + count(b.y)`
 * The sub-expression `x` is not a grouping key; it is the alias of a grouping key, which are not visible to <ProjectionItem>s within the same clause.
 
 . `MATCH (a)-[]->(b) RETURN a AS x, size(keys(x)) + count(b.y)`
 * The sub-expression `x` is not a grouping key; it is the alias of a grouping key, which are not visible to <ProjectionItem>s within the same clause.
+
+. `MATCH (a)-[c]->(b) WITH a, c, {dim: properties(b)} AS b RETURN a, b.dim.x, sum(c.p) + b.dim.x`
+* The sub-expression `b.dim.x` is not a recognized grouping key.
 
 === Valid orderings
 
@@ -624,7 +678,7 @@ The following clauses exhibit valid row orderings.
 For each example we list why it is valid.
 
 . `RETURN 1 + count(\*) AS x ORDER BY x`
-* The expression `x` is an alias.
+* The expression `x` is a recognized alias.
 
 . `RETURN 1, 1 + count(*) ORDER BY 2`
 * The expression `1` is a constant.
@@ -633,45 +687,39 @@ For each example we list why it is valid.
 * The expression `$x` is a parameter.
 
 . `MATCH (a) RETURN a.x, 1 + count(a.x) ORDER BY a.x % 2`
-* The sub-expression `a.x` is a grouping key.
+* The sub-expression `a.x` is a recognized grouping key.
 * The sub-expression `2` is a constant.
 
 . `MATCH (a) WITH a.x AS ax RETURN ax, ax + count(ax) ORDER BY ax`
-* The expression `ax` is a grouping key.
+* The expression `ax` is a recognized grouping key.
 
 . `MATCH (a)-[]->(b) RETURN a, a.x + count(b.y) ORDER BY a.y`
-* The sub-expression `a` is a grouping key.
+* The sub-expression `a` is a recognized grouping key.
 
 . `MATCH (a)-[]->(b) RETURN a, count(b.y) ORDER BY size(keys(a))`
-* The sub-expression `a` is a grouping key.
+* The sub-expression `a` is a recognized grouping key.
 
 . `MATCH (x) RETURN x.a, x.b, x.c, x.a + x.b + count(x) + x.c ORDER BY x.a + x.c`
-* The sub-expressions `x.a` and `x.c` are grouping keys.
+* The sub-expressions `x.a` and `x.c` are recognized grouping keys.
 
-. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1`
-* The sub-expression `a.x + 1` is a grouping key.
-
-. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax)`
-* The sub-expression `ax` is a grouping key.
+. `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax) ORDER BY ax - 1`
+* The sub-expression `ax` is a recognized grouping key.
 * The sub-expression `1` is a constant.
 
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax, ax - 1 + count(ax) ORDER BY ax + 2`
-* The sub-expression `ax` is a grouping key.
+* The sub-expression `ax` is a recognized grouping key.
 * The sub-expression `2` is a constant.
 
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) ORDER BY x + 2`
-* The sub-expression `x` is an alias.
+* The sub-expression `x` is an recognized alias.
 * The sub-expression `2` is a constant.
 
 . `MATCH (a) WITH a.x + 1 as ax RETURN ax AS x, ax - 1 + count(ax) AS y ORDER BY x + 2 - y`
-* The sub-expressions `x` and `y` are aliases.
+* The sub-expressions `x` and `y` are recognized aliases.
 * The sub-expression `2` is a constant.
 
 . `WITH {a:1, b:2} AS map RETURN map.a, map.a + count(map.b) ORDER BY map.a`
-* The expression `map.a` is a grouping key.
-
-. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x) ORDER BY x.a + x.b + x.c`
-* The expression `x.a + x.b + x.c` is a grouping key.
+* The expression `map.a` is a recognized grouping key.
 
 === Invalid orderings
 
@@ -680,6 +728,9 @@ For each example we list why it is invalid.
 
 . `RETURN 1 + count(\*) ORDER BY 1 + count(*)`
 * The expression `1 + count(*)` is not a grouping key.
+
+. `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 1`
+* The sub-expression `a.x + 1` is a recognized grouping key.
 
 . `MATCH (a) RETURN a.x + 1, a.x + 1 + count(a.x) ORDER BY a.x + 2`
 * The expression `a.x + 2` is not a grouping key.
@@ -692,9 +743,12 @@ For each example we list why it is invalid.
 * The expression `x.a + x.c` is not a grouping key.
 * The sub-expressions `x.a` and `x.c` and `x` are not grouping keys, either.
 
+. `MATCH (x) RETURN x.a + x.b + x.c, x.a + x.b + x.c + count(x) ORDER BY x.a + x.b + x.c`
+* The expression `x.a + x.b + x.c` is not a recognized grouping key.
+
 == What others do
 
-All other major query language explicitly delineate grouping key expressions.
+All other major query languages explicitly delineate grouping key expressions.
 
 For instance, SQL does so by requiring users to list all grouping key expressions in the GROUP BY clause.
 If the GROUP BY clause is present in a query, the projection in the SELECT clause have to fulfill a similar syntax restriction as defined by this CIP.
@@ -731,7 +785,7 @@ To this effect, the proposed rules of the syntax restriction are a heuristic, wh
 
 The RETURN clause
 
-.[[Q7]]Q7
+.[[Q8]]Q8
 [source, cypher]
 ----
 RETURN a AS a, (b - b) + SUM(c) AS foo

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -556,10 +556,10 @@ For an expression _ex_ and a projection list _L_, let _AVAILABLE_TO_ORDER_(_ex_,
 * If _ex_ is either
 ** A constant,
 ** A parameter,
-** An aggregation function, i.e. of the form `_agg_(_subEx_)`,
 ** A grouping key, i.e. _ex_ ∈ _RECOGNIZED_GROUPING_KEYS_(_L_), or
 ** An alias, i.e. _ex_ ∈ _RECOGNIZED_ALIASES_(_L_),
-* or if _ex_ comprises sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds.
+* or if _ex_ comprises sub-expressions, it only comprises sub-expressions _subEx_ for which _AVAILABLE_TO_ORDER_(_subEx_, _L_) holds,
+* or if _ex_ is aggregation expression in _L_, i.e. there is a <ProjectionItem>s _p_ = `_ex_ AS _al_` in _L_.
 
 [IMPORTANT]
 ====

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -548,7 +548,7 @@ For each example we list why it is valid.
 . `RETURN count($x) + $x`
 * The sub-expression `$x` is a parameter.
 
-. `RETURN 1 + count($x) + $x * 7 + sum($x) + 'cake'`
+. `RETURN 1 + count($x) + $x * 2 + sum($x) + 'cake'`
 * The sub-expressions `1`, `2`, and `'cake'` are constants.
 * The sub-expression `$x` is a parameter.
 

--- a/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
+++ b/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 == Background
 
-In this CIP we assume two baseline semantics as a given and as well-defined.
+In this CIP we assume two baseline semantics as given and well-defined.
 Each baseline semantics captures on capability of the WITH and the RETURN clause in isolation -- similar to https://en.wikipedia.org/wiki/Relational_algebra[relational algebra operators].
 
 _<<Baseline projection>>_ :: Describes the projection of binding table


### PR DESCRIPTION
This PR provides CIP that clarifies the semantics of grouping key and aggregation expressions in the WITH and the RETURN clause.

[Rendered view](https://github.com/hvub/openCypher/blob/CIP-on-grouping-keys-and-aggregation-expressions/cip/1.accepted/CIP2021-07-07-Grouping-keys-and-aggregation-expressions.adoc).