### PR TITLE
Restructure Scala Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,13 +115,7 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-scala_${scala.binary.version}</artifactId>
-        <version>${dep.cucumber.version}</version>
-      </dependency>
-
-      <dependency>
+       <dependency>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-junit</artifactId>
         <version>${dep.cucumber.version}</version>
@@ -152,19 +146,6 @@
         <artifactId>xmlgraphics-commons</artifactId>
         <version>${dep.xmlgraphics-commons.version}</version>
         <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>${dep.scalatest.version}</version>
-        <!--scope>test</scope--> <!-- tck-api uses scalatest in compile scope-->
-        <exclusions>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -203,30 +184,6 @@
         <artifactId>hamcrest</artifactId>
         <version>${dep.hamcrest.version}</version>
         <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.lihaoyi</groupId>
-        <artifactId>fastparse_${scala.binary.version}</artifactId>
-        <version>${dep.fastparse.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.lihaoyi</groupId>
-        <artifactId>cask_${scala.binary.version}</artifactId>
-        <version>${dep.cask.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.lihaoyi</groupId>
-        <artifactId>scalatags_${scala.binary.version}</artifactId>
-        <version>${dep.scalatags.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.scala-lang.modules</groupId>
-        <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
-        <version>${dep.scala.compat.version}</version>
       </dependency>
 
     </dependencies>
@@ -420,7 +377,6 @@
     <profile>
       <id>scala-212</id>
       <properties>
-        <dep.cask.version>0.2.9</dep.cask.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.13</scala.version>
       </properties>
@@ -428,7 +384,6 @@
     <profile>
       <id>scala-213</id>
       <properties>
-        <dep.cask.version>0.7.12</dep.cask.version>
         <scala.binary.version>2.13</scala.binary.version>
         <scala.version>2.13.7</scala.version>
       </properties>

--- a/tools/tck-api/pom.xml
+++ b/tools/tck-api/pom.xml
@@ -76,11 +76,13 @@
     <dependency>
       <groupId>com.lihaoyi</groupId>
       <artifactId>fastparse_${scala.binary.version}</artifactId>
+      <version>${dep.fastparse.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+      <version>${dep.scala.compat.version}</version>
     </dependency>
 
     <dependency>
@@ -97,8 +99,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <version>${dep.scalatest.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+          </exclusion>
+        </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/tools/tck-compatibility-tests/tck-compatibility-tests-util/pom.xml
+++ b/tools/tck-compatibility-tests/tck-compatibility-tests-util/pom.xml
@@ -92,6 +92,13 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${dep.scalatest.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -83,11 +83,13 @@
         <dependency>
             <groupId>com.lihaoyi</groupId>
             <artifactId>cask_${scala.binary.version}</artifactId>
+            <version>${dep.cask.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.lihaoyi</groupId>
             <artifactId>scalatags_${scala.binary.version}</artifactId>
+            <version>${dep.scalatags.version}</version>
         </dependency>
 
         <!-- Test deps -->
@@ -101,6 +103,13 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${dep.scalatest.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 
@@ -111,5 +120,20 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>scala-212</id>
+            <properties>
+                <dep.cask.version>0.2.9</dep.cask.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-213</id>
+            <properties>
+                <dep.cask.version>0.7.12</dep.cask.version>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/tools/tck-integrity-tests/pom.xml
+++ b/tools/tck-integrity-tests/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-scala_${scala.binary.version}</artifactId>
+            <version>${dep.cucumber.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -111,6 +112,13 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>${dep.scalatest.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 

--- a/tools/tck-reporting/pom.xml
+++ b/tools/tck-reporting/pom.xml
@@ -45,13 +45,6 @@
         </dependency>
 
         <dependency>
-            <!-- dependency of tck-api listed here for intellij to get the scala version right -->
-            <groupId>com.lihaoyi</groupId>
-            <artifactId>fastparse_${scala.binary.version}</artifactId>
-            <version>${dep.fastparse.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>

--- a/tools/tck-reporting/pom.xml
+++ b/tools/tck-reporting/pom.xml
@@ -10,7 +10,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tck-reporting</artifactId>
+    <artifactId>tck-reporting_${scala.binary.version}</artifactId>
     <name>openCypher TCK Reporting</name>
     <url>http://opencypher.org</url>
     <description>Generate cucumber.json and use Cucumber plugins with openCypher TCK API</description>
@@ -27,6 +27,15 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.spurint.maven.plugins</groupId>
+                <artifactId>scala-cross-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
For the 2.13 cross build to work the Scala dependencies cannot be in the top level .pom as this will not work in a dependency hierarchy unless everything has a Scala version. To fix, move all the Scala dependencies under the scala modules so that the non-Scala modules can stay as they are. tck-reporting has direct Scala dependencies so no choice there.