### PR TITLE
Add support for Scala cross building for 2.12 and 2.13

### DIFF
--- a/.github/workflows/pr_and_push_verification.yml
+++ b/.github/workflows/pr_and_push_verification.yml
@@ -20,8 +20,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build with Maven
-      run: mvn clean verify --file pom.xml
+    - name: Build for Scala 2.12 with Maven
+      run: mvn -P scala-212 clean verify --file pom.xml
+    - name: Build for Scala 2.13 with Maven
+      run: mvn -P scala-213 clean verify --file pom.xml
     - name: Grammar scripts
       run: |
         ./tools/grammar/src/main/shell/launch.sh RailRoadDiagramPages -outputDir=grammar/generated/railroad cypher.xml

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
     <dep.maven.source.plugin.version>3.2.1</dep.maven.source.plugin.version>
     <dep.maven.surefire.plugin.version>2.22.2</dep.maven.surefire.plugin.version>
     <dep.scala.maven.plugin.version>3.4.4</dep.scala.maven.plugin.version>
-    <dep.scala.version>${scala.version}</dep.scala.version>
     <dep.scalatest.version>3.2.2</dep.scalatest.version>
     <dep.scalatest.runner.version>0.1.8</dep.scalatest.runner.version>
     <dep.xmlgraphics-commons.version>2.4</dep.xmlgraphics-commons.version>
@@ -54,7 +53,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.rootdir>${project.basedir}</project.rootdir>
     <scala.binary.version>2.12</scala.binary.version>
-    <scala.version/>
+    <scala.version>2.12.13</scala.version>
     <test.runner.jvm/>
     <test.runner.jvm.settings.additional/>
     <test.runner.jvm.settings>
@@ -88,7 +87,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>${dep.scala.version}</version>
+        <version>${scala.version}</version>
       </dependency>
 
       <dependency>
@@ -230,7 +229,7 @@
             </execution>
           </executions>
           <configuration>
-            <scalaVersion>${dep.scala.version}</scalaVersion>
+            <scalaVersion>${scala.version}</scalaVersion>
             <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
           </configuration>
         </plugin>
@@ -390,15 +389,9 @@
         <forkCounts>1C</forkCounts>
       </properties>
     </profile>
+    <!-- This is all the defaults -->
     <profile>
       <id>scala-212</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <scala.version>2.12.13</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
-      </properties>
     </profile>
     <profile>
       <id>scala-213</id>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dep.maven.source.plugin.version>3.2.1</dep.maven.source.plugin.version>
     <dep.maven.surefire.plugin.version>2.22.2</dep.maven.surefire.plugin.version>
     <dep.scala.maven.plugin.version>3.4.4</dep.scala.maven.plugin.version>
-    <dep.scala.version>2.12.10</dep.scala.version>
+    <dep.scala.version>${scala.version}</dep.scala.version>
     <dep.scalatest.version>3.2.2</dep.scalatest.version>
     <dep.scalatest.runner.version>0.1.8</dep.scalatest.runner.version>
     <dep.xmlgraphics-commons.version>2.4</dep.xmlgraphics-commons.version>
@@ -54,6 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.rootdir>${project.basedir}</project.rootdir>
     <scala.binary.version>2.12</scala.binary.version>
+    <scala.version/>
     <test.runner.jvm/>
     <test.runner.jvm.settings.additional/>
     <test.runner.jvm.settings>
@@ -352,6 +353,19 @@
           <version>${dep.maven.compiler.plugin.version}</version>
         </plugin>
 
+        <plugin>
+          <groupId>org.spurint.maven.plugins</groupId>
+          <artifactId>scala-cross-maven-plugin</artifactId>
+          <version>0.3.0</version>
+          <executions>
+            <execution>
+              <id>rewrite-pom</id>
+              <goals>
+                <goal>rewrite-pom</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -377,11 +391,21 @@
       </properties>
     </profile>
     <profile>
