### PR TITLE
Grammar toolkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
       </dependency>
 
       <dependency>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-gherkin-vintage</artifactId>
+        <version>${dep.cucumber.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-svggen</artifactId>
         <version>${dep.batik.version}</version>

--- a/tck/index.adoc
+++ b/tck/index.adoc
@@ -140,6 +140,7 @@ Within each member, there are additional categories.
 
 * WithSkipLimit1 - Skip
 * WithSkipLimit2 - Limit
+* WithSkipLimit3 - Skip and limit
 
 === With-where
 

--- a/tools/grammar/pom.xml
+++ b/tools/grammar/pom.xml
@@ -137,6 +137,9 @@
           <include>**/*.xml</include>
         </includes>
       </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
     </resources>
   </build>
 </project>

--- a/tools/grammar/pom.xml
+++ b/tools/grammar/pom.xml
@@ -86,6 +86,12 @@
       <version>2.17.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-gherkin-vintage</artifactId>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Conditional.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Conditional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Conditional.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Conditional.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.grammar;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public abstract class Conditional
+{
+    public static final String XML_NAMESPACE = "http://opencypher.org/conditional";
+
+    public interface Flags
+    {
+        boolean isTrue( String flag );
+    }
+
+    public abstract boolean check( Flags flags );
+
+    static final Conditional NONE = new Conditional()
+    {
+        @Override
+        public boolean check( Flags flags )
+        {
+            return true;
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            return new SingleGiven( flag );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            return new SingleUnless( flag );
+        }
+    };
+    private static final Conditional UNSATISFIABLE = new Conditional()
+    {
+        @Override
+        public boolean check( Flags flags )
+        {
+            return false;
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            return this;
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            return this;
+        }
+    };
+
+    abstract Conditional given( String flag );
+
+    abstract Conditional unless( String flag );
+
+    private static class SingleGiven extends Conditional
+    {
+        private final String flag;
+
+        SingleGiven( String flag )
+        {
+            this.flag = flag;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            return flags.isTrue( flag );
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( this.flag.equals( flag ) )
+            {
+                return this;
+            }
+            return new MultipleGiven( this.flag, flag );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( this.flag.equals( flag ) )
+            {
+                return UNSATISFIABLE;
+            }
+            return new SingleCombined( this.flag, flag );
+        }
+    }
+
+    private static class SingleUnless extends Conditional
+    {
+        private final String flag;
+
+        SingleUnless( String flag )
+        {
+            this.flag = flag;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            return !flags.isTrue( flag );
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( this.flag.equals( flag ) )
+            {
+                return UNSATISFIABLE;
+            }
+            return new SingleCombined( flag, this.flag );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( this.flag.equals( flag ) )
+            {
+                return this;
+            }
+            return new MultipleUnless( this.flag, flag );
+        }
+    }
+
+    private static class MultipleGiven extends Conditional
+    {
+        private final String[] flags;
+
+        MultipleGiven( String... flags )
+        {
+            this.flags = flags;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            for ( String flag : this.flags )
+            {
+                if ( !flags.isTrue( flag ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : flags )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return this;
+                }
+            }
+            String[] flags = Arrays.copyOf( this.flags, this.flags.length + 1 );
+            flags[this.flags.length] = flag;
+            return new MultipleGiven( flags );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : flags )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return UNSATISFIABLE;
+                }
+            }
+            return new Combined( flags, new String[]{flag} );
+        }
+    }
+
+    private static class MultipleUnless extends Conditional
+    {
+        private final String[] flags;
+
+        MultipleUnless( String... flags )
+        {
+            this.flags = flags;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            for ( String flag : this.flags )
+            {
+                if ( flags.isTrue( flag ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : flags )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return UNSATISFIABLE;
+                }
+            }
+            return new Combined( new String[]{flag}, flags );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : flags )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return this;
+                }
+            }
+            String[] flags = Arrays.copyOf( this.flags, this.flags.length + 1 );
+            flags[this.flags.length] = flag;
+            return new MultipleUnless( flags );
+        }
+    }
+
+    private static class SingleCombined extends Conditional
+    {
+        private final String given;
+        private final String unless;
+
+        SingleCombined( String given, String unless )
+        {
+            this.given = given;
+            this.unless = unless;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            return flags.isTrue( given ) && !flags.isTrue( unless );
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( given.equals( flag ) )
+            {
+                return this;
+            }
+            if ( unless.equals( flag ) )
+            {
+                return UNSATISFIABLE;
+            }
+            return new Combined( new String[]{given, flag}, new String[]{unless} );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            if ( unless.equals( flag ) )
+            {
+                return this;
+            }
+            if ( given.equals( flag ) )
+            {
+                return UNSATISFIABLE;
+            }
+            return new Combined( new String[]{given}, new String[]{unless, flag} );
+        }
+    }
+
+    private static class Combined extends Conditional
+    {
+        private final String[] given;
+        private final String[] unless;
+
+        Combined( String[] given, String[] unless )
+        {
+            this.given = given;
+            this.unless = unless;
+        }
+
+        @Override
+        public boolean check( Flags flags )
+        {
+            for ( String flag : given )
+            {
+                if ( !flags.isTrue( flag ) )
+                {
+                    return false;
+                }
+            }
+            for ( String flag : unless )
+            {
+                if ( flags.isTrue( flag ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        Conditional given( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : given )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return this;
+                }
+            }
+            for ( String f : unless )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return UNSATISFIABLE;
+                }
+            }
+            String[] flags = Arrays.copyOf( given, given.length + 1 );
+            flags[given.length] = flag;
+            return new Combined( flags, unless );
+        }
+
+        @Override
+        Conditional unless( String flag )
+        {
+            Objects.requireNonNull( flag, "flag" );
+            for ( String f : unless )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return this;
+                }
+            }
+            for ( String f : given )
+            {
+                if ( f.equals( flag ) )
+                {
+                    return UNSATISFIABLE;
+                }
+            }
+            String[] flags = Arrays.copyOf( unless, unless.length + 1 );
+            flags[unless.length] = flag;
+            return new Combined( given, flags );
+        }
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Container.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Container.java
@@ -30,6 +30,7 @@ package org.opencypher.grammar;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 
 import org.opencypher.tools.xml.Child;
 
@@ -88,6 +89,15 @@ abstract class Container extends Node implements Terms
     final void literal( char[] buffer, int start, int length )
     {
         LiteralNode.fromCharacters( buffer, start, length, this::add );
+    }
+
+    final Node addAll( Iterable<? extends Grammar.Term> terms )
+    {
+        for ( Grammar.Term term : terms )
+        {
+            term.addTo( this );
+        }
+        return this;
     }
 
     final Node addAll( Grammar.Term first, Grammar.Term... more )

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Dependencies.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Dependencies.java
@@ -69,7 +69,7 @@ class Dependencies
                     .append( "Productions used in non-terminals have not been defined:" );
             for ( Map.Entry<String, Set<ProductionNode>> entry : missingProductions.entrySet() )
             {
-                message.append( "\n  " ).append( entry.getKey() );
+                message.append( "\n  '" ).append( entry.getKey() ).append( "'" );
                 String sep = " used from: ";
                 for ( ProductionNode origin : entry.getValue() )
                 {

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ForeignReference.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ForeignReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ForeignReference.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ForeignReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,44 +27,12 @@
  */
 package org.opencypher.grammar;
 
-public interface NonTerminal
+abstract class ForeignReference implements ReferenceTarget
 {
-    Production production();
-
-    default String productionName()
+    public final ProductionNode production()
     {
-        return production().name();
+        return null;
     }
 
-    default Grammar.Term productionDefinition()
-    {
-        return production().definition();
-    }
-
-    default <Scope> Scope productionScope( Scope scope, ScopeRule.Transformation<Scope> transition )
-    {
-        return production().scope( scope, transition );
-    }
-
-    boolean skip();
-
-    boolean inline();
-
-    Production declaringProduction();
-
-    String title();
-
-    interface ReferenceResolver<T>
-    {
-        T resolveProduction( Production production );
-
-        T unknownReference( NonTerminal nonTerminal );
-
-        interface WG3<T> extends ReferenceResolver<T>
-        {
-            T resolveWG3Reference( String standard, String part, String production );
-        }
-    }
-
-    <T> T resolveReference( ReferenceResolver<T> resolver );
+    public abstract Grammar.Unresolved.Production resolve( Grammar.Resolver resolver );
 }

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Grammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Grammar.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collector;
@@ -176,6 +177,7 @@ public interface Grammar
 
     static Term oneOf( Term first, Term... alternatives )
     {
+        Objects.requireNonNull( first, "first term" );
         if ( alternatives == null || alternatives.length == 0 )
         {
             return first;
@@ -217,6 +219,7 @@ public interface Grammar
 
     static Term sequence( Term first, Term... more )
     {
+        Objects.requireNonNull( first, "first term" );
         if ( more == null || more.length == 0 )
         {
             return first;

--- a/tools/grammar/src/main/java/org/opencypher/grammar/GrammarAnnotation.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/GrammarAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/GrammarAnnotation.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/GrammarAnnotation.java
@@ -1,0 +1,635 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.grammar;
+
+import org.opencypher.tools.xml.Attribute;
+import org.opencypher.tools.xml.Child;
+import org.opencypher.tools.xml.Element;
+import org.opencypher.tools.xml.XmlFile;
+import org.opencypher.tools.xml.XmlParser;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static org.opencypher.tools.xml.XmlParser.xmlParser;
+
+@Element( uri = Grammar.ANNOTATION_XML_NAMESPACE, name = "GrammarAnnotation" )
+class GrammarAnnotation extends ProtoGrammar
+{
+    static final XmlParser<GrammarAnnotation> XML = xmlParser( GrammarAnnotation.class );
+    private ProtoGrammar grammar;
+    private String name;
+
+    @Attribute
+    void grammar( XmlFile grammar ) throws ParserConfigurationException, SAXException, IOException
+    {
+        this.grammar = parse( grammar );
+        if ( name != null )
+        { // there are no guarantees about assignment order of attributes
+            this.grammar.setName( name );
+        }
+    }
+
+    @Attribute( optional = true )
+    void name( String name )
+    {
+        if ( grammar != null )
+        {
+            grammar.setName( name );
+        }
+        else
+        { // there are no guarantees about assignment order of attributes
+            this.name = name;
+        }
+    }
+
+    @Override
+    String language()
+    {
+        return grammar.language();
+    }
+
+    @Override
+    ProductionNode production( String name )
+    {
+        return grammar.production( name );
+    }
+
+    @Override
+    void setName( String name )
+    {
+        grammar.setName( name );
+    }
+
+    @Override
+    Grammar resolve( Grammar.Resolver resolver, Set<ResolutionOption> options )
+    {
+        return grammar.resolve( resolver, options );
+    }
+
+    @Child( {SkipProduction.class, InlineProduction.class, SkipReference.class, InlineReference.class, NonTerminalTitle.class, Replace.class, Remove.class,
+            Recursively.class, MarkAndSweep.class} )
+    @Override
+    void apply( Patch patch )
+    {
+        grammar.apply( patch );
+    }
+
+    @Child
+    @Override
+    void add( ProductionNode production )
+    {
+        grammar.add( production );
+    }
+
+    @Element( uri = Grammar.ANNOTATION_XML_NAMESPACE, name = "replace" )
+    static class Replace extends Patch
+    {
+        final List<ProductionNode> productions = new ArrayList<>();
+        final ProtoGrammar grammar;
+
+        Replace( GrammarAnnotation parent )
+        {
+            this.grammar = parent.grammar;
+        }
+
+        @Override
+        void apply( Mutator mutator )
+        {
+            for ( ProductionNode production : productions )
+            {
+                mutator.replaceProduction( production.name, ( replacement, current ) -> replacement, production );
+            }
+        }
+
+        @Child
+        void add( ProductionNode production )
+        {
+            productions.add( production );
+        }
+    }
+
+    @Element( uri = Grammar.ANNOTATION_XML_NAMESPACE, name = "remove" )
+    static class Remove extends Patch
+    {
+        @Attribute
+        String production;
+
+        @Override
+        void apply( Mutator mutator )
+        {
+            mutator.removeProduction( production );
+        }
+    }
+
+    @Element( uri = Grammar.ANNOTATION_XML_NAMESPACE, name = "recursively" )
+    static class Recursively extends TransitivePatch
+    {
+        @Attribute
+        String from;
+        @Attribute( uri = Grammar.OPENCYPHER_XML_NAMESPACE, optional = true )
+        Boolean lexer;
+        @Attribute( uri = Grammar.RAILROAD_XML_NAMESPACE, optional = true )
+        Boolean skip, inline;
+
+        @Override
+        void apply( Mutator mutator )
+        {
+            applyTransitive( from, mutator );
+        }
+
+        @Override
+        void applyTo( ProductionNode production )
+        {
+            if ( lexer != null )
+            {
+                production.lexer = lexer;
+            }
+            if ( skip != null )
+            {
+                production.skip = skip;
+            }
+            if ( inline != null )
+            {
+                production.inline = inline;
+            }
+        }
+    }
+
+    @Element( uri = Grammar.ANNOTATION_XML_NAMESPACE, name = "mark-and-sweep" )
+    static class MarkAndSweep extends TransitivePatch
+    {
+        @Attribute
+        String root;
+
+        @Override
+        void apply( Mutator mutator )
+        {
+            Set<String> mark = applyTransitive( root, mutator );
+            for ( String production : mutator.productions() )
+            {
+                if ( !mark.contains( production ) )
+                {
+                    mutator.removeProduction( production );
+                }
+            }
+        }
+
+        @Override
+        void applyTo( ProductionNode production )
+        {
+        }
+    }
+
+    @Element( uri = Grammar.RAILROAD_XML_NAMESPACE, name = "skip" )
+    static class SkipProduction extends SingleProductionPatch
+    {
+        @Override
+        ProductionNode production( ProductionNode production )
+        {
+            production.skip = true;
+            return production;
+        }
+    }
+
+    @Element( uri = Grammar.RAILROAD_XML_NAMESPACE, name = "inline" )
+    static class InlineProduction extends SingleProductionPatch
+    {
+        @Override
+        ProductionNode production( ProductionNode production )
+        {
+            production.inline = true;
+            return production;
+        }
+    }
+
+    @Element( uri = Grammar.RAILROAD_XML_NAMESPACE, name = "skipNonTerminal" )
+    static class SkipReference extends SingleProductionPatch
+    {
+        @Attribute
+        String ref;
+
+        @Override
+        Node nonTerminal( NonTerminalNode nonTerminal )
+        {
+            if ( ref.equals( nonTerminal.ref ) )
+            {
+                nonTerminal.skip = true;
+            }
+            return nonTerminal;
+        }
+    }
+
+    @Element( uri = Grammar.RAILROAD_XML_NAMESPACE, name = "inlineNonTerminal" )
+    static class InlineReference extends SingleProductionPatch
+    {
+        @Attribute
+        String ref;
+
+        @Override
+        Node nonTerminal( NonTerminalNode nonTerminal )
+        {
+            if ( ref.equals( nonTerminal.ref ) )
+            {
+                nonTerminal.inline = true;
+            }
+            return nonTerminal;
+        }
+    }
+
+    @Element( uri = Grammar.RAILROAD_XML_NAMESPACE, name = "nonTerminalTitle" )
+    static class NonTerminalTitle extends SingleProductionPatch
+    {
+        @Attribute
+        String ref;
+
+        @Attribute
+        String title;
+
+        @Override
+        Node nonTerminal( NonTerminalNode nonTerminal )
+        {
+            if ( ref.equals( nonTerminal.ref ) )
+            {
+                nonTerminal.title = title;
+            }
+            return nonTerminal;
+        }
+    }
+
+    static abstract class SingleProductionPatch extends Patch
+            implements ProductionTransformation<Void,ProductionNode,RuntimeException>, TermTransformation<Void,Node,RuntimeException>
+    {
+        @Attribute
+        String production;
+
+        @Override
+        void apply( Mutator mutator )
+        {
+            mutator.replaceProduction( production, this, null );
+        }
+
+        @Override
+        public final ProductionNode transformProduction( Void param, Production production ) throws RuntimeException
+        {
+            if ( production instanceof ProductionNode )
+            {
+                ProductionNode node = (ProductionNode) production;
+                return production( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle productions of type " + production.getClass() );
+            }
+        }
+
+        ProductionNode production( ProductionNode production )
+        {
+            Node definition = production.transform( (TermTransformation<Void,Node,RuntimeException>) this, null );
+            if ( definition != production.definition )
+            {
+                return production.replace( definition );
+            }
+            else
+            {
+                return production;
+            }
+        }
+
+        @Override
+        public final Node transformAlternatives( Void param, Alternatives alternatives ) throws RuntimeException
+        {
+            if ( alternatives instanceof AlternativesNode )
+            {
+                AlternativesNode node = (AlternativesNode) alternatives;
+                return alternatives( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + alternatives.getClass() );
+            }
+        }
+
+        Node alternatives( AlternativesNode alternatives )
+        {
+            List<Node> terms = transformCollection( alternatives );
+            if ( terms != null )
+            {
+                AlternativesNode replacement = new AlternativesNode();
+                replacement.nodes.addAll( terms );
+                return replacement;
+            }
+            else
+            {
+                return alternatives;
+            }
+        }
+
+        @Override
+        public final Node transformSequence( Void param, Sequence sequence ) throws RuntimeException
+        {
+            if ( sequence instanceof SequenceNode )
+            {
+                SequenceNode node = (SequenceNode) sequence;
+                return sequence( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + sequence.getClass() );
+            }
+        }
+
+        Node sequence( SequenceNode sequence )
+        {
+            List<Node> terms = transformCollection( sequence );
+            if ( terms != null )
+            {
+                SequenceNode replacement = new SequenceNode();
+                replacement.nodes.addAll( terms );
+                return replacement;
+            }
+            else
+            {
+                return sequence;
+            }
+        }
+
+        private List<Node> transformCollection( Container container )
+        {
+            List<Node> terms = null;
+            int term = 0;
+            for ( Grammar.Term contents : container )
+            {
+                Node replacement = contents.transform( this, null );
+                if ( replacement != contents && terms == null )
+                {
+                    terms = new ArrayList<>( container.terms() );
+                    for ( int i = 0; i < term; i++ )
+                    {
+                        terms.add( container.nodes.get( i ) );
+                    }
+                }
+                if ( terms != null )
+                {
+                    if ( replacement != null )
+                    {
+                        terms.add( replacement );
+                    }
+                }
+                else
+                {
+                    term++;
+                }
+            }
+            return terms;
+        }
+
+        @Override
+        public final Node transformLiteral( Void param, Literal literal ) throws RuntimeException
+        {
+            if ( literal instanceof LiteralNode )
+            {
+                LiteralNode node = (LiteralNode) literal;
+                return literal( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + literal.getClass() );
+            }
+        }
+
+        Node literal( LiteralNode literal )
+        {
+            return literal;
+        }
+
+        @Override
+        public final Node transformNonTerminal( Void param, NonTerminal nonTerminal ) throws RuntimeException
+        {
+            if ( nonTerminal instanceof NonTerminalNode )
+            {
+                NonTerminalNode node = (NonTerminalNode) nonTerminal;
+                return nonTerminal( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + nonTerminal.getClass() );
+            }
+        }
+
+        Node nonTerminal( NonTerminalNode nonTerminal )
+        {
+            return nonTerminal;
+        }
+
+        @Override
+        public final Node transformOptional( Void param, Optional optional ) throws RuntimeException
+        {
+            if ( optional instanceof OptionalNode )
+            {
+                OptionalNode node = (OptionalNode) optional;
+                return optional( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + optional.getClass() );
+            }
+        }
+
+        Node optional( OptionalNode optional )
+        {
+            return optional.replaceTerm( optional.term().transform( this, null ) );
+        }
+
+        @Override
+        public final Node transformRepetition( Void param, Repetition repetition ) throws RuntimeException
+        {
+            if ( repetition instanceof RepetitionNode )
+            {
+                RepetitionNode node = (RepetitionNode) repetition;
+                return repetition( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + repetition.getClass() );
+            }
+        }
+
+        Node repetition( RepetitionNode repetition )
+        {
+            return repetition.replaceTerm( repetition.term().transform( this, null ) );
+        }
+
+        @Override
+        public final Node transformEpsilon( Void param ) throws RuntimeException
+        {
+            return epsilon();
+        }
+
+        Node epsilon()
+        {
+            return Node.epsilon();
+        }
+
+        @Override
+        public final Node transformCharacters( Void param, CharacterSet characters ) throws RuntimeException
+        {
+            if ( characters instanceof CharacterSetNode )
+            {
+                CharacterSetNode node = (CharacterSetNode) characters;
+                return characterSet( node );
+            }
+            else
+            {
+                throw new IllegalStateException( "Cannot handle nodes of of type " + characters.getClass() );
+            }
+        }
+
+        Node characterSet( CharacterSetNode characterSet )
+        {
+            return characterSet;
+        }
+    }
+
+    static abstract class TransitivePatch extends Patch
+    {
+        final Set<String> applyTransitive( String start, Mutator mutator )
+        {
+            Queue<String> queue = new LinkedList<>();
+            queue.add( start );
+            Transformation transformation = new Transformation();
+            for ( String production; null != (production = queue.poll()); )
+            {
+                if ( !transformation.done( production ) )
+                {
+                    transformation.transform( mutator, production, queue );
+                }
+            }
+            return transformation.done;
+        }
+
+        abstract void applyTo( ProductionNode production );
+
+        private final class Transformation
+                implements ProductionTransformation<Queue<String>,ProductionNode,RuntimeException>, TermTransformation<Queue<String>,Void,RuntimeException>
+        {
+            final Set<String> done = new HashSet<>();
+
+            boolean done( String production )
+            {
+                return done.contains( production );
+            }
+
+            void transform( Mutator mutator, String production, Queue<String> queue )
+            {
+                mutator.replaceProduction( production, this, queue );
+            }
+
+            @Override
+            public ProductionNode transformProduction( Queue<String> queue, Production production ) throws RuntimeException
+            {
+                ProductionNode node = (ProductionNode) production;
+                done.add( node.name );
+                applyTo( node );
+                production.definition().transform( this, queue );
+                return node;
+            }
+
+            @Override
+            public Void transformNonTerminal( Queue<String> queue, NonTerminal nonTerminal ) throws RuntimeException
+            {
+                String name = ((NonTerminalNode) nonTerminal).ref;
+                if ( !done( name ) )
+                {
+                    queue.add( name );
+                }
+                return null;
+            }
+
+            @Override
+            public Void transformAlternatives( Queue<String> queue, Alternatives alternatives ) throws RuntimeException
+            {
+                for ( Grammar.Term term : alternatives )
+                {
+                    term.transform( this, queue );
+                }
+                return null;
+            }
+
+            @Override
+            public Void transformSequence( Queue<String> queue, Sequence sequence ) throws RuntimeException
+            {
+                for ( Grammar.Term term : sequence )
+                {
+                    term.transform( this, queue );
+                }
+                return null;
+            }
+
+            @Override
+            public Void transformOptional( Queue<String> queue, Optional optional ) throws RuntimeException
+            {
+                optional.term().transform( this, queue );
+                return null;
+            }
+
+            @Override
+            public Void transformRepetition( Queue<String> queue, Repetition repetition ) throws RuntimeException
+            {
+                repetition.term().transform( this, queue );
+                return null;
+            }
+
+            @Override
+            public Void transformLiteral( Queue<String> param, Literal literal ) throws RuntimeException
+            {
+                return null;
+            }
+
+            @Override
+            public Void transformCharacters( Queue<String> queue, CharacterSet characters ) throws RuntimeException
+            {
+                return null;
+            }
+
+            @Override
+            public Void transformEpsilon( Queue<String> queue ) throws RuntimeException
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Located.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Located.java
@@ -80,8 +80,9 @@ class Located implements LocationAware
                 return pos;
             }
         }
-        throw new IllegalStateException( "Located objects should share a root, " +
-                                         "and be included from different positions where their trees diverge." );
+//        throw new IllegalStateException( "Located objects should share a root, " +
+//                                         "and be included from different positions where their trees diverge." );
+        return 0;
     }
 
     private static List<Located> trace( Map<String, ? extends Located> locations, Located located )

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Node.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Node.java
@@ -105,10 +105,21 @@ abstract class Node extends Grammar.Term implements LocationAware
         return this;
     }
 
+    boolean isEpsilon()
+    {
+        return false;
+    }
+
     static Node epsilon()
     {
         return new Node()
         {
+            @Override
+            boolean isEpsilon()
+            {
+                return true;
+            }
+
             @Override
             public int hashCode()
             {

--- a/tools/grammar/src/main/java/org/opencypher/grammar/OptionalNode.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/OptionalNode.java
@@ -44,6 +44,14 @@ final class OptionalNode extends Sequenced implements Optional
     }
 
     @Override
+    OptionalNode copy()
+    {
+        OptionalNode optional = new OptionalNode();
+        optional.probability = this.probability;
+        return optional;
+    }
+
+    @Override
     public double probability()
     {
         return probability;

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Production.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Production.java
@@ -42,7 +42,32 @@ public interface Production
 
     <Scope> Scope scope( Scope scope, ScopeRule.Transformation<Scope> transition );
 
-    <P, T, EX extends Exception> T transform( TermTransformation<P, T, EX> transformation, P parameter ) throws EX;
+    <P, T, EX extends Exception> T transform( TermTransformation<P,T,EX> transformation, P parameter ) throws EX;
+
+    default boolean isEmpty()
+    {
+        Grammar.Term def = definition();
+        if ( def instanceof Node )
+        {
+            Node node = (Node) def;
+            return node.isEpsilon();
+        }
+        else
+        {
+            return def.transform( new TermTransformation<Void,Boolean,RuntimeException>()
+            {   // <pre>
+                @Override public Boolean transformEpsilon( Void param ) { return true; }
+                @Override public Boolean transformAlternatives( Void param, Alternatives alternatives ) { return false; }
+                @Override public Boolean transformSequence( Void param, Sequence sequence ) { return false; }
+                @Override public Boolean transformLiteral( Void param, Literal literal ) { return false; }
+                @Override public Boolean transformNonTerminal( Void param, NonTerminal nonTerminal ) { return false; }
+                @Override public Boolean transformOptional( Void param, Optional optional ) { return false; }
+                @Override public Boolean transformRepetition( Void param, Repetition repetition ) { return false; }
+                @Override public Boolean transformCharacters( Void param, CharacterSet characters ) { return false; }
+                // </pre>
+            }, null );
+        }
+    }
 
     boolean skip();
 
@@ -51,7 +76,7 @@ public interface Production
     boolean legacy();
 
     boolean lexer();
-    
+
     boolean bnfsymbols();
 
     Collection<NonTerminal> references();

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ProductionResolver.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ProductionResolver.java
@@ -32,16 +32,18 @@ import java.util.Set;
 
 class ProductionResolver
 {
+    private final Grammar.Resolver resolver;
     private final Map<String, ProductionNode> productions;
     private final Dependencies dependencies;
     private final Set<String> unused;
-    private final Set<Root.ResolutionOption> options;
+    private final Set<ProtoGrammar.ResolutionOption> options;
     private final Set<String> legacyProductions;
     private int nonTerminalIndex;
 
-    public ProductionResolver( Map<String,ProductionNode> productions, Dependencies dependencies, Set<String> unused,
-            Set<Root.ResolutionOption> options, Set<String> legacyProductions )
+    public ProductionResolver( Grammar.Resolver resolver, Map<String,ProductionNode> productions, Dependencies dependencies,
+            Set<String> unused, Set<ProtoGrammar.ResolutionOption> options, Set<String> legacyProductions )
     {
+        this.resolver = resolver;
         this.productions = productions;
         this.dependencies = dependencies;
         this.unused = unused;
@@ -52,7 +54,7 @@ class ProductionResolver
     public ProductionNode resolveProduction( ProductionNode origin, String name )
     {
         ProductionNode production = productions.get( name.toLowerCase() );
-        if ( production == null && !options.contains( Root.ResolutionOption.INCLUDE_LEGACY ) && !legacyProductions.contains( name.toLowerCase() ) )
+        if ( production == null && !options.contains( ProtoGrammar.ResolutionOption.INCLUDE_LEGACY ) && !legacyProductions.contains( name.toLowerCase() ) )
         {
             dependencies.missingProduction( name, origin );
         }
@@ -71,5 +73,10 @@ class ProductionResolver
     public int nextNonTerminalIndex()
     {
         return nonTerminalIndex++;
+    }
+
+    public Grammar.Unresolved.Production resolve( ForeignReference reference )
+    {
+        return resolver.resolve( reference );
     }
 }

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ProtoGrammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ProtoGrammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ProtoGrammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ProtoGrammar.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.grammar;
+
+import org.opencypher.tools.xml.Attribute;
+import org.opencypher.tools.xml.XmlFile;
+import org.opencypher.tools.xml.XmlParser;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.xml.parsers.ParserConfigurationException;
+
+abstract class ProtoGrammar
+{
+    static ProtoGrammar parse( Path input, XmlParser.Option... options ) throws ParserConfigurationException, SAXException, IOException
+    {
+        return Parsing.XML.parse( input, options );
+    }
+
+    static ProtoGrammar parse( Reader input, XmlParser.Option... options ) throws ParserConfigurationException, SAXException, IOException
+    {
+        return Parsing.XML.parse( input, options );
+    }
+
+    static ProtoGrammar parse( InputStream input, XmlParser.Option... options ) throws IOException, SAXException, ParserConfigurationException
+    {
+        return Parsing.XML.parse( input, options );
+    }
+
+    static ProtoGrammar parse( XmlFile file ) throws IOException, SAXException, ParserConfigurationException
+    {
+        return file.parse( Parsing.XML );
+    }
+
+    abstract String language();
+
+    abstract ProductionNode production( String name );
+
+    abstract void setName( String name );
+
+    enum ResolutionOption
+    {
+        ALLOW_ROOTLESS,
+        SKIP_UNUSED_PRODUCTIONS,
+        IGNORE_UNUSED_PRODUCTIONS,
+        INCLUDE_LEGACY
+    }
+
+    final Grammar resolve( Grammar.Resolver resolver, ResolutionOption... config )
+    {
+        Set<ResolutionOption> options = EnumSet.noneOf( ProtoGrammar.ResolutionOption.class );
+        if ( config != null )
+        {
+            Collections.addAll( options, config );
+        }
+        return resolve( resolver, options );
+    }
+
+    static final Grammar.Resolver NO_RESOLVER = reference -> null;
+
+    abstract Grammar resolve( Grammar.Resolver resolver, Set<ResolutionOption> options );
+
+    abstract void add( ProductionNode production );
+
+    abstract void apply( Patch patch );
+
+    static abstract class Patch
+    {
+        private Conditional conditional = Conditional.NONE;
+
+        abstract void apply( Mutator mutator );
+
+        @Attribute( optional = true, uri = Conditional.XML_NAMESPACE )
+        void given( String flag )
+        {
+            conditional = conditional.given( flag );
+        }
+
+        @Attribute( optional = true, uri = Conditional.XML_NAMESPACE )
+        void unless( String flag )
+        {
+            conditional = conditional.unless( flag );
+        }
+    }
+
+    static abstract class Mutator
+    {
+        abstract <P, EX extends Exception> void replaceProduction( String production, ProductionTransformation<P,ProductionNode,EX> transformation, P param )
+                throws EX;
+
+        abstract void removeProduction( String production );
+
+        abstract Collection<String> productions();
+    }
+
+    private static class Parsing
+    {
+        static final XmlParser<ProtoGrammar> XML = XmlParser.combine( ProtoGrammar.class, Root.XML, WG3Grammar.XML, GrammarAnnotation.XML );
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ReferenceTarget.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ReferenceTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/ReferenceTarget.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/ReferenceTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,44 +27,9 @@
  */
 package org.opencypher.grammar;
 
-public interface NonTerminal
+interface ReferenceTarget
 {
-    Production production();
+    ProductionNode production();
 
-    default String productionName()
-    {
-        return production().name();
-    }
-
-    default Grammar.Term productionDefinition()
-    {
-        return production().definition();
-    }
-
-    default <Scope> Scope productionScope( Scope scope, ScopeRule.Transformation<Scope> transition )
-    {
-        return production().scope( scope, transition );
-    }
-
-    boolean skip();
-
-    boolean inline();
-
-    Production declaringProduction();
-
-    String title();
-
-    interface ReferenceResolver<T>
-    {
-        T resolveProduction( Production production );
-
-        T unknownReference( NonTerminal nonTerminal );
-
-        interface WG3<T> extends ReferenceResolver<T>
-        {
-            T resolveWG3Reference( String standard, String part, String production );
-        }
-    }
-
-    <T> T resolveReference( ReferenceResolver<T> resolver );
+    <T> T resolve( NonTerminalNode nonTerminal, NonTerminal.ReferenceResolver<T> resolver );
 }

--- a/tools/grammar/src/main/java/org/opencypher/grammar/RepetitionNode.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/RepetitionNode.java
@@ -110,4 +110,14 @@ class RepetitionNode extends Sequenced implements Repetition
             result.append( '}' );
         }
     }
+
+    @Override
+    RepetitionNode copy()
+    {
+        RepetitionNode repetition = new RepetitionNode();
+        repetition.min = this.min;
+        repetition.max = this.max;
+        repetition.norm = this.norm;
+        return repetition;
+    }
 }

--- a/tools/grammar/src/main/java/org/opencypher/grammar/Sequenced.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/Sequenced.java
@@ -110,4 +110,17 @@ abstract class Sequenced extends Node
     void attributeString( StringBuilder result )
     {
     }
+
+    final Node replaceTerm( Node replacement )
+    {
+        if ( term != replacement && (term != null || !replacement.isEpsilon()) )
+        {
+            Sequenced copy = copy();
+            copy.term = replacement;
+            return copy;
+        }
+        return this;
+    }
+
+    abstract Sequenced copy();
 }

--- a/tools/grammar/src/main/java/org/opencypher/grammar/WG3Grammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/WG3Grammar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/WG3Grammar.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/WG3Grammar.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.grammar;
+
+import org.opencypher.tools.grammar.RailRoadDiagramPages;
+import org.opencypher.tools.grammar.SQLBNF;
+import org.opencypher.tools.io.Output;
+import org.opencypher.tools.xml.Attribute;
+import org.opencypher.tools.xml.Child;
+import org.opencypher.tools.xml.Element;
+import org.opencypher.tools.xml.LocationAware;
+import org.opencypher.tools.xml.XmlParser;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.opencypher.tools.xml.XmlParser.xmlParser;
+
+@Element( uri = WG3Grammar.XML_NAMESPACE, name = "grammar" )
+class WG3Grammar implements LocationAware
+{
+    public static void main( String[] args ) throws Exception
+    {
+        for ( String arg : args )
+        {
+            run( Path.of( arg ) );
+        }
+    }
+
+    private static void run( Path inputFile ) throws Exception
+    {
+        Grammar grammar = XML.parse( inputFile ).grammar.build( Grammar.Builder.Option.ALLOW_ROOTLESS );
+        SQLBNF.write( grammar, Output.stdOut() );
+        Map<String,Object> properties = new HashMap<>();
+        properties.put( "RailRoadDiagramPages.outputDir", inputFile.resolveSibling( "railroads" ) );
+        // TODO: don't use SQLBNF yet, the output is broken!
+        //properties.put( "RailRoadDiagramPages.bnfFlavour", (RailRoadDiagramPages.BnfFlavour)(SQLBNF::html) );
+        Files.list( inputFile.toAbsolutePath().getParent() )
+                .filter( path -> path.toString().toUpperCase().endsWith( "GQL.PDF" ) )
+                .max( Comparator.comparing( ( Path path ) -> path.getFileName().toString() ) )
+                .ifPresent( path -> properties.put( "RailRoadDiagramPages.productionDetailsLink", "../" + path.getFileName().toString() + "#''BNF_{0}''" ) );
+        RailRoadDiagramPages.generate( grammar, Output.stdOut(), properties );
+    }
+
+    static final String XML_NAMESPACE = "";
+    static final XmlParser<WG3Grammar> XML = xmlParser( WG3Grammar.class );
+    Grammar.Builder grammar;
+
+    @Override
+    public void location( String path, int lineNumber, int columnNumber )
+    {
+        int end = path.lastIndexOf( '.' );
+        String language = path.substring( path.lastIndexOf( '/' ) + 1, end < 0 ? path.length() : end );
+        grammar = Grammar.grammar( language );
+    }
+
+    @Child
+    void add( BnfDef def )
+    {
+        def.addTo( grammar );
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "BNFDef" )
+    static class BnfDef
+    {
+        @Attribute( name = "name" )
+        String name;
+        boolean predicative;
+        private Rhs def;
+
+        @Attribute( optional = true )
+        void predicative( String predicative )
+        {
+            this.predicative = "yes".equalsIgnoreCase( predicative );
+        }
+
+        @Child
+        void setDef( Rhs def )
+        {
+            if ( this.def != null )
+            {
+                throw new IllegalStateException( "Body of '" + name + "' already defined." );
+            }
+            this.def = def;
+        }
+
+        void addTo( Grammar.Builder grammar )
+        {
+            if ( def == null )
+            {
+                throw new IllegalStateException( "Body of '" + name + "' not defined." );
+            }
+//            if ( def.terms.isEmpty() )
+//            {
+//                System.err.println( "<" + name + "> IS EMPTY!!!" );
+//            }
+            if ( def.seeTheRules )
+            {
+                grammar.production( name, "SEE THE RULES", def.term() );
+            }
+            else
+            {
+                grammar.production( name, def.term() );
+            }
+        }
+    }
+
+    static abstract class Body// implements Term
+    {
+        final List<Grammar.Term> terms = new ArrayList<>();
+        private State state = State.INITIAL;
+
+        @Child
+        final void literal( char[] buffer, int start, int length )
+        {
+            LiteralNode.fromCharacters( buffer, start, length, this::text );
+        }
+
+        private void text( LiteralNode literal )
+        {
+            state.seq( terms, literal, getClass() );
+        }
+
+        @Child
+        void alt( Alt term )
+        {
+            state = state.alt( terms, term.term(), getClass() );
+        }
+
+        @Child( {BNF.class, Group.class, Opt.class, Keyword.class, TerminalSymbol.class} )
+        void seq( Term term )
+        {
+            state = state.seq( terms, term.term(), getClass() );
+        }
+
+        @Child
+        void ellipsis( Ellipsis ellipsis )
+        {
+            if ( state == State.ALT )
+            {
+                throw new IllegalStateException( "Cannot add <ellipsis> to alt group." );
+            }
+            int last = terms.size() - 1;
+            terms.set( last, Grammar.oneOrMore( terms.get( last ) ) );
+        }
+
+        public Grammar.Term term()
+        {
+            if ( terms.size() == 1 )
+            {
+                return terms.get( 0 );
+            }
+            return state.term( terms, getClass() );
+        }
+
+        enum State
+        {   // <pre>
+            INITIAL
+            {
+                @Override
+                Grammar.Term term( List<Grammar.Term> terms, Class<? extends Body> type )
+                {
+                    if (true) // TODO: temporary measure? Ultimately, I believe there should not be empty production rules.
+                    {
+                        return Grammar.epsilon();
+                    }
+                    throw new IllegalStateException( "Cannot create term from empty group in <" + type.getSimpleName().toLowerCase() + ">." );
+                }
+            },
+            ALT
+            {
+                @Override
+                State seq( List<Grammar.Term> terms, Grammar.Term term, Class<? extends Body> type )
+                {
+                    throw new IllegalStateException( "Cannot add <" + term.getClass().getSimpleName().toLowerCase() + "> to alt group in <" + type.getSimpleName().toLowerCase() + ">." );
+                }
+
+                @Override
+                Grammar.Term term( List<Grammar.Term> terms, Class<? extends Body> type )
+                {
+                    return new AlternativesNode().addAll( terms );
+                }
+            },
+            SEQ
+            {
+                @Override
+                State alt( List<Grammar.Term> terms, Grammar.Term term, Class<? extends Body> type )
+                {
+                    throw new IllegalStateException( "Cannot add <alt> to sequential group in <" + type.getSimpleName().toLowerCase() + ">.");
+                }
+
+                @Override
+                Grammar.Term term( List<Grammar.Term> terms, Class<? extends Body> aClass)
+                {
+                    return new SequenceNode().addAll( terms );
+                }
+            },
+            ; // </pre>
+
+            State alt( List<Grammar.Term> terms, Grammar.Term term, Class<? extends Body> aClass )
+            {
+                terms.add( term );
+                return ALT;
+            }
+
+            State seq( List<Grammar.Term> terms, Grammar.Term term, Class<? extends Body> aClass )
+            {
+                terms.add( term );
+                return SEQ;
+            }
+
+            abstract Grammar.Term term( List<Grammar.Term> terms, Class<? extends Body> aClass );
+        }
+    }
+
+    interface Term
+    {
+        Grammar.Term term();
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "rhs" )
+    static class Rhs extends Body
+    {
+        boolean seeTheRules;
+
+        @Child
+        void seeTheRules( SeeTheRules seeTheRules )
+        {
+            this.seeTheRules = true;
+        }
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "BNF" )
+    static class BNF implements Term
+    {
+        @Attribute
+        String name;
+
+        @Override
+        public Grammar.Term term()
+        {
+            return Grammar.nonTerminal( name );
+        }
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "alt" )
+    static class Alt extends Body implements Term
+    {
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "group" )
+    static class Group extends Body implements Term
+    {
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "opt" )
+    static class Opt extends Body implements Term
+    {
+        @Override
+        public Grammar.Term term()
+        {
+            OptionalNode opt = new OptionalNode();
+            opt.add( (Node)super.term() );
+            return opt;
+        }
+    }
+
+    static abstract class Literal implements Term
+    {
+        private Node literal;
+
+        @Child
+        final void literal( char[] buffer, int start, int length )
+        {
+            LiteralNode.fromCharacters( buffer, start, length, this::add );
+        }
+
+        private void add( LiteralNode literal )
+        {
+            if ( this.literal != null )
+            {
+                SequenceNode seq;
+                if ( this.literal instanceof SequenceNode )
+                {
+                    seq = (SequenceNode) this.literal;
+                }
+                else
+                {
+                    seq = new SequenceNode();
+                    seq.add( this.literal );
+                    this.literal = seq;
+                }
+                seq.add( literal );
+            }
+            else
+            {
+                this.literal = literal;
+            }
+        }
+
+        @Override
+        public Grammar.Term term()
+        {
+            if ( literal == null )
+            {
+                throw new IllegalStateException( "No keyword!" );
+            }
+            return literal;
+        }
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "kw" )
+    static class Keyword extends Literal
+    {
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "terminalsymbol" )
+    static class TerminalSymbol extends Literal
+    {
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "seeTheRules" )
+    static class SeeTheRules
+    {
+    }
+
+    @Element( uri = WG3Grammar.XML_NAMESPACE, name = "ellipsis" )
+    static class Ellipsis
+    {
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/grammar/WG3Reference.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/WG3Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/grammar/WG3Reference.java
+++ b/tools/grammar/src/main/java/org/opencypher/grammar/WG3Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,44 +27,36 @@
  */
 package org.opencypher.grammar;
 
-public interface NonTerminal
+class WG3Reference extends ForeignReference
 {
-    Production production();
+    private final String standard, part, name;
 
-    default String productionName()
+    WG3Reference( String standard, String part, String name )
     {
-        return production().name();
+        this.standard = standard;
+        this.part = part;
+        this.name = name;
     }
 
-    default Grammar.Term productionDefinition()
+    @Override
+    public <T> T resolve( NonTerminalNode nonTerminal, NonTerminal.ReferenceResolver<T> resolver )
     {
-        return production().definition();
-    }
-
-    default <Scope> Scope productionScope( Scope scope, ScopeRule.Transformation<Scope> transition )
-    {
-        return production().scope( scope, transition );
-    }
-
-    boolean skip();
-
-    boolean inline();
-
-    Production declaringProduction();
-
-    String title();
-
-    interface ReferenceResolver<T>
-    {
-        T resolveProduction( Production production );
-
-        T unknownReference( NonTerminal nonTerminal );
-
-        interface WG3<T> extends ReferenceResolver<T>
+        if ( resolver instanceof NonTerminal.ReferenceResolver.WG3 )
         {
-            T resolveWG3Reference( String standard, String part, String production );
+            NonTerminal.ReferenceResolver.WG3<T> wg3 = (NonTerminal.ReferenceResolver.WG3<T>) resolver;
+            return wg3.resolveWG3Reference( standard, part, nonTerminal.ref );
         }
+        return resolver.unknownReference( nonTerminal );
     }
 
-    <T> T resolveReference( ReferenceResolver<T> resolver );
+    @Override
+    public Grammar.Unresolved.Production resolve( Grammar.Resolver resolver )
+    {
+        if ( resolver instanceof Grammar.Resolver.WG3 )
+        {
+            Grammar.Resolver.WG3 wg3 = (Grammar.Resolver.WG3) resolver;
+            return wg3.resolve( standard, part, name );
+        }
+        return null;
+    }
 }

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Antlr4.java
@@ -28,19 +28,39 @@
 package org.opencypher.tools.grammar;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
+import org.antlr.runtime.ANTLRReaderStream;
+import org.antlr.v4.Tool;
+import org.antlr.v4.misc.OrderedHashMap;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.LexerInterpreter;
+import org.antlr.v4.runtime.ParserInterpreter;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.tool.ANTLRMessage;
+import org.antlr.v4.tool.ANTLRToolListener;
+import org.antlr.v4.tool.ErrorManager;
+import org.antlr.v4.tool.Rule;
+import org.antlr.v4.tool.ast.GrammarRootAST;
 import org.opencypher.grammar.CharacterSet;
 import org.opencypher.grammar.Grammar;
 import org.opencypher.grammar.NonTerminal;
@@ -80,16 +100,29 @@ public class Antlr4 extends BnfWriter {
         write(grammar, output(stream));
     }
 
-    public static void write(Grammar grammar, Output output) {
-        String header = grammar.header();
-        if (header != null) {
-            output.println("/**").append(" * ").printLines(header, " * ").println(" */");
-        }
-        output.append("grammar ").append(grammar.language()).println(";").println();
+    public static void write( Grammar grammar, Path path, OutputStream stream )
+    {
+        write( grammar, stream );
+    }
 
-        try (Antlr4 antlr = new Antlr4(output)) {
-            grammar.accept(antlr);
+    public static void write( Grammar grammar, Output output )
+    {
+        try ( Antlr4 antlr = new Antlr4( ProductionMappingListener.NONE, output ) )
+        {
+            antlr.write( grammar );
         }
+    }
+
+    private void write( Grammar grammar )
+    {
+        String header = grammar.header();
+        if ( header != null )
+        {
+            output.println( "/**" ).append( " * " ).printLines( header, " * " ).println( " */" );
+        }
+        output.append( "grammar " ).append( unspaceString( grammar.language() ) ).println( ";" ).println();
+
+        grammar.accept( this );
     }
 
     public static void main(String... args) throws Exception {
@@ -102,7 +135,7 @@ public class Antlr4 extends BnfWriter {
         }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        execute(Antlr4::write, out, "grammar/cypher.xml");
+        execute( ( grammar, workingDir, stream ) -> write( grammar, stream ), out, "grammar/cypher.xml");
 
         if (g4OutputFilePath == null) {
             System.out.print(out.toString(UTF_8.name()));
@@ -113,6 +146,204 @@ public class Antlr4 extends BnfWriter {
         }
     }
 
+    public static Parser generateParser( Grammar grammar, String root, Output output )
+    {
+        Output.Readable source = Output.stringBuilder();
+        org.antlr.v4.Tool tool = new org.antlr.v4.Tool();
+        AntlrMessageLogger messages = new AntlrMessageLogger( tool, output );
+        try ( Antlr4 antlr = new Antlr4( messages, source ) )
+        {
+            antlr.write( grammar );
+        }
+        ANTLRReaderStream generatorInput;
+        try
+        {
+            generatorInput = new ANTLRReaderStream( source.reader() );
+        }
+        catch ( IOException e )
+        {
+            throw new IllegalStateException( "Failed to create reader from buffer." );
+        }
+        GrammarRootAST ast = tool.parse( grammar.language(), generatorInput );
+        org.antlr.v4.tool.Grammar g = tool.createGrammar( ast );
+        tool.process( g, false );
+        messages.report( source, grammar );
+        String rootRuleName = ruleName( root );
+        Rule rootRule = g.getRule( rootRuleName );
+        if ( rootRule == null )
+        {
+            throw new IllegalArgumentException(
+                    "The generated parser does not define a rule for '" + root + "' (it should have been called '" + rootRuleName + "' by the parser)." );
+        }
+        int rootRuleIndex = rootRule.index;
+        return input ->
+        {
+            LexerInterpreter lexer = g.createLexerInterpreter( CharStreams.fromString( input ) );
+            ParserInterpreter parser = g.createParserInterpreter( new CommonTokenStream( lexer ) );
+            ParseTree tree = parser.parse( rootRuleIndex );
+            return new Antlr4Tree( tree );
+        };
+    }
+
+    private static class AntlrMessageLogger implements ProductionMappingListener, ANTLRToolListener
+    {
+        private final Output output;
+        private final ErrorManager errMgr;
+        private boolean errors;
+        private final Map<String, Production> productions = new HashMap<>();
+        private final List<Message> messages = new ArrayList<>();
+
+        AntlrMessageLogger( Tool tool, Output output )
+        {
+            this.errMgr = tool.errMgr;
+            this.output = output;
+            tool.addListener( this );
+        }
+
+        @Override
+        public void map( String name, Production production )
+        {
+            productions.put( name, production );
+        }
+
+        @Override
+        public void info( String msg )
+        {
+            output.format( "ANTLR Parser Generator: %s%n", msg );
+        }
+
+        @Override
+        public void error( ANTLRMessage msg )
+        {
+            errors = true;
+            messages.add( new Message( true, msg ) );
+        }
+
+        @Override
+        public void warning( ANTLRMessage msg )
+        {
+            messages.add( new Message( false, msg ) );
+        }
+
+        public void report( Output.Readable source, Grammar grammar )
+        {
+            if ( !messages.isEmpty() )
+            {
+                messages.sort( Comparator.comparingInt( ( Message msg ) -> msg.message.line ).thenComparing( ( Message msg ) -> msg.message.charPosition ) );
+                source.lines( new BiConsumer<>()
+                {
+                    Iterator<Message> iterator = messages.iterator();
+                    Message message = iterator.next();
+
+                    @Override
+                    public void accept( String line, Integer no )
+                    {
+                        output.format( "%7d: ", no ).println( line );
+                        while ( message != null && message.message.line <= no )
+                        {
+                            if ( message.message.charPosition >= 0 )
+                            {
+                                output.append( message.error ? "ERROR:   " : "WARNING: " ).repeat( ' ', message.message.charPosition ).append( '^' ).println();
+                            }
+                            output.append( message.error ? "ERROR:   " : "WARNING: " ).println( errMgr.getMessageTemplate( message.message ).render() );
+                            message = iterator.hasNext() ? iterator.next() : null;
+                        }
+                    }
+                } );
+                Map<String,List<Message>> productions = new HashMap<>();
+                for ( Message message : messages )
+                {
+                    addProductions( productions, message, message.message.getArgs() );
+                }
+                for ( Map.Entry<String,List<Message>> entry : productions.entrySet() )
+                {
+                    output.println();
+                    Production production;
+                    try
+                    {
+                        production = grammar.production( entry.getKey() );
+                    }
+                    catch ( IllegalArgumentException noSuchProduction )
+                    {
+                        production = null;
+                    }
+                    if ( production != null )
+                    {
+                        ISO14977.append( production, output );
+                    }
+                    else
+                    {
+                        output.append( "Keyword \"" ).append( entry.getKey() ).println( "\"" );
+                    }
+                    for ( Message message : entry.getValue() )
+                    {
+                        output.println( errMgr.getMessageTemplate( message.message ).render() );
+                    }
+                    output.println();
+                }
+                if ( errors )
+                {
+                    throw new IllegalStateException(
+                            "There were errors when generating the ANTLR parser. " + productions.size() + " productions in error: " + productions.keySet() );
+                }
+            }
+        }
+
+        private void addProductions( Map<String,List<Message>> productions, Message message, Object obj )
+        {
+            if ( obj instanceof String )
+            {
+                Production production = this.productions.get( obj );
+                productions.computeIfAbsent( production != null ? production.name() : (String) obj, key -> new ArrayList<>() ).add( message );
+            }
+            else if ( obj instanceof Rule )
+            {
+                addProductions( productions, message, ((Rule) obj).name );
+            }
+            else if ( obj instanceof Object[] )
+            {
+                for ( Object object : (Object[]) obj )
+                {
+                    addProductions( productions, message, object );
+                }
+            }
+            else if ( obj instanceof Collection<?> )
+            {
+                for ( Object object : (Collection<?>) obj )
+                {
+                    addProductions( productions, message, object );
+                }
+            }
+        }
+
+        static class Message
+        {
+            final boolean error;
+            final ANTLRMessage message;
+
+            Message( boolean error, ANTLRMessage message )
+            {
+                this.error = error;
+                this.message = message;
+            }
+        }
+    }
+
+    private static class Antlr4Tree implements Parser.ParseTree
+    {
+        private final ParseTree tree;
+
+        Antlr4Tree( ParseTree tree )
+        {
+            this.tree = tree;
+        }
+    }
+
+    private static String ruleName( String rule )
+    {
+        return Antlr4.prefix + unspaceString( rule );
+    }
+
     private final Map<String, CharacterSet> fragmentRules = new HashMap<>();
     private final Set<String> seenKeywords = new HashSet<>();
     /*
@@ -120,9 +351,12 @@ public class Antlr4 extends BnfWriter {
      * production, and is emptied when the production is exited.
      */
     private final Map<String, String> keywordsInProduction = new LinkedHashMap<>();
+    private final ProductionMappingListener mappingListener;
 
-    private Antlr4(Output output) {
-        super(output);
+    private Antlr4( ProductionMappingListener mappingListener, Output output )
+    {
+        super( output );
+        this.mappingListener = mappingListener;
     }
 
     @Override
@@ -145,7 +379,8 @@ public class Antlr4 extends BnfWriter {
         for (Map.Entry<String, CharacterSet> rule : fragmentRules.entrySet()) {
             CharacterSet set = rule.getValue();
             output.append("fragment ");
-            lexerRule(rule.getKey()).append(" : ");
+            lexerRule(rule.getKey());
+            output.append(" : ");
             if (set.name() != null && !set.isControlCharacter()) {
                 // antlr 4.7.2 is thought to accept all the names we know except the control
                 // characters
@@ -189,12 +424,14 @@ public class Antlr4 extends BnfWriter {
     @Override
     protected void productionStart(Production p) {
         currentProduction = p.name();
+        String name;
         if (p.lexer()) {
-            lexerRule(currentProduction);
+            name = lexerRule(currentProduction);
         } else {
-            parserRule(currentProduction);
+            name = parserRule(currentProduction);
             nextLexerRule = 0;
         }
+        mappingListener.map( name, p );
         // we don't really want the : to line up with all the pipes (at least, I don't)
         alternativesLinePrefix(currentProduction.length());
         output.append(":  ");
@@ -214,17 +451,7 @@ public class Antlr4 extends BnfWriter {
             if (!seenKeywords.contains(ruleName)) {
                 seenKeywords.add(ruleName);
                 caseInsensitiveProductionStart(ruleName);
-                for (char c : lexerRule.getValue().toCharArray()) {
-                    // possible alternative style (can't work out what the indirect way of this is
-                    // can't cope with non-alpha numerics and test not setup for it
-                    // output.append(String.valueOf( c ).toUpperCase() );
-                    groupWith('(', () -> {
-                        literal(String.valueOf(c).toUpperCase());
-                        alternativesSeparator();
-                        literal(String.valueOf(c).toLowerCase());
-                    }, ')');
-                    sequenceSeparator();
-                }
+                inline( lexerRule.getValue() );
                 output.println(" ;").println();
             }
         }
@@ -332,25 +559,35 @@ public class Antlr4 extends BnfWriter {
         }
     }
 
-    private String unspaceString(String original) {
-        return original.replaceAll("\\s+", "_");
+    private static String unspaceString(String original) {
+        return original.replaceAll("(\\s+|-|\\.)", "_");
     }
 
-    private Output parserRule(String name) {
-        return output.append(prefix(unspaceString(name)));
+    private String parserRule( String name )
+    {
+        String handle = prefix( unspaceString( name ) );
+        output.append( handle );
+        return handle;
     }
 
-    private Output lexerRule(String original) {
-        String name = unspaceString(original);
-        int cp = name.codePointAt(0);
-        if (!isUpperCase(cp)) {
-            if (name.codePoints().noneMatch(Character::isUpperCase)) {
-                return output.append(name.toUpperCase());
+    private String lexerRule( String original )
+    {
+        String name = unspaceString( original );
+        int cp = name.codePointAt( 0 );
+        if ( !isUpperCase( cp ) )
+        {
+            if ( name.codePoints().noneMatch( Character::isUpperCase ) )
+            {
+                name = name.toUpperCase();
             }
-            return output.appendCodePoint(toUpperCase(cp)).append(name, charCount(cp), name.length());
-        } else {
-            return output.append(name);
+            else
+            {
+                name = new StringBuilder( name.length() ).appendCodePoint( toUpperCase( cp ) ).append( name, charCount( cp ), name.length() ).toString();
+            }
         }
+//        name = Antlr4.prefix.toUpperCase() + name;
+        output.append( name );
+        return name;
     }
 
     @Override
@@ -364,7 +601,7 @@ public class Antlr4 extends BnfWriter {
     }
 
     private boolean reserved(String ruleName) {
-        return ruleName.equals("SKIP");
+        return ruleName.equals("SKIP") || ruleName.equals("MORE");
     }
 
     private void inline(String value) {
@@ -384,9 +621,12 @@ public class Antlr4 extends BnfWriter {
                     start = i + Character.charCount(cp);
                     cp = Character.toUpperCase(cp);
                     String upper = String.valueOf((char) cp);
-                    escapeAndEnclose(upper);
-                    alternativesSeparator();
-                    escapeAndEnclose(upper.toLowerCase());
+                    groupWith( '(', () ->
+                    {
+                        escapeAndEnclose( upper );
+                        alternativesSeparator();
+                        escapeAndEnclose( upper.toLowerCase() );
+                    }, ')' );
                 }
             }
             if (start < value.length()) {
@@ -417,7 +657,8 @@ public class Antlr4 extends BnfWriter {
     @Override
     protected void caseInsensitiveProductionStart(String name) {
         currentProduction = name;
-        lexerRule(currentProduction).append(" : ");
+        lexerRule( currentProduction );
+        output.append( " : " );
         nextLexerRule = 0;
     }
 

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/CypherGeneratorFactory.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/CypherGeneratorFactory.java
@@ -72,7 +72,7 @@ public class CypherGeneratorFactory extends GeneratorFactory<CypherGeneratorFact
 
     public static void main( String... args ) throws Exception
     {
-        execute( ( grammar, out ) -> {
+        execute( ( grammar, workingDir, out ) -> {
             Output.Readable output = stringBuilder();
             new CypherGeneratorFactory()
             {

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/HtmlLinker.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/HtmlLinker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/HtmlLinker.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/HtmlLinker.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.grammar;
+
+import org.opencypher.grammar.CharacterSet;
+import org.opencypher.grammar.NonTerminal;
+
+public interface HtmlLinker
+{
+    String referenceLink( NonTerminal reference );
+
+    default String charsetLink( CharacterSet charset )
+    {
+        return charsetLink( CharacterSet.Unicode.toSetString( charset ) );
+    }
+
+    String charsetLink( String charset );
+}

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
@@ -29,6 +29,7 @@ package org.opencypher.tools.grammar;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.file.Path;
 
 import org.opencypher.grammar.CharacterSet;
 import org.opencypher.grammar.Grammar;
@@ -51,7 +52,7 @@ public class ISO14977 extends BnfWriter
         write( grammar, output( writer ) );
     }
 
-    public static void write( Grammar grammar, OutputStream stream )
+    public static void write( Grammar grammar, Path workingDir, OutputStream stream )
     {
         write( grammar, output( stream ) );
     }
@@ -79,6 +80,18 @@ public class ISO14977 extends BnfWriter
     public static void append( Grammar.Term term, Output output )
     {
         term.accept( new ISO14977( output ) );
+    }
+
+    public static void append( Production production, Output output )
+    {
+        new ISO14977( output )
+        {
+            @Override
+            protected void productionEnd()
+            {
+                output.println( " ;" );
+            }
+        }.visitProduction( production );
     }
 
     public static Output string( Output str, Production production )

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ISO14977.java
@@ -95,18 +95,6 @@ public class ISO14977 extends BnfWriter
         }
     }
 
-    public interface HtmlLinker
-    {
-        String referenceLink( NonTerminal reference );
-
-        default String charsetLink( CharacterSet charset )
-        {
-            return charsetLink( CharacterSet.Unicode.toSetString( charset ) );
-        }
-
-        String charsetLink( String charset );
-    }
-
     private ISO14977( Output output )
     {
         super( output );
@@ -119,7 +107,7 @@ public class ISO14977 extends BnfWriter
 
         Html( HtmlTag html, HtmlLinker linker )
         {
-            super( html.output() );
+            super( html.textOutput() );
             this.html = html;
             this.linker = linker;
         }

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Main.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Main.java
@@ -133,23 +133,35 @@ interface Main extends Serializable
             Grammar.ParserOption[] options = Grammar.ParserOption.from( System.getProperties() );
             Path grammarPath = null;
             String path = args[0];
-            if ( path.indexOf( '/' ) == -1 )
+            FileSystem fs = null;
+            try
             {
-                URL resource = program.getClass().getResource( "/" + path );
-                if ( resource != null )
+                if ( path.indexOf( '/' ) == -1 )
                 {
-                    URI uri = resource.toURI();
-                    try ( FileSystem ignored = "jar".equalsIgnoreCase( uri.getScheme() ) ? FileSystems.newFileSystem( uri, Collections.emptyMap() ) : null )
+                    URL resource = program.getClass().getResource( "/" + path );
+                    if ( resource != null )
                     {
+                        URI uri = resource.toURI();
+                        if ( "jar".equalsIgnoreCase( uri.getScheme() ) )
+                        {
+                            fs = FileSystems.newFileSystem( uri, Collections.emptyMap() );
+                        }
                         grammarPath = Paths.get( uri );
                     }
                 }
+                if ( grammarPath == null )
+                {
+                    grammarPath = Paths.get( path );
+                }
+                program.write( Grammar.parseXML( grammarPath, options ), grammarPath.getParent(), out );
             }
-            if ( grammarPath == null )
+            finally
             {
-                grammarPath = Paths.get( path );
+                if (fs != null)
+                {
+                    fs.close();
+                }
             }
-            program.write( Grammar.parseXML( grammarPath, options ), grammarPath.getParent(), out );
         }
         else
         {

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ParseTrees.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ParseTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ParseTrees.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ParseTrees.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.grammar;
+
+import org.opencypher.grammar.Grammar;
+import org.opencypher.tools.io.Output;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+class ParseTrees extends Tool
+{
+    interface Options
+    {
+        default Path sources()
+        {
+            return null;
+        }
+
+        default Parser.Generator parserGenerator()
+        {
+            return Antlr4::generateParser;
+        }
+
+        default String rootProduction()
+        {
+            return null;
+        }
+    }
+
+    public static void main( String... args ) throws Exception
+    {
+        main( ParseTrees::new, ParseTrees::generate, args );
+    }
+
+    private final Options options;
+
+    ParseTrees( Path workingDir, Map<?,?> properties )
+    {
+        super( workingDir, properties );
+        this.options = options( Options.class );
+    }
+
+    public void generate( Grammar grammar, Output output ) throws IOException
+    {
+        Parser parser = options.parserGenerator().generateParser( grammar, rootProductionRule( grammar ), output );
+        Path sources = options.sources();
+        if ( sources != null )
+        {
+            Path destination = outputDir();
+            if ( Files.isDirectory( sources ) )
+            {
+                Files.walk( sources ).filter( Files::isRegularFile ).forEach( path -> generate( parser, path, destination, output ) );
+            }
+            else if ( Files.isRegularFile( sources ) )
+            {
+                generate( parser, sources, destination, output );
+            }
+            else
+            {
+                output.format( "ParseTree Source does not exist: %s,%n", sources );
+            }
+        }
+        else
+        {
+            output.println( "No 'source' specified for ParseTree." );
+        }
+    }
+
+    private String rootProductionRule( Grammar grammar )
+    {
+        String root = options.rootProduction();
+        if ( root == null )
+        {
+            String language = grammar.language();
+            if ( grammar.hasProduction( language ) )
+            {
+                return language;
+            }
+            throw new IllegalStateException( "No root production rule specified for " + language );
+        }
+        return root;
+    }
+
+    private void generate( Parser parser, Path source, Path destination, Output log )
+    {
+        String filename = source.getFileName().toString();
+        int dot = filename.lastIndexOf( '.' );
+        switch ( dot < 0 ? "" : filename.substring( dot ).toLowerCase() )
+        {
+        case ".cypher":
+            try
+            {
+                Parser.ParseTree tree = parser.parse( Files.readString( source ) );
+                if ( false )
+                {
+                    System.out.println( tree );
+                }
+            }
+            catch ( IOException e )
+            {
+                log.format( "IOException in reading '%s': %s%n", source, e.getMessage() );
+            }
+            break;
+        case ".feature":
+//            new GherkinVintageFeatureParser();
+            //break;
+        default:
+            log.format( "Cannot determine type of file: %s%n", source );
+        }
+    }
+
+    @Override
+    protected <T> T transform( Class<T> type, String value )
+    {
+        if ( type == Parser.Generator.class )
+        {
+            return type.cast( Parser.generator( value ) );
+        }
+        return super.transform( type, value );
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Parser.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Parser.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 "Neo Technology,"
+ * Copyright (c) 2015-2021 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,46 +25,33 @@
  * described as "implementation extensions to Cypher" or as "proposed changes to
  * Cypher that are not yet approved by the openCypher community".
  */
-package org.opencypher.grammar;
+package org.opencypher.tools.grammar;
 
-public interface NonTerminal
+import org.opencypher.grammar.Grammar;
+import org.opencypher.tools.io.Output;
+
+public interface Parser
 {
-    Production production();
-
-    default String productionName()
+    static Generator generator( String name )
     {
-        return production().name();
-    }
-
-    default Grammar.Term productionDefinition()
-    {
-        return production().definition();
-    }
-
-    default <Scope> Scope productionScope( Scope scope, ScopeRule.Transformation<Scope> transition )
-    {
-        return production().scope( scope, transition );
-    }
-
-    boolean skip();
-
-    boolean inline();
-
-    Production declaringProduction();
-
-    String title();
-
-    interface ReferenceResolver<T>
-    {
-        T resolveProduction( Production production );
-
-        T unknownReference( NonTerminal nonTerminal );
-
-        interface WG3<T> extends ReferenceResolver<T>
+        if ( "Antlr4".equalsIgnoreCase( name ) )
         {
-            T resolveWG3Reference( String standard, String part, String production );
+            return ( grammar, root, output ) -> Antlr4.generateParser( grammar, root, output );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unknown parser generator: " + name );
         }
     }
 
-    <T> T resolveReference( ReferenceResolver<T> resolver );
+    interface Generator
+    {
+        Parser generateParser( Grammar grammar, String root, Output output );
+    }
+
+    ParseTree parse( String input );
+
+    interface ParseTree
+    {
+    }
 }

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ProductionMappingListener.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ProductionMappingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/ProductionMappingListener.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/ProductionMappingListener.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.grammar;
+
+import org.opencypher.grammar.Production;
+
+import java.util.Arrays;
+
+interface ProductionMappingListener
+{
+    void map( String name, Production production );
+
+    static ProductionMappingListener combine( ProductionMappingListener... listeners )
+    {
+        if ( listeners == null || listeners.length == 0 )
+        {
+            return NONE;
+        }
+        if ( listeners.length == 1 )
+        {
+            if ( listeners[0] == null )
+            {
+                return NONE;
+            }
+            return listeners[0];
+        }
+        int len = listeners.length;
+        for ( int i = 0; i < len; i++ )
+        {
+            while ( (listeners[i] == null || listeners[i] == NONE) && i < len )
+            {
+                listeners[i] = listeners[--len];
+            }
+            for ( int j = 0; j < i; j++ )
+            {
+                if ( listeners[i] == listeners[j] )
+                {
+                    listeners[i--] = listeners[--len];
+                    break;
+                }
+            }
+        }
+        if ( len == 0 )
+        {
+            return NONE;
+        }
+        if ( len == 1 )
+        {
+            return listeners[0];
+        }
+        ProductionMappingListener[] targets = Arrays.copyOf( listeners, len );
+        return ( name, production ) ->
+        {
+            for ( ProductionMappingListener listener : targets )
+            {
+                listener.map( name, production );
+            }
+        };
+    }
+
+    ProductionMappingListener NONE = ( name, production ) ->
+    {
+    };
+}

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
@@ -54,6 +54,32 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import static org.opencypher.tools.Reflection.pathOf;
 
+/**
+ * Used for specifying a "project" in xml, to define a set of tools to run on a (set of) grammar(s).
+ *
+ * Example:
+ * <code><pre>
+ * &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+ * &lt;project xmlns="http://opencypher.org/grammar/project"&gt;
+ *   &lt;grammar id="g1" path="grammars/my-grammar.xml"/&gt;
+ *   &lt;grammar id="g-two" path="grammars/another-grammar.xml"/&gt;
+ *
+ *   &lt;output tool="{@linkplain RailRoadDiagramPages RAIL_ROAD_DIAGRAM_PAGES}" grammar="g1" path="out-dir/rr"&gt;
+ *     &lt;option key="{@linkplain RailRoadDiagramPages.Options#productionDetailsLink() productionDetailsLink}" value="my-language.pdf#{1}"/&gt;
+ *   &lt;/output&gt;
+ *
+ *   &lt;output tool="{@linkplain SQLBNF WG3BNF}" grammar="g1" path="out-dir/g1.bnf"/&gt;
+ *   &lt;output tool="{@linkplain ISO14977 ISO14977}" grammar="g-two" path="out-dir/g-two.bnf"/&gt;
+ *   &lt;output tool="{@linkplain Antlr4 ANTLR4}" grammar="g-two" path="out-dir/g-two.g"/&gt;
+ *
+ *   &lt;output tool="{@linkplain ParseTrees PARSE_TREE}" grammar="g-two" path="out-dir/parse-trees"&gt;
+ *     &lt;option key="{@linkplain Project.Tool#log(Map) log}" value="out-dir/parse-tree-gen.log"/&gt;
+ *     &lt;option key="{@linkplain ParseTrees.Options#sources() sources}" value="source-samples/g-two/"/&gt;
+ *     &lt;option key="{@linkplain ParseTrees.Options#rootProduction() rootProduction}" value="grammar root"/&gt;
+ *   &lt;/output&gt;
+ * &lt;/project&gt;
+ * </pre></code>
+ */
 @Element( uri = Project.NAMESPACE, name = "project" )
 class Project
 {

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Project.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.grammar;
+
+import org.opencypher.grammar.Conditional;
+import org.opencypher.grammar.Grammar;
+import org.opencypher.tools.io.Output;
+import org.opencypher.tools.xml.Attribute;
+import org.opencypher.tools.xml.Child;
+import org.opencypher.tools.xml.Element;
+import org.opencypher.tools.xml.XmlFile;
+import org.opencypher.tools.xml.XmlParser;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.xml.parsers.ParserConfigurationException;
+
+import static org.opencypher.tools.Reflection.pathOf;
+
+@Element( uri = Project.NAMESPACE, name = "project" )
+class Project
+{
+    static final String NAMESPACE = Grammar.XML_NAMESPACE + "/project";
+    static final XmlParser<Project> XML = XmlParser.xmlParser( Project.class );
+
+    public static void main( String... args ) throws Exception
+    {
+        if ( args == null || args.length < 1 )
+        {
+            String path = pathOf( Main.class );
+            if ( new File( path ).isFile() && path.endsWith( ".jar" ) )
+            {
+                System.err.printf( "USAGE: java -jar %s Project <project.xml> ...%n", path );
+            }
+            else
+            {
+                System.err.printf( "USAGE: java -cp %s %s Project <project.xml> ...%n", path, Main.class.getName() );
+            }
+            System.exit( 1 );
+        }
+        else
+        {
+            Path xml = Path.of( args[0] );
+            if ( !Files.isRegularFile( xml ) )
+            {
+                System.err.println( "No such file: " + args[0] );
+                System.exit( 1 );
+            }
+            Map<String,String> options = new HashMap<>();
+            for ( int i = 1; i < args.length; i++ )
+            {
+                int eq = args[i].indexOf( '=' );
+                if ( eq < 0 )
+                {
+                    options.put( args[i], null );
+                }
+                else
+                {
+                    options.put( args[i].substring( 0, eq ), args[i].substring( eq + 1 ) );
+                }
+            }
+            XML.parse( xml ).execute( xml.getParent(), options );
+        }
+    }
+
+    private final List<Source> sources = new ArrayList<>();
+    private final List<Target> targets = new ArrayList<>();
+
+    @Child
+    void input( Source input )
+    {
+        sources.add( input );
+    }
+
+    @Child
+    void output( Target output )
+    {
+        targets.add( output );
+    }
+
+    void execute( Path workingDir, Map<String,String> options ) throws Exception
+    {
+        // TODO: use 'options' to inject config/parameters into the structure parsed from the XML
+        for ( Task task : work( grammars() ) )
+        {
+            task.execute( workingDir );
+        }
+    }
+
+    private Map<String,Grammar> grammars() throws ParserConfigurationException, SAXException, IOException
+    {
+        Map<String,Grammar.Unresolved> resolution = new HashMap<>();
+        Grammar.Unresolved[] prestage = new Grammar.Unresolved[sources.size()];
+        for ( int i = 0; i < prestage.length; i++ )
+        {
+            Source source = sources.get( i );
+            resolution.put( source.id, prestage[i] = Grammar.Unresolved.parseXML( source.path ) );
+        }
+        Map<String,Grammar> grammars = new HashMap<>();
+        for ( int i = 0; i < prestage.length; i++ )
+        {
+            Source source = sources.get( i );
+            grammars.put( source.id, prestage[i].resolve( source.resolver( resolution ) ) );
+        }
+        return grammars;
+    }
+
+    private Task[] work( Map<String,Grammar> grammars )
+    {
+        Task[] work = new Task[targets.size()];
+        Map<String,Map<Tool,List<Task>>> tasks = new HashMap<>();
+        for ( int i = 0; i < work.length; i++ )
+        {
+            Target target = targets.get( i );
+            Grammar grammar = grammars.get( target.grammar );
+            if ( grammar == null )
+            {
+                throw new IllegalArgumentException( "No such grammar: " + target.grammar );
+            }
+            tasks.computeIfAbsent( target.grammar, key -> new EnumMap<>( Tool.class ) )
+                    .computeIfAbsent( target.tool, key -> new ArrayList<>() )
+                    .add( work[i] = new Task( grammar, target.tool, target.path, target.options, tasks ) );
+        }
+        return work;
+    }
+
+    @Element( uri = Project.NAMESPACE, name = "grammar" )
+    static class Source
+    {
+        @Attribute
+        String id;
+        @Attribute
+        XmlFile path;
+        final List<ReferenceFormat> references = new ArrayList<>();
+        final Set<String> flags = new HashSet<>();
+
+        @Child( {WG3ReferenceFormat.class} )
+        void reference( ReferenceFormat reference )
+        {
+            references.add( reference );
+        }
+
+        @Child
+        void flag( Flag flag )
+        {
+            flags.add( flag.name );
+        }
+
+        Grammar.Resolver resolver( Map<String,Grammar.Unresolved> grammars )
+        {
+            Grammar.Resolver[] resolvers = new Grammar.Resolver[references.size()];
+            for ( int i = 0; i < resolvers.length; i++ )
+            {
+                resolvers[i] = references.get( i ).resolver( grammars );
+            }
+            return Grammar.Resolver.combine( resolvers );
+        }
+    }
+
+    @Element( uri = Project.NAMESPACE, name = "output" )
+    static class Target
+    {
+        @Attribute
+        Tool tool;
+        @Attribute
+        String grammar;
+        @Attribute
+        Path path;
+        final Map<String,Object> options = new HashMap<>();
+
+        @Child
+        void option( Option option )
+        {
+            tool.addOption( options, option.key, option.value );
+        }
+    }
+
+    @Element( uri = Conditional.XML_NAMESPACE, name = "flag" )
+    static class Flag
+    {
+        @Attribute
+        String name;
+    }
+
+    @Element( uri = Project.NAMESPACE, name = "option" )
+    static class Option
+    {
+        @Attribute
+        String key;
+        @Attribute
+        String value;
+    }
+
+    static abstract class ReferenceFormat
+    {
+        abstract Grammar.Resolver resolver( Map<String,Grammar.Unresolved> grammars );
+    }
+
+    @Element( uri = Project.NAMESPACE, name = "WG3Reference" )
+    static class WG3ReferenceFormat extends ReferenceFormat
+    {
+        @Attribute( optional = true )
+        String standard, part;
+        @Attribute
+        String resolves;
+
+        @Override
+        Grammar.Resolver.WG3 resolver( Map<String,Grammar.Unresolved> grammars )
+        {
+            Grammar.Unresolved grammar = grammars.get( resolves );
+            if ( grammar == null )
+            {
+                throw new IllegalArgumentException( "Undefined grammar: " + resolves );
+            }
+            return ( standard, part, nonTerminal ) ->
+                    Objects.equals( WG3ReferenceFormat.this.standard, standard ) && Objects.equals( WG3ReferenceFormat.this.part, part )
+                    ? grammar.production( nonTerminal ) : null;
+        }
+    }
+
+    enum Tool
+    {
+        RAIL_ROAD_DIAGRAM_PAGES( RailRoadDiagramPages.class ) // <pre>
+        {// </pre>
+
+            @Override
+            void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception
+            {
+                options.put( reKey( "outputDir" ), path );
+                RailRoadDiagramPages.generate( grammar, workingDir, log( options ), options );
+            }
+        },
+        WG3BNF( SQLBNF.class ) // <pre>
+        {// </pre>
+
+            @Override
+            void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception
+            {
+                write( grammar, workingDir, SQLBNF::write, path );
+            }
+        },
+        ISO14977( org.opencypher.tools.grammar.ISO14977.class ) // <pre>
+        {// </pre>
+
+            @Override
+            void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception
+            {
+                write( grammar, workingDir, org.opencypher.tools.grammar.ISO14977::write, path );
+            }
+        },
+        ANTLR4( Antlr4.class ) // <pre>
+        {// </pre>
+
+            @Override
+            void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception
+            {
+                write( grammar, workingDir, Antlr4::write, path );
+            }
+        },
+        PARSE_TREES( ParseTrees.class ) // <pre>
+        {// </pre>
+
+            @Override
+            void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception
+            {
+                options.put( reKey( "outputDir" ), path );
+                new ParseTrees( workingDir, options ).generate( grammar, log( options ) );
+            }
+        };
+
+        private final String keyPrefix;
+
+        Tool( Class<?> tool )
+        {
+            this.keyPrefix = tool.getSimpleName();
+        }
+
+        void addOption( Map<String,Object> options, String key, String value )
+        {
+            options.put( key, value );
+        }
+
+        abstract void execute( Grammar grammar, Path workingDir, Path path, Map<String,Object> options ) throws Exception;
+
+        String reKey( String key )
+        {
+            return keyPrefix + "." + key;
+        }
+
+        Path path( Map<String,Object> options, String key )
+        {
+            Object path = options.get( reKey( key ) );
+            if ( path instanceof String )
+            {
+                path = Path.of( (String) path );
+            }
+            return (Path) path;
+        }
+
+        Output log( Map<String,Object> options )
+        {
+            Object log = options.get( reKey( "log" ) );
+            if ( log instanceof String )
+            {
+                log = Output.output( Path.of( (String) log ) );
+            }
+            else if ( log == null )
+            {
+                log = Output.stdOut();
+            }
+            return (Output) log;
+        }
+
+        void write( Grammar grammar, Path workingDir, Executor tool, Path path ) throws IOException
+        {
+            try ( OutputStream out = Files.newOutputStream( path ) )
+            {
+                tool.execute( grammar, workingDir, out );
+            }
+        }
+
+        private interface Executor
+        {
+            void execute( Grammar grammar, Path workingDir, OutputStream out );
+        }
+    }
+
+    private static class Task
+    {
+        private final Grammar grammar;
+        private final Tool tool;
+        private final Path path;
+        private final Map<String,Object> options = new HashMap<>();
+        private final Map<String,Map<Tool,List<Task>>> tasks;
+
+        Task( Grammar grammar, Tool tool, Path path, Map<String,Object> options, Map<String,Map<Tool,List<Task>>> tasks )
+        {
+            this.grammar = grammar;
+            this.tool = tool;
+            this.path = path;
+            this.tasks = tasks;
+            for ( Map.Entry<String,Object> option : options.entrySet() )
+            {
+                this.options.put( tool.reKey( option.getKey() ), option.getValue() );
+            }
+        }
+
+        void execute( Path workingDir )
+        {
+            try
+            {
+                tool.execute( grammar, workingDir, path, options );
+            }
+            catch ( Exception e )
+            {
+                System.err.printf( "Failed to execute %s on %s.%n", tool.name(), grammar.language() );
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/RailRoadDiagramPages.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/RailRoadDiagramPages.java
@@ -73,6 +73,20 @@ public final class RailRoadDiagramPages extends Tool implements ShapeRenderer.Li
 {
     interface Options extends Diagram.BuilderOptions
     {
+        /**
+         * Specified in {@linkplain Project project xml files} as:
+         * <code><pre>
+         * &lt;output tool="RAIL_ROAD_DIAGRAM_PAGES" grammar="..." path="..."&gt;
+         *   &lt;option key="productionDetailsLink" value="!!! VALUE GOES HERE !!!"/&gt;
+         * &lt;/output&gt;
+         * </pre></code>
+         * <p>
+         * For links into one of the SQL or GQL standard PDFs, this option value should be something like:
+         * <code>value="path/to/some-file.pdf#''BNF_{0}''"</code>.
+         * Where the double single quotes (<code>''</code>) is an escaped single quote (the string formatting logic
+         * needs this to be escaped), and the <code>{0}</code> is a placeholder for where the name of the non-terminal
+         * will be inserted.
+         */
         default ProductionDetailsLinker productionDetailsLink()
         {
             return null;

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/RailRoadDiagrams.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/RailRoadDiagrams.java
@@ -54,9 +54,9 @@ public final class RailRoadDiagrams extends Tool implements ShapeRenderer.Linker
         main( RailRoadDiagrams::new, RailRoadDiagrams::generate, args );
     }
 
-    private RailRoadDiagrams( Map<?, ?> properties )
+    private RailRoadDiagrams( Path workingDir, Map<?, ?> properties )
     {
-        super( properties );
+        super( workingDir, properties );
     }
 
     private void generate( Grammar grammar, Output output ) throws XMLStreamException, IOException
@@ -90,7 +90,8 @@ public final class RailRoadDiagrams extends Tool implements ShapeRenderer.Linker
     static Diagram.CanvasProvider<SVGShapes, XMLStreamException> canvas( Output log, Path dir )
     {
         return svgFile( name -> {
-            Path file = dir.resolve( name + ".svg" ).toAbsolutePath();
+            String filename = name.replace( '/', ' ' );
+            Path file = dir.resolve( filename + ".svg" ).toAbsolutePath();
             log.format( "Writing Railroad diagram for %s to %s%n", name, file );
             return output( file );
         } );

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Recursive.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Recursive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Recursive.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Recursive.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.grammar;
+
+import org.opencypher.grammar.Alternatives;
+import org.opencypher.grammar.CharacterSet;
+import org.opencypher.grammar.Grammar;
+import org.opencypher.grammar.Literal;
+import org.opencypher.grammar.NonTerminal;
+import org.opencypher.grammar.Optional;
+import org.opencypher.grammar.Production;
+import org.opencypher.grammar.Repetition;
+import org.opencypher.grammar.Sequence;
+import org.opencypher.grammar.TermTransformation;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+class Recursive
+{
+    static List<Recursive> findLeftRecursive( Grammar grammar )
+    {
+        List<Recursive> result = new ArrayList<>();
+        grammar.accept( production ->
+        {
+            Builder builder = new Builder( true, production );
+            production.definition().transform( builder, true );
+            builder.addTo( result );
+        } );
+        return result;
+    }
+
+    final Production production;
+    private final List<Trace> recursions;
+
+    private Recursive( Production production, List<Trace> recursions )
+    {
+        this.production = production;
+        this.recursions = recursions;
+    }
+
+    public void accept( TraceVisitor visitor )
+    {
+        for ( Trace trace : recursions )
+        {
+            visitor.trace( production, trace.left, trace.trace );
+        }
+    }
+
+    interface TraceVisitor
+    {
+        void trace( Production production, boolean left, Production[] trace );
+    }
+
+    private static class Trace
+    {
+        private final boolean left;
+        private final Production[] trace;
+
+        Trace( boolean left, Production[] trace )
+        {
+            this.left = left;
+            this.trace = trace;
+        }
+    }
+
+    private static class Builder implements TermTransformation<Boolean,Boolean,RuntimeException>
+    {
+        Builder( boolean leftOnly, Production root )
+        {
+            this( leftOnly, new Trail( null, root ), root, new ArrayList<>(), new HashSet<>() );
+        }
+
+        private final boolean leftOnly;
+        private final Production root;
+        private final Trail trail;
+        private final List<Trace> recursions;
+        private final Set<String> seen;
+
+        private Builder( boolean leftOnly, Trail trail, Production root, List<Trace> recursions, Set<String> seen )
+        {
+            this.leftOnly = leftOnly;
+            this.trail = trail;
+            this.root = root;
+            this.recursions = recursions;
+            this.seen = seen;
+        }
+
+        void addTo( List<Recursive> result )
+        {
+            if ( !recursions.isEmpty() )
+            {
+                result.add( new Recursive( root, recursions ) );
+            }
+        }
+
+        private void traverse( Production production, Boolean first )
+        {
+            production.definition().transform( new Builder( leftOnly, new Trail( trail, production ), root, recursions, seen ), first );
+        }
+
+        @Override
+        public Boolean transformNonTerminal( Boolean first, NonTerminal nonTerminal )
+        {
+            if ( Objects.equals( root.name(), nonTerminal.productionName() ) )
+            {
+                recursions.add( trail.build( first ) );
+            }
+            else if ( /*seen.add( nonTerminal.productionName() ) ||*/ !trail.contains( nonTerminal.production() ) )
+            {
+                traverse( nonTerminal.production(), first );
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean transformAlternatives( Boolean first, Alternatives alternatives )
+        {
+            boolean stillFirst = first;
+            for ( Grammar.Term term : alternatives )
+            {
+                boolean possiblyEmpty = term.transform( this, first );
+                stillFirst |= possiblyEmpty;
+            }
+            return stillFirst;
+        }
+
+        @Override
+        public Boolean transformSequence( Boolean first, Sequence sequence )
+        {
+            for ( Grammar.Term term : sequence )
+            {
+                first = term.transform( this, first );
+                if ( leftOnly && !first )
+                {
+                    return false;
+                }
+            }
+            return first;
+        }
+
+        @Override
+        public Boolean transformOptional( Boolean first, Optional optional )
+        {
+            return first;
+        }
+
+        @Override
+        public Boolean transformRepetition( Boolean first, Repetition repetition )
+        {
+            return first && repetition.minTimes() == 0;
+        }
+
+        @Override
+        public Boolean transformEpsilon( Boolean first )
+        {
+            return first;
+        }
+
+        @Override
+        public Boolean transformLiteral( Boolean first, Literal literal )
+        {
+            return false;
+        }
+
+        @Override
+        public Boolean transformCharacters( Boolean first, CharacterSet characters )
+        {
+            return false;
+        }
+    }
+
+    private static class Trail
+    {
+        private final Trail trail;
+        private final Production production;
+
+        Trail( Trail trail, Production production )
+        {
+            this.trail = trail;
+            this.production = production;
+        }
+
+        boolean contains( Production production )
+        {
+            return this.production == production || (trail != null && trail.contains( production ));
+        }
+
+        Trace build( boolean left )
+        {
+            Production[] result = new Production[size()];
+            populate( result, result.length - 1 );
+            return new Trace( left, result );
+        }
+
+        private int size()
+        {
+            return trail == null ? 1 : trail.size() + 1;
+        }
+
+        private void populate( Production[] result, int pos )
+        {
+            result[pos] = production;
+            if ( trail != null )
+            {
+                trail.populate( result, pos - 1 );
+            }
+        }
+    }
+}

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/SQLBNF.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/SQLBNF.java
@@ -32,11 +32,8 @@ import static org.opencypher.tools.io.Output.output;
 
 import java.io.OutputStream;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,7 +91,6 @@ public class SQLBNF extends BnfWriter
         }
     }
 
-    
     public static void main( String... args ) throws Exception
     {
         Main.execute( SQLBNF::write, args );
@@ -117,18 +113,6 @@ public class SQLBNF extends BnfWriter
         {
             new SQLBNF.Html( code, linker ).visitProduction( production );
         }
-    }
-
-    public interface HtmlLinker
-    {
-        String referenceLink( NonTerminal reference );
-
-        default String charsetLink( CharacterSet charset )
-        {
-            return charsetLink( CharacterSet.Unicode.toSetString( charset ) );
-        }
-
-        String charsetLink( String charset );
     }
 
     /*
@@ -164,7 +148,7 @@ public class SQLBNF extends BnfWriter
 
         Html( HtmlTag html, HtmlLinker linker )
         {
-            super( html.output() );
+            super( html.textOutput() );
             this.html = html;
             this.linker = linker;
         }

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/SQLBNF.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/SQLBNF.java
@@ -32,6 +32,7 @@ import static org.opencypher.tools.io.Output.output;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -72,6 +73,11 @@ public class SQLBNF extends BnfWriter
         write( grammar, output( stream ) );
     }
 
+    public static void write( Grammar grammar, Path path, OutputStream stream )
+    {
+        write( grammar, stream );
+    }
+
     public static void write( Grammar grammar, Output output )
     {
         String header = grammar.header();
@@ -93,7 +99,7 @@ public class SQLBNF extends BnfWriter
 
     public static void main( String... args ) throws Exception
     {
-        Main.execute( SQLBNF::write, args );
+        Main.execute( ( grammar, workingDir, stream ) -> write( grammar, stream ), args );
     }
 
     public static void append( Grammar.Term term, Output output )

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Tool.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Tool.java
@@ -68,9 +68,11 @@ abstract class Tool implements Function<Method, Object>
     private static final Method FX_FONT_METHOD;
     private final String prefix;
     private final Map<?, ?> properties;
+    private final Path workingDir;
 
-    Tool( Map<?, ?> properties )
+    Tool( Path workingDir, Map<?, ?> properties )
     {
+        this.workingDir = workingDir;
         this.prefix = getClass().getSimpleName() + ".";
         this.properties = properties;
     }
@@ -91,7 +93,7 @@ abstract class Tool implements Function<Method, Object>
 
     interface Constructor<T> extends Serializable
     {
-        T create( Map<?, ?> properties );
+        T create( Path workingDir, Map<?, ?> properties );
     }
 
     interface Entry<T>
@@ -105,9 +107,9 @@ abstract class Tool implements Function<Method, Object>
         execute( new Main()
         {
             @Override
-            public void write( Grammar grammar, OutputStream out ) throws Exception
+            public void write( Grammar grammar, Path workingDir, OutputStream out ) throws Exception
             {
-                entry.invoke( constructor.create( System.getProperties() ), grammar, Output.output( out ) );
+                entry.invoke( constructor.create( workingDir, System.getProperties() ), grammar, Output.output( out ) );
             }
 
             @Override
@@ -208,6 +210,8 @@ abstract class Tool implements Function<Method, Object>
                 return parseBoolean( param );
             case "java.awt.Font":
                 return awtFont( key, param );
+            case "java.nio.file.Path":
+                return path( param );
             case FX_FONT:
                 return fxFont( key, param );
             default:
@@ -231,6 +235,11 @@ abstract class Tool implements Function<Method, Object>
     protected <T> T transform( Class<T> type, String value )
     {
         return null;
+    }
+
+    private Path path( String path )
+    {
+        return workingDir.resolve( path );
     }
 
     private java.awt.Font awtFont( Method method, String font )

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Tool.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Tool.java
@@ -210,6 +210,8 @@ abstract class Tool implements Function<Method, Object>
                 return awtFont( key, param );
             case FX_FONT:
                 return fxFont( key, param );
+            default:
+                return transform( type, param );
             }
         }
         else if ( value == null )
@@ -223,6 +225,11 @@ abstract class Tool implements Function<Method, Object>
                 return fxFont( key, lookup( name + ".family" ) );
             }
         }
+        return null;
+    }
+
+    protected <T> T transform( Class<T> type, String value )
+    {
         return null;
     }
 

--- a/tools/grammar/src/main/java/org/opencypher/tools/grammar/Xml.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/grammar/Xml.java
@@ -72,7 +72,7 @@ public class Xml extends XmlGenerator implements ProductionVisitor<SAXException>
 
     public static void main( String... args ) throws Exception
     {
-        Main.execute( Xml::write, args );
+        Main.execute( ( grammar1, workingDir, stream ) -> write( grammar1, stream ), args );
     }
 
     private final Grammar grammar;

--- a/tools/grammar/src/main/java/org/opencypher/tools/io/HtmlTag.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/io/HtmlTag.java
@@ -278,9 +278,24 @@ public final class HtmlTag implements AutoCloseable
      *
      * @return the underlying {@link Output}
      */
-    public Output output()
+    public Output textOutput()
     {
-        return output;
+        return new Output()
+        {
+            @Override
+            public Output append( char x )
+            {
+                if ( x == '<' )
+                {
+                    output.append( "&lt;" );
+                }
+                else
+                {
+                    output.append( x );
+                }
+                return this;
+            }
+        };
     }
 
     public static final class HeadTag

--- a/tools/grammar/src/main/java/org/opencypher/tools/io/HtmlTag.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/io/HtmlTag.java
@@ -42,13 +42,12 @@ import java.nio.file.Path;
  *             .{@link #text(String) text}("Welcome to My Page") // adds text content to the tag
  *             .{@link #close() close}();                   // closes the &lt;/h1&gt; tag
  *         body.{@link #text(String) text}("This is a very neat page.");
- *         body.{@link #p() p}();
+ *         body.{@link #p(String) p}("It contains some text!");
  *         body.{@link #text(String) text}("You should come back when there is more content.");
  *         body.{@link #br() br}();
  *         body.{@link #text(String) text}("Until then, here is a picture of a cat for you to look at:");
  *         // img tags should not be closed, so we simply don't invoke the {@link #close close()} method.
  *         body.{@link #tag(String, Attribute[]) tag}("img", {@link HtmlTag}.{@link HtmlTag#attr attr}("src", "http://thecatapi.com/api/images/get?format=src&amp;type=gif") );
- *         body.{@link #p() p}();
  *         body.{@link #textTag textTag}("b", "To do:");
  *         try ( {@link HtmlTag} list = body.{@link #tag(String, Attribute[]) tag}("ul") ) {
  *             list.{@link #textTag textTag}("li", "Find cuter cat")
@@ -114,9 +113,11 @@ public final class HtmlTag implements AutoCloseable
         return textTag( "a", text, attr( "href", href ) );
     }
 
-    public void p()
+    public void p( String text )
     {
-        output.println( "<p>" );
+        output.append( "<p>" );
+        text( text );
+        output.append( "</p>" );
     }
 
     public void br()

--- a/tools/grammar/src/main/java/org/opencypher/tools/io/Output.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/io/Output.java
@@ -27,6 +27,7 @@
  */
 package org.opencypher.tools.io;
 
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -299,6 +300,15 @@ public interface Output extends Appendable, Closeable
         return result.toString();
     }
 
+    default Output repeat( int cp, int times )
+    {
+        for ( int i = 0; i < times; i++ )
+        {
+            appendCodePoint( cp );
+        }
+        return this;
+    }
+
     /**
      * An extension of {@link Output} that signals that what was written can be read back.
      */
@@ -353,6 +363,23 @@ public interface Output extends Appendable, Closeable
         {
             return new CharSequenceReader( this, 0, length() );
         }
+
+        default void lines( BiConsumer<String,Integer> lineHandler )
+        {
+            BufferedReader reader = new BufferedReader( reader() );
+            try
+            {
+                String line;
+                for ( int no = 1; null != (line = reader.readLine()); no++ )
+                {
+                    lineHandler.accept( line, no );
+                }
+            }
+            catch ( IOException e )
+            {
+                throw new IllegalStateException( "Should not throw exception when reading from Readable.", e );
+            }
+        }
     }
 
     /**
@@ -361,7 +388,7 @@ public interface Output extends Appendable, Closeable
      * The replacement function can (and is recommended to) be a <i>partial function</i>, only returning replacements
      * for the code points that are to be escaped and returning {@code null} for other code points.
      *
-     * @param str         the character sequence to escape the contents of.
+     * @param str the character sequence to escape the contents of.
      * @param replacement the replacement function that defines how to escape the code points that need escaping.
      * @return this {@code Output} instance to allow invocation chaining.
      */
@@ -376,9 +403,9 @@ public interface Output extends Appendable, Closeable
      * The replacement function can (and is recommended to) be a <i>partial function</i>, only returning replacements
      * for the code points that are to be escaped and returning {@code null} for other code points.
      *
-     * @param str         the character sequence to escape the contents of.
-     * @param start       the position in the given character sequence to start at.
-     * @param end         the position in the given character sequence to end at.
+     * @param str the character sequence to escape the contents of.
+     * @param start the position in the given character sequence to start at.
+     * @param end the position in the given character sequence to end at.
      * @param replacement the replacement function that defines how to escape the code points that need escaping.
      * @return this {@code Output} instance to allow invocation chaining.
      */

--- a/tools/grammar/src/main/java/org/opencypher/tools/xml/ParserStateMachine.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/xml/ParserStateMachine.java
@@ -130,6 +130,10 @@ class ParserStateMachine extends DefaultHandler2
         if ( uri.isEmpty() )
         {
             uri = prefixToUri.get( "" );
+            if ( uri == null )
+            {
+                uri = "";
+            }
         }
         if ( !node.builder.attribute( required, node.value, resolver, uri, name, type, value ) )
         {
@@ -201,8 +205,7 @@ class ParserStateMachine extends DefaultHandler2
             Object value = child.create( this.value );
             if ( value instanceof LocationAware )
             {
-                ((LocationAware) value).location(
-                        locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber() );
+                ((LocationAware) value).location( locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber() );
             }
             return new Node( this, child, value );
         }
@@ -258,6 +261,10 @@ class ParserStateMachine extends DefaultHandler2
                 {
                     builder.header( value, comment );
                 }
+            }
+            if ( value instanceof LocationAware )
+            {
+                ((LocationAware) value).location( locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber()  );
             }
             return new RootNode( builder, value );
         }

--- a/tools/grammar/src/main/java/org/opencypher/tools/xml/ParserStateMachine.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/xml/ParserStateMachine.java
@@ -242,16 +242,25 @@ class ParserStateMachine extends DefaultHandler2
         @Override
         Node child( String uri, String name, Locator locator ) throws SAXException
         {
-            if ( !builder.uri.equalsIgnoreCase( uri ) || !builder.name.equalsIgnoreCase( name ) )
+            NodeBuilder root;
+            if ( builder.name == null )
+            {
+                root = builder.child( uri, name );
+            }
+            else
+            {
+                root = builder;
+            }
+            if ( !root.uri.equalsIgnoreCase( uri ) || !root.name.equalsIgnoreCase( name ) )
             {
                 throw new SAXException(
-                        "Root element must be '" + builder.name + "' in namespace '" + builder.uri +
+                        "Root element must be '" + root.name + "' in namespace '" + root.uri +
                         "', but was '" + name + "' in namespace '" + uri + "'" );
             }
-            Object value = builder.create( null );
+            Object value = root.create( null );
             if ( headers instanceof char[] )
             {
-                builder.header( value, (char[]) headers );
+                root.header( value, (char[]) headers );
             }
             else if ( headers instanceof List<?> )
             {
@@ -259,14 +268,14 @@ class ParserStateMachine extends DefaultHandler2
                 List<char[]> comments = (List<char[]>) headers;
                 for ( char[] comment : comments )
                 {
-                    builder.header( value, comment );
+                    root.header( value, comment );
                 }
             }
             if ( value instanceof LocationAware )
             {
                 ((LocationAware) value).location( locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber()  );
             }
-            return new RootNode( builder, value );
+            return new RootNode( root, value );
         }
 
         @Override

--- a/tools/grammar/src/main/java/org/opencypher/tools/xml/Resolver.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/xml/Resolver.java
@@ -98,6 +98,7 @@ abstract class Resolver
     static void initialize( Initializer init )
     {
         init.add( Resolver::file );
+        init.add( Resolver::path );
     }
 
     interface Initializer

--- a/tools/grammar/src/main/java/org/opencypher/tools/xml/Structure.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/xml/Structure.java
@@ -213,11 +213,12 @@ class Structure
                     }
                     else if ( constructor.getParameterCount() == 1 )
                     {
-                        for ( Class<?> base = constructor.getParameterTypes()[0];
-                              base != Object.class; base = base.getSuperclass() )
-                        {
-                            constructors.putIfAbsent( base, constructor );
-                        }
+                        constructors.put( constructor.getParameterTypes()[0], constructor );
+//                        for ( Class<?> base = constructor.getParameterTypes()[0];
+//                              base != Object.class; base = base.getSuperclass() )
+//                        {
+//                            constructors.putIfAbsent( base, constructor );
+//                        }
                     }
                 }
             }

--- a/tools/grammar/src/main/java/org/opencypher/tools/xml/XmlParser.java
+++ b/tools/grammar/src/main/java/org/opencypher/tools/xml/XmlParser.java
@@ -68,6 +68,17 @@ public final class XmlParser<Root>
         return new XmlParser<>( root, NodeBuilder.tree( root ) );
     }
 
+    @SafeVarargs
+    public static <T> XmlParser<T> combine( Class<T> base, XmlParser<? extends T>... parsers )
+    {
+        NodeBuilder[] rootBuilders = new NodeBuilder[parsers.length];
+        for ( int i = 0; i < parsers.length; i++ )
+        {
+            rootBuilders[i] = parsers[i].builder;
+        }
+        return new XmlParser<>( base, NodeBuilder.choice( rootBuilders ) );
+    }
+
     /**
      * Parse the XML document at the given path.
      *
@@ -154,7 +165,7 @@ public final class XmlParser<Root>
             throws ParserConfigurationException, SAXException, IOException
     {
         ParserStateMachine stateMachine = new ParserStateMachine( resolver, builder, options );
-        SAXParser parser = saxParser();
+        SAXParser parser = saxParser( true );
         parser.setProperty( LEXICAL_HANDLER, stateMachine ); // handle XML comments as well
         parser.parse( input, stateMachine );
         return root.cast( stateMachine.produceRoot() );
@@ -177,10 +188,15 @@ public final class XmlParser<Root>
         return String.format( "XmlParser{%s as %s}", builder, root );
     }
 
-    static SAXParser saxParser() throws ParserConfigurationException, SAXException
+    static SAXParser saxParser( boolean validateDTD ) throws ParserConfigurationException, SAXException
     {
         SAXParserFactory sax = SAXParserFactory.newInstance();
         sax.setNamespaceAware( true );
+        if ( !validateDTD )
+        {
+            sax.setValidating( false );
+            sax.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false );
+        }
         return sax.newSAXParser();
     }
 }

--- a/tools/grammar/src/main/resources/explore-backlinks.css
+++ b/tools/grammar/src/main/resources/explore-backlinks.css
@@ -1,0 +1,22 @@
+ul.backlinks
+{
+    list-style: none
+}
+
+ul.backlinks > li.unexplored::before
+{
+    content: '⊞';
+    color: black;
+    display: inline-block;
+    width: 1em;
+    margin-left: -1em
+}
+
+ul.backlinks > li::before
+{
+    content: "⊟";
+    color: black;
+    display: inline-block;
+    width: 1em;
+    margin-left: -1em
+}

--- a/tools/grammar/src/main/resources/explore-backlinks.js
+++ b/tools/grammar/src/main/resources/explore-backlinks.js
@@ -1,0 +1,45 @@
+window.onload=function(){
+    var elements = document.getElementsByClassName("backlink");
+    for (let i = 0; i < elements.length; i++) {
+        var item = elements[i];
+        item.onclick = openBacklink;
+        item.className += ' unexplored';
+        var refName = item.getAttribute('backlink');
+        var def = backlinks[refName];
+        if (def) {
+            var a = item.firstChild;
+            a.setAttribute('title', def.bnf);
+        }
+    }
+};
+
+function openBacklink(e) {
+    e.stopImmediatePropagation();
+    var item = e.srcElement || e.target;
+
+    var list = item.lastChild;
+    if (list.tagName === 'UL') {
+        if (list.style.display === 'none') {
+            item.className = '';
+            list.style.display = '';
+        } else {
+            item.className = 'unexplored';
+            list.style.display = 'none';
+        }
+    } else {
+        item.className = '';
+        console.log("new list!", list.tagName, list);
+        var refName = item.getAttribute('backlink');
+        var def = backlinks[refName];
+        if (def) {
+            var refs = def.references;
+            var items = "";
+            for (let i = 0; i < refs.length; i++) {
+                var ref = refs[i];
+                var refDef = backlinks[ref];
+                items += '<li class="unexplored" onclick="openBacklink" backlink="' + ref + '"><a href="' + refDef.link + '" title="' + refDef.bnf + '">' + ref + '</a></li>';
+            }
+            item.innerHTML += '<ul class="backlinks">' + items + '</ul>';
+        }
+    }
+}

--- a/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4Test.java
+++ b/tools/grammar/src/test/java/org/opencypher/tools/grammar/Antlr4Test.java
@@ -119,7 +119,7 @@ public class Antlr4Test
                 "oC_bar",
                 "   :  LITER@L ;",
                 "",
-                "LITER@L : ( 'L' | 'l' ) ( 'I' | 'i' ) ( 'T' | 't' ) ( 'E' | 'e' ) ( 'R' | 'r' ) ( '@' | '@' ) ( 'L' | 'l' )  ;",
+                "LITER@L : ( 'L' | 'l' ) ( 'I' | 'i' ) ( 'T' | 't' ) ( 'E' | 'e' ) ( 'R' | 'r' ) '@' ( 'L' | 'l' ) ;",
                 "" );
     }
 

--- a/tools/grammar/src/test/resources/cypher-error.txt
+++ b/tools/grammar/src/test/resources/cypher-error.txt
@@ -4,16 +4,16 @@ MATCH ()§
 OPTIONAL MATCH ()§
 START n = node(1)§
 WITH 1 AS a§
-UNWIND [] AS foo§
+UNWIND [] AS flags§
 LOAD CSV from $url AS list§
 //
 // invalid combinations of clauses
 RETURN 1 RETURN 2§
 RETURN 1 MATCH ()§
-RETURN 1 WITH 2 AS foo§
+RETURN 1 WITH 2 AS flags§
 CREATE () MATCH () RETURN 1§
-CREATE () UNWIND [] AS foo RETURN 1§
-MERGE () UNWIND [] AS foo RETURN 1§
+CREATE () UNWIND [] AS flags RETURN 1§
+MERGE () UNWIND [] AS flags RETURN 1§
 //
 // Miscellaneous errors
 //
@@ -23,7 +23,7 @@ CALL db.labels() YIELD -§
 CALL db.labels() YIELD -
 RETURN count(label) AS numLabels§
 CALL db.labels() YIELD -
-WHERE label CONTAINS 'User' AND foo + bar = foo
+WHERE label CONTAINS 'User' AND flags + bar = flags
 RETURN count(label) AS numLabels§
 RETURN +--+--++4§
 RETURN ----+-+-1§

--- a/tools/grammar/src/test/resources/cypher-legacy.txt
+++ b/tools/grammar/src/test/resources/cypher-legacy.txt
@@ -79,4 +79,4 @@ CYPHER 2.3 START n = node  (6, 7, 8) RETURN n§
 USING PERIODIC COMMIT 500
 LOAD CSV FROM 'http://neo4j.com/docs/3.1.0/csv/artists.csv' AS line
 CREATE (:Artist { name: line[1], year: toInt(line[2])})§
-RETURN "foo" =~ "regex"§
+RETURN "flags" =~ "regex"§


### PR DESCRIPTION
This adds the ability to read and process WG3 grammar files.
It also adds the ability to work with grammar "projects", which allows defining a set of inputs (that can relate to one another) and a set of outputs derived from those inputs. The "projects" notion should be able to replace scripts that run multiple tools over grammars to generate a set of outputs.
There is also a feature where a grammar can be defined as a patch on top of another grammar. This is useful when working on a proposed change in order to be able to test the whole new grammar in total while keeping a neat record of the changes made.

I will say that the state of this work is not my finest. It is a bit "work in progress". In particular it is lacking in testing, documentation and could do with quite a bit of refactoring to simplify things. But it does work, and it does not break things that have worked before.