### PR TITLE
Add missing results order check in tck scenarios

### DIFF
--- a/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
@@ -164,7 +164,7 @@ Feature: ReturnOrderBy2 - Order by a single expression (order of projection)
       RETURN n.name, count(*) AS foo
         ORDER BY n.name
       """
-    Then the result should be, in any order:
+    Then the result should be, in order:
       | n.name  | foo |
       | 'nisse' | 1   |
     And no side effects

--- a/tck/features/clauses/return-skip-limit/ReturnSkipLimit2.feature
+++ b/tck/features/clauses/return-skip-limit/ReturnSkipLimit2.feature
@@ -61,7 +61,7 @@ Feature: ReturnSkipLimit2 - Limit
       ORDER BY n.name ASC
       LIMIT 2
       """
-    Then the result should be, in any order:
+    Then the result should be, in order:
       | n             |
       | ({name: 'A'}) |
       | ({name: 'B'}) |

--- a/tck/features/expressions/pattern/Pattern2.feature
+++ b/tck/features/expressions/pattern/Pattern2.feature
@@ -236,7 +236,7 @@ Feature: Pattern2 - Pattern Comprehension
       RETURN [p = (liker)--() | p] AS isNew
         ORDER BY liker.time
       """
-    Then the result should be, in any order:
+    Then the result should be, in order:
       | isNew                               |
       | [<({time: 10})-[:T]->({time: 20})>] |
       | [<({time: 20})<-[:T]-({time: 10})>] |


### PR DESCRIPTION
TCK scenarios should check order if query ends with ORDER BY