### PR TITLE
Syntactic coverage

### DIFF
--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>tck-api_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.opencypher</groupId>
+            <artifactId>grammar</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.scala-lang.modules</groupId>

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/coverage/SyntacticCoverage.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/coverage/SyntacticCoverage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 "Neo Technology,"
+ * Copyright (c) 2015-2022 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/coverage/SyntacticCoverage.scala
+++ b/tools/tck-inspection/src/main/scala/org/opencypher/tools/tck/inspection/coverage/SyntacticCoverage.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015-2021 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.inspection.coverage
+
+import org.antlr.v4.Tool
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.InterpreterRuleContext
+import org.antlr.v4.runtime.ParserInterpreter
+import org.antlr.v4.runtime.tree.ParseTree
+import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.v4.tool.Grammar
+import org.opencypher.tools.grammar.Antlr4
+import org.opencypher.tools.tck.api.CypherTCK
+import org.opencypher.tools.tck.api.ExecQuery
+import org.opencypher.tools.tck.api.Execute
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Paths
+
+object SyntacticCoverage {
+  private val RULES_PREFIX = "oC_"
+  private val GRAMMAR_SOURCE = "/cypher.xml"
+
+  private val oCGrammar = {
+    val url = this.getClass.getResource(GRAMMAR_SOURCE)
+    org.opencypher.grammar.Grammar.parseXML(Paths.get(url.toURI))
+  }
+  private val grammar: Grammar = {
+    val grammarString = {
+      val out = new ByteArrayOutputStream
+      Antlr4.write(oCGrammar, out)
+      out.toString(UTF_8.name)
+    }
+    val tool = new Tool()
+    val ast = tool.parseGrammarFromString(grammarString)
+    val grammar = tool.createGrammar(ast)
+    tool.process(grammar, false)
+    //println(grammar.getRuleNames.map(name => s"$name\t${grammar.getRule(name).numberOfAlts}").mkString(System.lineSeparator()))
+    grammar
+  }
+
+  def main(args: Array[String]): Unit = {
+    val scenarios = CypherTCK.allTckScenariosFromFilesystem("tck/features")
+    val queries = scenarios.flatMap(_.steps.collect {
+      case Execute(query, ExecQuery, _) => query
+    })
+    val (ruleUse, ruleUseDistinctByScenario) = collectRulesFromQueries(queries)
+    val ruleCoverage: Map[Int, Seq[Int]] = ruleUse.groupBy(i => i)
+    val scenarioDistinctRuleCoverage: Map[Int, Seq[Int]] = ruleUseDistinctByScenario.groupBy(i => i)
+
+    val rulesNames = grammar.getRuleNames.map(_.substring(RULES_PREFIX.length))
+    val rulesNamesMaxLength = rulesNames.map(_.length).max
+    val lines = rulesNames.indices.map(i =>
+      s"${rulesNames(i)}${" "*(rulesNamesMaxLength - rulesNames(i).length)}" +
+      f"${ruleCoverage.get(i).map(_.size).getOrElse(0)}%7d" +
+      f"${scenarioDistinctRuleCoverage.get(i).map(_.size).getOrElse(0)}%7d"
+    )
+    println(lines.mkString(System.lineSeparator()))
+  }
+
+  def collectRulesFromQueries(queries: Seq[String]): (Seq[Int], Seq[Int]) = {
+    val trees = queries.map(query => Option(initParser(query).parse(grammar.getRule("oC_Cypher" ).index)))
+    (trees.flatMap(t => collectRulesFromParseTree(t)), trees.flatMap(t => collectRulesFromParseTree(t).toSet))
+  }
+
+  def collectRulesFromParseTree(tree: Option[ParseTree]): Seq[Int] = tree match {
+    case None => List[Int]()
+    case Some(tree) =>
+      tree.getPayload match {
+        case payload: InterpreterRuleContext =>
+          val children = (0 until tree.getChildCount).map(i => Option(tree.getChild(i)))
+          val childRules = children.flatMap(child => collectRulesFromParseTree(child))
+          val (rules, terminals) = children.foldLeft((List[InterpreterRuleContext](), List[TerminalNode]())){
+            case (p, Some(child: InterpreterRuleContext)) => (child :: p._1, p._2)
+            case (p, Some(child: TerminalNode)) => (p._1, child :: p._2)
+            case (p, _) => p
+          }
+          val (numRules, numTerminals) = (rules.size, terminals.size)
+          val isToCount = {
+            if(numTerminals > 0) {
+              true
+            } else {
+              val rule = grammar.getRule(payload.getRuleIndex)
+              if(rule.name.endsWith("Expression") && numRules < 2 && rule.numberOfAlts < 2) {
+                false
+              } else {
+                true
+              }
+            }
+          }
+          if(isToCount)
+            payload.getRuleIndex +: childRules
+          else
+            childRules
+        case _ => List[Int]()
+      }
+  }
+
+  def initParser(query: String): ParserInterpreter = {
+    val lexer = grammar.createLexerInterpreter(CharStreams.fromString(query))
+    val parser = grammar.createParserInterpreter(new CommonTokenStream(lexer))
+    lexer.removeErrorListeners()
+    parser.removeErrorListeners()
+    parser
+  }
+}


