### PR TITLE
Add TCK error characteristics wildcards

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -267,14 +267,18 @@ object CypherTCK {
       scenarioSteps
     }.toList
     val (name, number) = parseNameAndNumber(nameAndNumber)
-    val tagsInferred = {
-      if (steps.exists {
+    val tagsInferred = tags ++ Set(TCKTags.NEGATIVE_TEST, TCKTags.WILDCARD_ERROR_DETAILS).filter {
+      case TCKTags.NEGATIVE_TEST => steps.exists {
         case ExpectError(_, _, _, _) => true
         case _ => false
-      })
-        tags + TCKTags.NEGATIVE_TEST
-      else
-        tags
+      }
+      case TCKTags.WILDCARD_ERROR_DETAILS => steps.exists {
+        case ExpectError(TCKErrorTypes.ERROR, _, _, _) => true
+        case ExpectError(_, TCKErrorPhases.ANY_TIME, _, _) => true
+        case ExpectError(_, _, TCKErrorDetails.ANY, _) => true
+        case _ => false
+      }
+      case _ => false
     }
     Scenario(categories.toList, featureName, number, name, exampleIndex, exampleName, tagsInferred, steps, pickle, sourceFile)
   }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -269,7 +269,7 @@ object CypherTCK {
     val (name, number) = parseNameAndNumber(nameAndNumber)
     val tagsInferred = tags ++ Set(TCKTags.NEGATIVE_TEST, TCKTags.WILDCARD_ERROR_DETAILS).filter {
       case TCKTags.NEGATIVE_TEST => steps.exists {
-        case ExpectError(_, _, _, _) => true
+        case _: ExpectError => true
         case _ => false
       }
       case TCKTags.WILDCARD_ERROR_DETAILS => steps.exists {

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Scenario.scala
@@ -28,7 +28,6 @@
 package org.opencypher.tools.tck.api
 
 import java.nio.file.Path
-
 import org.opencypher.tools.tck.SideEffectOps
 import org.opencypher.tools.tck.SideEffectOps._
 import org.opencypher.tools.tck.api.Graph.Result
@@ -37,6 +36,9 @@ import org.opencypher.tools.tck.api.events.TCKEvents.StepFinished
 import org.opencypher.tools.tck.api.events.TCKEvents.StepStarted
 import org.opencypher.tools.tck.api.events.TCKEvents.setStepFinished
 import org.opencypher.tools.tck.api.events.TCKEvents.setStepStarted
+import org.opencypher.tools.tck.constants.TCKErrorDetails
+import org.opencypher.tools.tck.constants.TCKErrorPhases
+import org.opencypher.tools.tck.constants.TCKErrorTypes
 import org.opencypher.tools.tck.values.CypherValue
 
 import scala.compat.Platform.EOL
@@ -124,17 +126,17 @@ case class Scenario(categories: List[String], featureName: String, number: Optio
           case (ctx, e @ ExpectError(errorType, phase, detail, _)) =>
             ctx.lastResult match {
               case Left(error) =>
-                if (error.errorType != errorType)
+                if (error.errorType != errorType && error.errorType != TCKErrorTypes.ERROR && errorType != TCKErrorTypes.ERROR)
                   Left(
                     ScenarioFailedException(
                       s"Wrong error type: expected $errorType, got ${error.errorType}",
                       error.exception.orNull))
-                if (error.phase != phase)
+                if (error.phase != phase && error.phase != TCKErrorPhases.ANY_TIME && phase != TCKErrorPhases.ANY_TIME)
                   Left(
                     ScenarioFailedException(
                       s"Wrong error phase: expected $phase, got ${error.phase}",
                       error.exception.orNull))
-                if (error.detail != detail)
+                if (error.detail != detail && error.detail != TCKErrorDetails.ANY && detail != TCKErrorDetails.ANY)
                   Left(
                     ScenarioFailedException(
                       s"Wrong error detail: expected $detail, got ${error.detail}",

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
@@ -41,18 +41,22 @@ object TCKErrorTypes {
   val ARGUMENT_ERROR = "ArgumentError"
   val ARITHMETIC_ERROR = "ArithmeticError"
   val PROCEDURE_ERROR = "ProcedureError"
+  // wildcard error type
+  val ERROR = "Error"
 
   val ALL = Set(SYNTAX_ERROR, SEMANTIC_ERROR, PARAMETER_MISSING,
                 CONSTRAINT_VERIFICATION_FAILED, CONSTRAINT_VALIDATION_FAILED,
                 ENTITY_NOT_FOUND, PROPERTY_NOT_FOUND, LABEL_NOT_FOUND, TYPE_ERROR,
-                ARGUMENT_ERROR, ARITHMETIC_ERROR, PROCEDURE_ERROR)
+                ARGUMENT_ERROR, ARITHMETIC_ERROR, PROCEDURE_ERROR, ERROR)
 }
 
 object TCKErrorPhases {
   val COMPILE_TIME = "compile time"
   val RUNTIME = "runtime"
+  // wildcard error phase
+  val ANY_TIME = "any time"
 
-  val ALL = Set(COMPILE_TIME, RUNTIME)
+  val ALL = Set(COMPILE_TIME, RUNTIME, ANY_TIME)
 }
 
 object TCKErrorDetails {
@@ -99,6 +103,8 @@ object TCKErrorDetails {
   val PROCEDURE_NOT_FOUND = "ProcedureNotFound"
   val UNEXPECTED_SYNTAX = "UnexpectedSyntax"
   val INTEGER_OVERFLOW = "IntegerOverflow"
+  // wildcard error detail
+  val ANY = "*"
 
   val ALL = Set(INVALID_ELEMENT_ACCESS,
                 MAP_ELEMENT_ACCESS_BY_NON_STRING,
@@ -141,5 +147,6 @@ object TCKErrorDetails {
                 PROCEDURE_NOT_FOUND,
                 DELETED_ENTITY_ACCESS,
                 UNEXPECTED_SYNTAX,
-                INTEGER_OVERFLOW)
+                INTEGER_OVERFLOW,
+                ANY)
 }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKTags.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKTags.scala
@@ -34,4 +34,5 @@ object TCKTags {
   val SKIP_STYLE_CHECK = "@skipStyleCheck"
   val SKIP_GRAMMAR_CHECK = "@skipGrammarCheck"
   val NEGATIVE_TEST = "@NegativeTest"
+  val WILDCARD_ERROR_DETAILS = "@WildcardErrorDetails"
 }

--- a/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
+++ b/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
@@ -53,7 +53,7 @@ Feature: Foo
       """
       RETURN foo()
       """
-    Then a Error should be raised at compile time: UnknownFunction
+    Then an Error should be raised at compile time: UnknownFunction
 
   Scenario: Fail at any time
     Given an empty graph
@@ -77,7 +77,7 @@ Feature: Foo
       """
       RETURN foo()
       """
-    Then a Error should be raised at any time: *
+    Then an Error should be raised at any time: *
 
   @ignore
   Scenario: Ignored

--- a/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
+++ b/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
@@ -71,7 +71,7 @@ Feature: Foo
       """
     Then a SyntaxError should be raised at compile time: *
 
-  Scenario: Fail with any type and detail at any type
+  Scenario: Fail with any type and any detail at any type
     Given an empty graph
     When executing query:
       """

--- a/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
+++ b/tools/tck-api/src/test/resources/org/opencypher/tools/tck/Foo.feature
@@ -47,6 +47,38 @@ Feature: Foo
       """
     Then a SyntaxError should be raised at compile time: UnknownFunction
 
+  Scenario: Fail with any type
+    Given an empty graph
+    When executing query:
+      """
+      RETURN foo()
+      """
+    Then a Error should be raised at compile time: UnknownFunction
+
+  Scenario: Fail at any time
+    Given an empty graph
+    When executing query:
+      """
+      RETURN foo()
+      """
+    Then a SyntaxError should be raised at any time: UnknownFunction
+
+  Scenario: Fail with any detail
+    Given an empty graph
+    When executing query:
+      """
+      RETURN foo()
+      """
+    Then a SyntaxError should be raised at compile time: *
+
+  Scenario: Fail with any type and detail at any type
+    Given an empty graph
+    When executing query:
+      """
+      RETURN foo()
+      """
+    Then a Error should be raised at any time: *
+
   @ignore
   Scenario: Ignored
     Given an unsupported step

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/TCKApiTest.scala
@@ -98,4 +98,9 @@ class TCKApiTest extends AnyFunSuite with Matchers {
     val negativeTestScenarios = scenarios.filter(_.name == "Fail")
     negativeTestScenarios.foreach(_.tags should contain (TCKTags.NEGATIVE_TEST))
   }
+
+  test("scenarios with an error wildcards in an ExpectError step have the TCKTags.WILDCARD_ERROR_DETAILS tag") {
+    val negativeTestScenarios = scenarios.filter(s => s.featureName == "Foo" && s.name.matches("(any time|any type|any detail)"))
+    negativeTestScenarios.foreach(_.tags should contain (TCKTags.WILDCARD_ERROR_DETAILS))
+  }
 }


### PR DESCRIPTION
With this PR scenarios can specify error characteristics (error type, the error phase, the error details) with a wildcard in the ExpectedError step of a scenario.

The wildcards are used in a scenario as follows:

- **Any error type:** `Then a Error should be raised at ...: ...`
- **Any error phase:** `Then a ... should be raised at any time: ...`
- **Any error detail:** `Then a ... should be raised at ...: *`

Where a wildcard is given, the TCK API will not test the respective error characteristics on the error returned by an implementation for the respective scenario step. In other words, a scenario with an error characteristics wildcard cannot fail on this error characteristics in this ExpectedError step. The scenario may still fail 
- on other steps
- on other error characteristics that are not specified with a wildcard, or 
- because the implementation fails produce an error at all.

All scenarios that is at least one error characteristics wildcard, get tagged with `@WildcardErrorDetails` so that they are easily identifiable.