-      <id>scala213</id>
+      <id>scala-212</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
-        <dep.scala.version>2.13.6</dep.scala.version>
+        <scala.version>2.12.13</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala-213</id>
+      <properties>
         <dep.cask.version>0.3.7</dep.cask.version>
         <scala.binary.version>2.13</scala.binary.version>
+        <scala.version>2.13.6</scala.version>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <dep.antlr4.version>4.7.2</dep.antlr4.version>
     <dep.batik.version>1.13</dep.batik.version>
+    <dep.cask.version>0.2.9</dep.cask.version>
     <dep.cucumber.version>5.7.0</dep.cucumber.version>
     <dep.hamcrest.version>2.2</dep.hamcrest.version>
     <dep.junit.platform.version>1.7.0</dep.junit.platform.version>
@@ -373,6 +374,14 @@
       </activation>
       <properties>
         <forkCounts>1C</forkCounts>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala213</id>
+      <properties>
+        <dep.scala.version>2.13.6</dep.scala.version>
+        <dep.cask.version>0.3.7</dep.cask.version>
+        <scala.binary.version>2.13</scala.binary.version>
       </properties>
     </profile>
   </profiles>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <project.rootdir>${project.basedir}/..</project.rootdir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <dep.fastparse.version>2.1.0</dep.fastparse.version>
+    <dep.fastparse.version>2.1.3</dep.fastparse.version>
   </properties>
 
   <licenses>

--- a/tools/tck-api/pom.xml
+++ b/tools/tck-api/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>tck-api_2.12</artifactId>
+  <artifactId>tck-api_${scala.binary.version}</artifactId>
   <name>openCypher TCK API</name>
   <url>http://opencypher.org</url>
   <description>openCypher Technology Compatibility Kit API</description>
@@ -27,7 +27,27 @@
   </licenses>
 
   <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/main/scala_${scala.binary.version}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>

--- a/tools/tck-api/pom.xml
+++ b/tools/tck-api/pom.xml
@@ -55,6 +55,10 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.spurint.maven.plugins</groupId>
+        <artifactId>scala-cross-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/SideEffectOps.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/SideEffectOps.scala
@@ -32,7 +32,6 @@ import org.opencypher.tools.tck.constants.TCKQueries._
 import org.opencypher.tools.tck.constants.TCKSideEffects._
 import org.opencypher.tools.tck.values.CypherValue
 
