### PR TITLE
Speed up integrity tests

### DIFF
--- a/tools/tck-inspection/pom.xml
+++ b/tools/tck-inspection/pom.xml
@@ -76,8 +76,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+            <version>${dep.scala.compat.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>fastparse_${scala.binary.version}</artifactId>
+            <version>${dep.fastparse.version}</version>
         </dependency>
 
         <dependency>

--- a/tools/tck-integrity-tests/pom.xml
+++ b/tools/tck-integrity-tests/pom.xml
@@ -82,6 +82,22 @@
         </dependency>
 
         <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>com.lihaoyi</groupId>
+            <artifactId>fastparse_${scala.binary.version}</artifactId>
+            <version>${dep.fastparse.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- For intellij to get runtime dependencies right -->
+            <groupId>org.opencypher</groupId>
+            <artifactId>tck</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.opencypher</groupId>
             <artifactId>grammar</artifactId>
             <version>${project.version}</version>

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ScenarioFormatChecker.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ScenarioFormatChecker.scala
@@ -35,16 +35,12 @@ import org.opencypher.tools.tck.api.groups.Tag
 import org.opencypher.tools.tck.api.groups.TckTree
 import org.opencypher.tools.tck.api.groups.Total
 import org.scalatest.OptionValues
-import org.scalatest.ParallelTestExecution
-import org.scalatest.funspec.AsyncFunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.Future
-
-trait ScenarioFormatChecker extends AsyncFunSpec with Matchers with OptionValues with ValidateScenario with ParallelTestExecution {
+trait ScenarioFormatChecker extends AnyFunSpec with Matchers with OptionValues with ValidateScenario {
 
   def create(scenarios: Seq[Scenario]): Unit = {
-
     implicit val tck: TckTree = TckTree(scenarios)
 
     def spawnTests(currentGroup: Group): Unit = {
@@ -58,9 +54,7 @@ trait ScenarioFormatChecker extends AsyncFunSpec with Matchers with OptionValues
           }
         case i: Item =>
           it(i.description) {
-            Future {
-              validateScenario(i.scenario)
-            }
+            validateScenario(i.scenario)
           }
         case _ => ()
       }

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateQuery.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateQuery.scala
@@ -43,8 +43,8 @@ import scala.util.Success
 import scala.util.Try
 
 trait ValidateQuery extends AppendedClues with Matchers with DescribeStepHelper {
-  private val parsedCache = new scala.collection.concurrent.TrieMap[String, Try[Unit]]()
-  private val normalizedCached = new scala.collection.concurrent.TrieMap[String, Boolean]()
+  private val parsedCache = new scala.collection.mutable.HashMap[String, Try[Unit]]()
+  private val normalizedCached = new scala.collection.mutable.HashMap[String, Boolean]()
 
   def validateQuery(execute: Execute, tags: Set[String] = Set.empty[String]): Assertion = {
     val query = execute.query

--- a/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
+++ b/tools/tck-integrity-tests/src/test/scala/org/opencypher/tools/tck/ValidateScenario.scala
@@ -37,7 +37,7 @@ import org.scalatest.matchers.should.Matchers
 
 trait ValidateScenario extends AppendedClues with Matchers with OptionValues with ValidateSteps {
 
-  private val scenarioNamesByFeature = scala.collection.concurrent.TrieMap[(List[String], String), List[(String, Option[Int])]]()
+  private val scenarioNamesByFeature = scala.collection.mutable.HashMap[(List[String], String), List[(String, Option[Int])]]()
 
   def validateScenario(scenario: Scenario): Assertion = {
     withClue("scenario has a number, greater than zero") {


### PR DESCRIPTION
This builds on PR #520.

The `TckScenarioFormatCheck` was set up to run tests in parallel, which however did not work. Unfortunately, it turned out that the parallel setup caused a massive amount of redundant execution. Looks like the check of every single scenario executed the ingestion of whole TCK, which makes scenario parsing quadratic in the number of scenarios — nothing promising with regards to execution speed. So that the `TckScenarioFormatCheck` end up needing over 20 minutes to check the TCK on a modern notebook computer.

Removing the parallel setup (a very simple code change) turned out to result in significantly faster execution of the `TckScenarioFormatCheck`. With this PR on the same computer, it checks the whole less than a minute.

Given that `TckScenarioFormatCheck` is part of every build run including testing, this is a very convenient and environmentally-friendly improvement.

