### PR TITLE
Improve list access type checking scenarios

### DIFF
--- a/tck/features/expressions/list/List1.feature
+++ b/tck/features/expressions/list/List1.feature
@@ -97,47 +97,74 @@ Feature: List1 - Dynamic Element Access
       | 'Apa' |
     And no side effects
 
-  Scenario: [6] Fail at runtime when attempting to index with a String into a List
-    Given any graph
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | 'name'  |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx]
-      """
-    Then a TypeError should be raised at runtime: ListElementAccessByNonInteger
-
-  Scenario: [7] Fail at runtime when trying to index into a list with a list
-    Given any graph
-    And parameters are:
-      | expr | ['Apa'] |
-      | idx  | ['Apa'] |
-    When executing query:
-      """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx]
-      """
-    Then a TypeError should be raised at compile time: ListElementAccessByNonInteger
-
-  Scenario: [8] Fail at compile time when attempting to index with a non-integer into a list
+  Scenario Outline: [6] Fail when indexing a non-list #Example: <exampleName>
     Given any graph
     When executing query:
       """
-      WITH [1, 2, 3, 4, 5] AS list, 3.14 AS idx
+      WITH <expr> AS list, 0 AS idx
       RETURN list[idx]
       """
-    Then a SyntaxError should be raised at compile time: ListElementAccessByNonInteger
+    Then an TypeError should be raised at any time: InvalidArgumentType
 
-  Scenario: [9] Fail at runtime when trying to index something which is not a list
+    Examples:
+      | expr   | exampleName  |
+      | true   | boolean      |
+      | 123    | integer      |
+      | 4.7    | float        |
+      | '1'    | string       |
+
+  Scenario Outline: [7] Fail when indexing a non-list given by a parameter #Example: <exampleName>
     Given any graph
     And parameters are:
-      | expr | 100 |
-      | idx  | 0   |
+      | expr | <expr> |
+      | idx  | 0      |
     When executing query:
       """
-      WITH $expr AS expr, $idx AS idx
-      RETURN expr[idx]
+      WITH $expr AS list, $idx AS idx
+      RETURN list[idx]
       """
-    Then a TypeError should be raised at runtime: InvalidArgumentType
+    Then an TypeError should be raised at any time: *
+
+    Examples:
+      | expr   | exampleName  |
+      | true   | boolean      |
+      | 123    | integer      |
+      | 4.7    | float        |
+      | '1'    | string       |
+
+  Scenario Outline: [8] Fail when indexing with a non-integer #Example: <exampleName>
+    Given any graph
+    When executing query:
+      """
+      WITH [1, 2, 3, 4, 5] AS list, <idx> AS idx
+      RETURN list[idx]
+      """
+    Then an TypeError should be raised at any time: *
+
+    Examples:
+      | idx    | exampleName  |
+      | true   | boolean      |
+      | 4.7    | float        |
+      | '1'    | string       |
+      | [1]    | list         |
+      | {x: 3} | map          |
+
+  Scenario Outline: [9] Fail when indexing with a non-integer given by a parameter #Example: <exampleName>
+    Given any graph
+    And parameters are:
+      | expr | ['Apa'] |
+      | idx  | <idx>   |
+    When executing query:
+      """
+      WITH $expr AS list, $idx AS idx
+      RETURN list[idx]
+      """
+    Then a TypeError should be raised at any time: *
+
+    Examples:
+      | idx    | exampleName  |
+      | true   | boolean      |
+      | 4.7    | float        |
+      | '1'    | string       |
+      | [1]    | list         |
+      | {x: 3} | map          |

--- a/tck/features/expressions/list/List1.feature
+++ b/tck/features/expressions/list/List1.feature
@@ -104,7 +104,7 @@ Feature: List1 - Dynamic Element Access
       WITH <expr> AS list, 0 AS idx
       RETURN list[idx]
       """
-    Then an TypeError should be raised at any time: InvalidArgumentType
+    Then a TypeError should be raised at any time: InvalidArgumentType
 
     Examples:
       | expr   | exampleName  |
@@ -123,7 +123,7 @@ Feature: List1 - Dynamic Element Access
       WITH $expr AS list, $idx AS idx
       RETURN list[idx]
       """
-    Then an TypeError should be raised at any time: *
+    Then a TypeError should be raised at any time: *
 
     Examples:
       | expr   | exampleName  |
@@ -139,7 +139,7 @@ Feature: List1 - Dynamic Element Access
       WITH [1, 2, 3, 4, 5] AS list, <idx> AS idx
       RETURN list[idx]
       """
-    Then an TypeError should be raised at any time: *
+    Then a TypeError should be raised at any time: *
 
     Examples:
       | idx    | exampleName  |

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateSteps.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateSteps.scala
@@ -37,6 +37,7 @@ import org.opencypher.tools.tck.api.InitQuery
 import org.opencypher.tools.tck.api.SideEffects
 import org.opencypher.tools.tck.api.Step
 import org.opencypher.tools.tck.constants.TCKErrorDetails
+import org.opencypher.tools.tck.constants.TCKErrorPhases
 import org.opencypher.tools.tck.constants.TCKErrorTypes
 import org.scalatest.AppendedClues
 import org.scalatest.Assertion
@@ -127,7 +128,7 @@ trait ValidateSteps extends AppendedClues with Matchers with OptionValues with V
           TCKErrorTypes.ALL should contain(ee.errorType)
         }
         withClue(s"${ee.description} has valid phase") {
-          Set("runtime", "compile time") should contain(ee.phase)
+          TCKErrorPhases.ALL should contain(ee.phase)
         }
         withClue(s"${ee.description} has valid detail") {
           TCKErrorDetails.ALL should contain(ee.detail)


### PR DESCRIPTION
This PR harmonizes scenarios in feature `List1` that check for invalid types in a list element access and relaxes the error details of this scenarios.

In passing this PR also fixes a bug in the step validation of the `TckScenarioFormatCheck` w.r.t. error detail wildcards.