-import scala.compat.Platform
 
 object SideEffectOps {
 
@@ -40,11 +39,11 @@ object SideEffectOps {
     override def toString: String = {
       val nonZeroSideEffects = ALL intersect v.keySet
       nonZeroSideEffects.toSeq
-        .sortBy(_.charAt(1))
+        .sortBy(str => (str.charAt(1), str.charAt(0)))
         .map { key =>
           s"${fill(key)}${v(key)}"
         }
-        .mkString(Platform.EOL)
+        .mkString(System.lineSeparator())
     }
 
     private def fill(s: String) = (s + ":                 ").take(16)

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -106,7 +106,7 @@ object CypherTCK {
       try {
         fs.foreach(_.close())
       } catch {
-        case _: UnsupportedOperationException => Unit
+        case _: UnsupportedOperationException => ()
       }
     }
   }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
@@ -39,7 +39,7 @@ import scala.compat.Platform.EOL
   */
 case class StringRecords(header: List[String], rows: List[Map[String, String]]) {
   def asValueRecords: CypherValueRecords = {
-    val converted = rows.map(_.mapValues(CypherValue(_)))
+    val converted = rows.map(_.map { case (k, v) => (k, CypherValue(v)) })
     CypherValueRecords(header, converted)
   }
 }
@@ -69,7 +69,7 @@ case class CypherValueRecords(header: List[String], rows: List[Map[String, Cyphe
 
 object CypherValueRecords {
   def fromRows(header: List[String], data: List[Map[String, String]], orderedLists: Boolean): CypherValueRecords = {
-    val parsed = data.map(row => row.mapValues(v => CypherValue(v, orderedLists)).view.force)
+    val parsed = data.map(row => row.map { case (k, v) => (k, CypherValue(v, orderedLists)) })
     CypherValueRecords(header, parsed)
   }
 

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/events/TCKEvents.scala
@@ -29,11 +29,9 @@ package org.opencypher.tools.tck.api.events
 
 import java.net.URI
 import java.util.UUID
-
 import org.opencypher.tools.tck.api.Graph.Result
 import org.opencypher.tools.tck.api.{Scenario, Step}
 
-import scala.collection.mutable
 
 /** Publishes TCK scenario execution events.
   *
@@ -69,11 +67,11 @@ object TCKEvents {
     def apply[T](): Publish[T] = new Publish[T]
   }
 
-  class Publish[T] extends mutable.Publisher[T] {
+  class Publish[T] extends Collections.Publisher[T] {
     def send(event: T): Unit = publish(event)
     def subscribe(callback: T => Unit): Unit = {
-      subscribe(new mutable.Subscriber[T, mutable.Publisher[T]] {
-        override def notify(pub: mutable.Publisher[T], event: T): Unit = {
+      subscribe(new Collections.Subscriber[T, Collections.Publisher[T]] {
+        override def notify(pub: Collections.Publisher[T], event: T): Unit = {
           callback(event)
         }
       })

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValueParser.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValueParser.scala
@@ -149,7 +149,7 @@ class CypherValueParser(val orderedLists: Boolean) {
     * A 'simple' string chunk; without apostrophes or backslash (escape sequence)
     */
   private def stringChunk[_: P]: P[Unit] = {
-    CharsWhile(c => c != ''' && c != '\\')
+    CharsWhile(c => c != '\'' && c != '\\')
   }
   /**
     * We escape apostrophes inside strings using a backslash

--- a/tools/tck-api/src/main/scala_2.12/org/opencypher/tools/tck/api/events/Collections.scala
+++ b/tools/tck-api/src/main/scala_2.12/org/opencypher/tools/tck/api/events/Collections.scala
@@ -25,47 +25,10 @@
  * described as "implementation extensions to Cypher" or as "proposed changes to
  * Cypher that are not yet approved by the openCypher community".
  */
-package org.opencypher.tools.tck
+package org.opencypher.tools.tck.api.events
 
-import org.opencypher.tools.tck.api.Scenario
-import org.opencypher.tools.tck.api.groups.ContainerGroup
-import org.opencypher.tools.tck.api.groups.Group
-import org.opencypher.tools.tck.api.groups.Item
-import org.opencypher.tools.tck.api.groups.Tag
-import org.opencypher.tools.tck.api.groups.TckTree
-import org.opencypher.tools.tck.api.groups.Total
-import org.scalatest.OptionValues
-import org.scalatest.ParallelTestExecution
-import org.scalatest.funspec.AsyncFunSpec
-import org.scalatest.matchers.should.Matchers
+object Collections {
 
-import scala.concurrent.Future
-
-trait ScenarioFormatChecker extends AsyncFunSpec with Matchers with OptionValues with ValidateScenario with ParallelTestExecution {
-
-  def create(scenarios: Seq[Scenario]): Unit = {
-
-    implicit val tck: TckTree = TckTree(scenarios)
-
-    def spawnTests(currentGroup: Group): Unit = {
-      currentGroup match {
-        case Total =>
-          Total.children.toSeq.sorted.foreach(spawnTests)
-        case _: Tag => ()
-        case g: ContainerGroup =>
-          describe(g.description) {
-            g.children.toSeq.sorted.foreach(spawnTests)
-          }
-        case i: Item =>
-          it(i.description) {
-            Future {
-              validateScenario(i.scenario)
-            }
-          }
-        case _ => ()
-      }
-    }
-
-    spawnTests(Total)
-  }
+  type Subscriber[Evt, Pub] = scala.collection.mutable.Subscriber[Evt, Pub]
+  type Publisher[Evt] = scala.collection.mutable.Publisher[Evt]
 }

--- a/tools/tck-api/src/main/scala_2.13/org/opencypher/tools/tck/api/events/Collections.scala
+++ b/tools/tck-api/src/main/scala_2.13/org/opencypher/tools/tck/api/events/Collections.scala
@@ -29,6 +29,10 @@ package org.opencypher.tools.tck.api.events
 
 import scala.collection.mutable
 
+/**
+ * This is a cut-down version of these classes from the 2.12 Scala collections API that just provides
+ * the functionality we use.
+ */
 object Collections {
 
   trait Subscriber[-Evt, -Pub] {

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/TckTreeTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/groups/TckTreeTest.scala
@@ -98,7 +98,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
       }
       describe("has every group, except Total, indented one more than their parent group so that") {
         tckTree.groups foreach {
-          case Total => Unit
+          case Total => ()
           case g =>
             it(s"group $g is indented one more than ${g.parent}") {
               g.indent should equal(g.parent.get.indent + 1)
@@ -113,7 +113,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
                 case _:ScenarioCategory | Total =>
               }
             }
-          case _ => Unit
+          case _ => ()
         }
       }
       describe("has every Feature group with a parent group which is a ScenarioCategory or Total so that") {
@@ -123,7 +123,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
               case _:ScenarioCategory | Total =>
             }
           }
-          case _ => Unit
+          case _ => ()
         }
       }
       describe("has every ScenarioItem group and ScenarioOutline group with a parent group which is a Feature or a Tag so that") {
@@ -140,7 +140,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
                 case _:Feature | _:Tag =>
               }
             }
-          case _ => Unit
+          case _ => ()
         }
       }
       describe("has every ExampleItem group with a parent group which is a ScenarioOutline so that") {
@@ -151,7 +151,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
                 case _:ScenarioOutline =>
               }
             }
-          case _ => Unit
+          case _ => ()
         }
       }
       describe("has every Tag group with a parent group which is Total so that") {
@@ -160,7 +160,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
             it(s"Tag group $t has a parent which is Total") {
               t.parent.value shouldBe Total
             }
-          case _ => Unit
+          case _ => ()
         }
       }
       describe("has every Item group grouping exactly the single scenario referenced in the group object so that") {
@@ -169,7 +169,7 @@ class TckTreeTest extends AnyFunSpec with GroupTest with Inspectors with Inside 
             it(s"Item group $i groups its and only its scenario") {
               tckTree.groupedScenarios(i) should equal(Set(i.scenario))
             }
-          case _ => Unit
+          case _ => ()
         }
       }
     }

--- a/tools/tck-compatibility-tests/util/pom.xml
+++ b/tools/tck-compatibility-tests/util/pom.xml
@@ -10,7 +10,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tck-compatibility-tests-util_2.12</artifactId>
+    <artifactId>tck-compatibility-tests-util_${scala.binary.version}</artifactId>
     <name>openCypher TCK Compatibility Tests</name>
     <url>http://opencypher.org</url>
     <description>Tools for running openCypher TCK scenarios on implementations</description>
@@ -44,6 +44,10 @@
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>scala-cross-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
+++ b/tools/tck-compatibility-tests/util/src/main/scala/org/opencypher/tools/tck/compatibility/AsyncScalaTests.scala
@@ -50,7 +50,7 @@ trait AsyncScalaTests extends AsyncFunSpec with ParallelTestExecution {
       currentGroup match {
         case Total =>
           Total.children.foreach(spawnTests)
-        case _: Tag => Unit // do not execute scenarios via tags, would be redundant
+        case _: Tag => () // do not execute scenarios via tags, would be redundant
         case g: ContainerGroup =>
           describe(g.description) {
             g.children.foreach(spawnTests)
@@ -65,7 +65,7 @@ trait AsyncScalaTests extends AsyncFunSpec with ParallelTestExecution {
               exec(i.scenario)
             } map { _ => succeed }
           }
-        case _ => Unit
+        case _ => ()
       }
     }
 

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -41,6 +41,10 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>scala-cross-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -10,7 +10,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tck-inspection_2.12</artifactId>
+    <artifactId>tck-inspection_${scala.binary.version}</artifactId>
     <name>openCypher TCK Inspection</name>
     <url>http://opencypher.org</url>
     <description>Tools for inspecting openCypher TCK scenarios</description>
@@ -58,13 +58,13 @@
 
         <dependency>
             <groupId>com.lihaoyi</groupId>
-            <artifactId>cask_2.12</artifactId>
-            <version>0.2.9</version>
+            <artifactId>cask_${scala.binary.version}</artifactId>
+            <version>${dep.cask.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.lihaoyi</groupId>
-            <artifactId>scalatags_2.12</artifactId>
+            <artifactId>scalatags_${scala.binary.version}</artifactId>
             <version>0.7.0</version>
         </dependency>
 

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/util/CallingSystemProcesses.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/util/CallingSystemProcesses.scala
@@ -47,7 +47,7 @@ object CallingSystemProcesses {
 
     val exitCode = cmd.!(logger)
 
-    ProcessReturn(exitCode, out, err, cmdSeq.mkString(" "))
+    ProcessReturn(exitCode, out.toSeq, err.toSeq, cmdSeq.mkString(" "))
   }
 
   def checkoutRepoCommit(repositoryUrl: String, commit: String, localDirectory: String): ProcessReturn = {
@@ -77,7 +77,7 @@ object CallingSystemProcesses {
 
     val exitCode = cmd.!(logger)
 
-    ProcessReturn(exitCode, out, err,
+    ProcessReturn(exitCode, out.toSeq, err.toSeq,
       gitCloneCmdSeq.mkString(" ") + "&&" +
         gitFetchCmdSeq.mkString(" ") + "&&" +
         gitCheckoutCmdSeq.mkString(" "))

--- a/tools/tck-integrity-tests/pom.xml
+++ b/tools/tck-integrity-tests/pom.xml
@@ -10,7 +10,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tck-integrity-tests_2.12</artifactId>
+    <artifactId>tck-integrity-tests_${scala.binary.version}</artifactId>
     <name>openCypher TCK Integrity Tests</name>
     <url>http://opencypher.org</url>
     <description>openCypher Technology Compatibility Kit Integrity Tests</description>
@@ -48,6 +48,10 @@
                 <configuration>
                     <!--skipTests>true</skipTests-->
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>scala-cross-maven-plugin</artifactId>
             </plugin>
         </plugins>
 

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateSteps.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateSteps.scala
@@ -64,7 +64,7 @@ trait ValidateSteps extends AppendedClues with Matchers with OptionValues with V
       case (_: ExpectResult, _) => numberOfExpectResultSteps += 1
       case (se: SideEffects, _) if se.source.getType == StepType.AND => numberOfExplicitSideEffectSteps += 1
       case (se: SideEffects, _) if se.source.getType == StepType.THEN => numberOfImplicitSideEffectSteps += 1
-      case _ => Unit
+      case _ => ()
     }
 
     withClue("scenario has exactly one `When executing query` steps") {

--- a/tools/tck-reporting/pom.xml
+++ b/tools/tck-reporting/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${dep.scala.version}</version>
+            <version>${scala.version}</version>
         </dependency>
 
         <dependency>

--- a/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
+++ b/tools/tck-reporting/src/test/java/org/opencypher/tools/tck/reporting/cucumber/CucumberReportAdapterTest.java
@@ -64,7 +64,7 @@ public class CucumberReportAdapterTest {
         Path featureFile = featuresPath.relativize(featuresPath.resolve("Foo.feature"));
         String content = getResource("Foo.feature");
 
-        Seq<Scenario> scenariosSeq = CypherTCK.parseFeature(featureFile, content, JavaConverters.asScalaBuffer(new java.util.ArrayList<String>())).scenarios();
+        Seq<Scenario> scenariosSeq = CypherTCK.parseFeature(featureFile, content, JavaConverters.asScalaBuffer(new java.util.ArrayList<String>()).toSeq()).scenarios();
         java.util.List<Scenario> scenarios = JavaConverters.seqAsJavaList(scenariosSeq);
 
         AbstractFunction0<Graph> graph = graph();

--- a/tools/tck-reporting/src/test/resources/org/opencypher/tools/tck/reporting/cucumber/expected.json
+++ b/tools/tck-reporting/src/test/resources/org/opencypher/tools/tck/reporting/cucumber/expected.json
@@ -64,7 +64,7 @@
           },
           {
             "output": [
-              "-labels:        0\n+labels:        0\n+nodes:         0\n-nodes:         0\n-properties:    0\n+properties:    0\n-relationships: 0\n+relationships: 0"
+              "+labels:        0\n-labels:        0\n+nodes:         0\n-nodes:         0\n+properties:    0\n-properties:    0\n+relationships: 0\n-relationships: 0"
             ],
             "result": {
               "status": "passed"
@@ -125,7 +125,7 @@
           },
           {
             "output": [
-              "-labels:        0\n+labels:        0\n+nodes:         0\n-nodes:         0\n-properties:    0\n+properties:    0\n-relationships: 0\n+relationships: 0"
+              "+labels:        0\n-labels:        0\n+nodes:         0\n-nodes:         0\n+properties:    0\n-properties:    0\n+relationships: 0\n-relationships: 0"
             ],
             "result": {
               "status": "passed"
@@ -201,7 +201,7 @@
           },
           {
             "output": [
-              "-labels:        0\n+labels:        0\n+nodes:         0\n-nodes:         0\n-properties:    0\n+properties:    0\n-relationships: 0\n+relationships: 0"
+              "+labels:        0\n-labels:        0\n+nodes:         0\n-nodes:         0\n+properties:    0\n-properties:    0\n+relationships: 0\n-relationships: 0"
             ],
             "result": {
               "status": "passed"
@@ -277,7 +277,7 @@
           },
           {
             "output": [
-              "-labels:        0\n+labels:        0\n+nodes:         0\n-nodes:         0\n-properties:    0\n+properties:    0\n-relationships: 0\n+relationships: 0"
+              "+labels:        0\n-labels:        0\n+nodes:         0\n-nodes:         0\n+properties:    0\n-properties:    0\n+relationships: 0\n-relationships: 0"
             ],
             "result": {
               "status": "passed"
@@ -353,7 +353,7 @@
           },
           {
             "output": [
-              "-labels:        0\n+labels:        0\n+nodes:         0\n-nodes:         0\n-properties:    0\n+properties:    0\n-relationships: 0\n+relationships: 0"
+              "+labels:        0\n-labels:        0\n+nodes:         0\n-nodes:         0\n+properties:    0\n-properties:    0\n+relationships: 0\n-relationships: 0"
             ],
             "result": {
               "status": "passed"


### PR DESCRIPTION
* Add two maven profiles, `scala-212` and `scala-213` to build for Scala 2.12 or Scala 2.13, keeping the existing default of Scala 2.12. 
* Due to collection library incompatibilities between 2.12 and 2.13, tck-api requires a slightly different classpath for each, so I've added `scala_2.12` and `scala_2.13` additional source directories for this module. 
* Added additional maven plugins for the additional src directory and rewriting the Scala versions in the .poms
* Changed the output of the side effects reporting to make the order it displays additions and deletions consistent. This was previously unordered and behaving differently on 2.12 and 2.13, causing a test failure.
* Upgrade some dependencies to be compatible with 2.12 and 2.13