### PR TITLE
Fix dependencies after M18 for Intellij

### DIFF
--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -76,8 +76,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+            <version>${dep.scala.compat.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>fastparse_${scala.binary.version}</artifactId>
+            <version>${dep.fastparse.version}</version>
         </dependency>
 
         <dependency>

--- a/tools/tck-integrity-tests/pom.xml
+++ b/tools/tck-integrity-tests/pom.xml
@@ -82,6 +82,22 @@
         </dependency>
 
         <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>fastparse_${scala.binary.version}</artifactId>
+            <version>${dep.fastparse.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>org.opencypher</groupId>
+            <artifactId>tck</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.opencypher</groupId>
             <artifactId>grammar</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Intellij has trouble identify dependencies of dependencies for runtime.

This PR adds these dependencies to the pom.