### PR TITLE
Fix type conversion scenarios

### DIFF
--- a/tck/features/expressions/typeConversion/TypeConversion1.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion1.feature
@@ -82,18 +82,24 @@ Feature: TypeConversion1 - To Boolean
       | null |
     And no side effects
 
-  Scenario Outline: [5] `toBoolean()` on invalid types #Example: <exampleName>
-    Given any graph
+  Scenario Outline: [5] Fail `toBoolean()` on invalid types #Example: <exampleName>
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ()-[:T]->()
+      """
     When executing query:
       """
-      WITH [true, <invalid>] AS list
-      RETURN toBoolean(list[1]) AS b
+      MATCH p = (n)-[r:T]->()
+      RETURN [x IN [true, <invalid>] | toInteger(x) ] AS list
       """
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid | exampleName |
-      | []      | list        |
-      | {}      | map         |
-      | 1       | integer     |
-      | 1.0     | float       |
+      | invalid | exampleName  |
+      | []      | list         |
+      | {}      | map          |
+      | 1.0     | float        |
+      | n       | node         |
+      | r       | relationship |
+      | p       | path         |

--- a/tck/features/expressions/typeConversion/TypeConversion1.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion1.feature
@@ -91,7 +91,7 @@ Feature: TypeConversion1 - To Boolean
     When executing query:
       """
       MATCH p = (n)-[r:T]->()
-      RETURN [x IN [true, <invalid>] | toInteger(x) ] AS list
+      RETURN [x IN [true, <invalid>] | toBoolean(x) ] AS list
       """
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 

--- a/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -136,7 +136,6 @@ Feature: TypeConversion2 - To Integer
 
     Examples:
       | invalid | exampleName  |
-      | true    | boolean      |
       | []      | list         |
       | {}      | map          |
       | n       | node         |

--- a/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -121,7 +121,7 @@ Feature: TypeConversion2 - To Integer
       | 42   |
     And no side effects
 
-  Scenario Outline: [8] `toInteger()` failing on invalid arguments
+  Scenario Outline: [8] Fail `toInteger()` on invalid types #Example: <exampleName>
     Given an empty graph
     And having executed:
       """
@@ -135,10 +135,10 @@ Feature: TypeConversion2 - To Integer
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid |
-      | true    |
-      | []      |
-      | {}      |
-      | n       |
-      | r       |
-      | p       |
+      | invalid | exampleName  |
+      | true    | boolean      |
+      | []      | list         |
+      | {}      | map          |
+      | n       | node         |
+      | r       | relationship |
+      | p       | path         |

--- a/tck/features/expressions/typeConversion/TypeConversion3.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion3.feature
@@ -96,7 +96,7 @@ Feature: TypeConversion3 - To Float
       | 4.0   |
     And no side effects
 
-  Scenario Outline: [6] `toFloat()` failing on invalid arguments
+  Scenario Outline: [6] Fail `toFloat()` on invalid types #Example: <exampleName>
     Given an empty graph
     And having executed:
       """
@@ -110,10 +110,10 @@ Feature: TypeConversion3 - To Float
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid |
-      | true    |
-      | []      |
-      | {}      |
-      | n       |
-      | r       |
-      | p       |
+      | invalid | exampleName  |
+      | true    | boolean      |
+      | []      | list         |
+      | {}      | map          |
+      | n       | node         |
+      | r       | relationship |
+      | p       | path         |

--- a/tck/features/expressions/typeConversion/TypeConversion4.feature
+++ b/tck/features/expressions/typeConversion/TypeConversion4.feature
@@ -148,7 +148,7 @@ Feature: TypeConversion4 - To String
       | 'x'      |
     And no side effects
 
-  Scenario Outline: [10] `toString()` failing on invalid arguments
+  Scenario Outline: [10] Fail `toString()` on invalid types #Example: <exampleName>
     Given an empty graph
     And having executed:
       """
@@ -162,9 +162,9 @@ Feature: TypeConversion4 - To String
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid |
-      | []      |
-      | {}      |
-      | n       |
-      | r       |
-      | p       |
+      | invalid | exampleName  |
+      | []      | list         |
+      | {}      | map          |
+      | n       | node         |
+      | r       | relationship |
+      | p       | path         |


### PR DESCRIPTION
This PR make minor improvement to type conversion function scenarios. The change is twofold:

1. It removes test on "invalid" argument type, which actually reasonable to accept
2. It harmonizes name and style of the invalid argument type scenarios across all four features