### PR DESCRIPTION
Build on PR #520.

This PR add a little tool that does some syntax coverage analysis of the TCK scenarios.

The current output is:

```
Cypher                             3752   3752
Statement                          3752   3752
Query                              3752   3752
RegularQuery                       3743   3735
Union                                16     12
SingleQuery                        3759   3735
SinglePartQuery                    3757   3733
MultiPartQuery                      972    972
UpdatingClause                     1353    318
ReadingClause                      1984   1493
Match                              1534   1268
Unwind                              414    216
Merge                               105     81
MergeAction                          28     25
Create                             1107    117
Set                                  88     85
SetItem                              90     85
Delete                               48     48
Remove                               33     33
RemoveItem                           35     33
InQueryCall                          36     35
StandaloneCall                       17     17
YieldItems                           34     33
YieldItem                            50     33
With                               1646    972
Return                             3633   3610
ProjectionBody                     5279   3624
ProjectionItems                    5278   3623
ProjectionItem                     7274   3616
Order                               341    338
Skip                                 46     46
Limit                               276    276
SortItem                            536    338
Where                              1239    831
Pattern                            2646   1367
PatternPart                        3302   1395
AnonymousPatternPart               3302   1395
PatternElement                     3302   1395
NodePattern                        6059   1403
PatternElementChain                2689    753
RelationshipPattern                2689    753
RelationshipDetail                 2525    657
Properties                          756    152
RelationshipTypes                  1862    290
NodeLabels                         1516    425
NodeLabel                          1561    425
RangeLiteral                        154    145
LabelName                          1561    425
RelTypeName                        1872    290
Expression                            0      0
OrExpression                        123     60
XorExpression                        87     32
AndExpression                       123     60
NotExpression                       181    153
ComparisonExpression               1417    689
AddOrSubtractExpression             393    227
MultiplyDivideModuloExpression      275    156
PowerOfExpression                     1      1
UnaryAddOrSubtractExpression        165    139
StringListNullOperatorExpression    404    338
ListOperatorExpression              167    137
StringOperatorExpression             32     29
NullOperatorExpression              210    172
PropertyOrLabelsExpression         1321    735
Atom                              32341   3679
Literal                           19445   2925
BooleanLiteral                     1022    263
ListLiteral                        1861    976
PartialComparisonExpression        1428    689
ParenthesizedExpression             294    179
RelationshipsPattern                 68     64
FilterExpression                    998    617
IdInColl                           1040    659
FunctionInvocation                 3254   1578
FunctionName                       3254   1578
ExistentialSubquery                  13     10
ExplicitProcedureInvocation          48     47
ImplicitProcedureInvocation           5      5
ProcedureResultField                 21     13
ProcedureName                        53     52
Namespace                          3307   1629
ListComprehension                   283    137
PatternComprehension                 16     16
PropertyLookup                     1383    754
CaseExpression                      251     75
CaseAlternative                     311     75
Variable                          18547   3501
NumberLiteral                     11144   2185
MapLiteral                         2767   1197
Parameter                            89     61
PropertyExpression                   79     73
PropertyKeyName                    8970   1727
IntegerLiteral                    10428   2100
DoubleLiteral                       811    264
SchemaName                        12403   1978
ReservedWord                         25     21
SymbolicName                      34904   3624
LeftArrowHead                       607    100
RightArrowHead                     1612    489
Dash                               5378    753
```

In the grammar rules for expressions are “drop-through”, so that even a literal causes all expression non-terminals to show up in the parse tree. With regards to coverage that is obviously not very informative. Hence, the numbers above do not count rules with they

- end with “Expression”,
- have less the 2 rule children in the parse tree,
- have 0 terminal children in the parse tree, and
- have less than 2 alternative and in the grammar.

With that the expression numbers look much more informative.

The difference between the columns is as follows:

- The first column counts all instances of a rule (non terminal) in the parse trees. 
- The second column counts all instances of a rule only once per `When executing query` step. For instance, `RETURN 123, 456`, would have `NumberLiteral     2   1`. I do not know of any scenario having more than one `When executing query` step, so you can think of the second column as the number of scenarios where the tested query has at least one instance of the respective rules.

I am still somewhat puzzled about where being practically no syntax which is not covered by a scenario query. However, potential reason are:

- Syntax is used in some scenarios, which actually test something else, e.g. mathematical operations are likely to have counts for this reason.
- A feature does not have special syntax, e.g. it is exposed through a built-in functions or are special combination of otherwise normal syntax.

However, this is coverage of syntax — not of semantics.