### PR TITLE
Fix a bug in UnaryAddSubtractExpression

### DIFF
--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -240,8 +240,10 @@
   </production>
 
   <production name="UnaryAddOrSubtractExpression" rr:inline="true">
-    <repeat><alt>+ -</alt> &WS; </repeat>
-    <non-terminal ref="StringListNullOperatorExpression"/>
+    <alt>
+      <non-terminal ref="StringListNullOperatorExpression"/>
+      <seq><alt>+ -</alt> &WS; <non-terminal ref="StringListNullOperatorExpression"/></seq>
+    </alt>
   </production>
 
   <production name="StringListNullOperatorExpression" rr:inline="true">

--- a/tools/grammar/src/test/resources/cypher-error.txt
+++ b/tools/grammar/src/test/resources/cypher-error.txt
@@ -25,3 +25,8 @@ RETURN count(label) AS numLabels§
 CALL db.labels() YIELD -
 WHERE label CONTAINS 'User' AND foo + bar = foo
 RETURN count(label) AS numLabels§
+RETURN +--+--++4§
+RETURN ----+-+-1§
+RETURN ----+-+-1.0§
+RETURN -   -    + 1 - +2§
+RETURN -   -    + 1 - +2.0§

--- a/tools/grammar/src/test/resources/cypher.txt
+++ b/tools/grammar/src/test/resources/cypher.txt
@@ -32,12 +32,10 @@ RETURN r§
 MATCH ()-[r:ACTED_IN*  ..  ]-()
 RETURN r§
 RETURN -1§
-RETURN ----+-+-1§
-RETURN -   -    + 1 - +2§
+RETURN 1 - 1 + +2§
 RETURN 1-+2§
 RETURN -1.0§
-RETURN ----+-+-1.0§
-RETURN -   -    + 1 - +2.0§
+RETURN 3 + 1 - +2.0§
 RETURN 0xd34db33f§
 RETURN 0777§
 RETURN 1e10§


### PR DESCRIPTION
The bug allowed arbitrarily many occurrences of `+` or `-` operators.
Only a single operator is allowed as part of this expression.
Since a literal expression also allows a preceding `-` character (for
a negative number literal), `--1` for example is also allowed.