### PR TITLE
Some CypherLists that are equal do not have the same hashcode

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
@@ -27,8 +27,6 @@
  */
 package org.opencypher.tools.tck.values
 
-import scala.util.hashing.MurmurHash3
-
 object CypherValue {
   def apply(s: String, orderedLists: Boolean = true): CypherValue = {
     val parser = new CypherValueParser(orderedLists)
@@ -114,7 +112,9 @@ case class CypherOrderedList(elements: List[CypherValue] = List.empty) extends C
   override def equals(obj: scala.Any): Boolean = obj match {
     case null => false
     case other: CypherOrderedList => elements == other.elements
-    case o: CypherUnorderedList => o == this
+    case o: CypherUnorderedList =>
+      // Delegate to CypherUnorderedList.equals which will sort the lists before comparing
+      o == this
     case _ => false
   }
 

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/values/CypherValue.scala
@@ -118,7 +118,7 @@ case class CypherOrderedList(elements: List[CypherValue] = List.empty) extends C
     case _ => false
   }
 
-  override def hashCode(): Int = MurmurHash3.productHash(this)
+  override def hashCode(): Int = Hashing.productHash(this)
 }
 
 /**
@@ -138,7 +138,7 @@ private[tck] case class CypherUnorderedList(elements: List[CypherValue] = List.e
     case _ => false
   }
 
-  override def hashCode(): Int = MurmurHash3.productHash(this)
+  override def hashCode(): Int = Hashing.productHash(this)
 }
 
 case object CypherNull extends CypherValue {

--- a/tools/tck-api/src/main/scala_2.12/org/opencypher/tools/tck/values/Hashing.scala
+++ b/tools/tck-api/src/main/scala_2.12/org/opencypher/tools/tck/values/Hashing.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2022 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.values
+
+import scala.util.hashing.MurmurHash3
+
+object Hashing {
+
+  def productHash(p: Product) = MurmurHash3.productHash(p)
+
+}

--- a/tools/tck-api/src/main/scala_2.13/org/opencypher/tools/tck/values/Hashing.scala
+++ b/tools/tck-api/src/main/scala_2.13/org/opencypher/tools/tck/values/Hashing.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2022 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.values
+
+import scala.util.hashing.MurmurHash3
+
+object Hashing {
+
+  def productHash(p: Product) = MurmurHash3.productHash(p, MurmurHash3.productSeed, ignorePrefix = true)
+
+}

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/values/CypherValueTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/values/CypherValueTest.scala
@@ -90,6 +90,14 @@ class CypherValueTest extends AnyFunSuite with Matchers {
     uList1 should equal(uList2)
   }
 
+  test("lists that are equal should have the same hashCode") {
+    val oList = CypherOrderedList(List(CypherString("Foo")))
+    val uList = CypherUnorderedList(List(CypherString("Foo")))
+
+    oList should equal(uList)
+    oList.hashCode() should equal(uList.hashCode())
+  }
+
   test("list comparisons simple example") {
     val orderedItems1 = List(CypherString("name"), CypherString("age"), CypherString("address"))
     val orderedItems2 = List(CypherString("age"), CypherString("name"), CypherString("address"))


### PR DESCRIPTION
On Scala 2.13, MurMurHash3 has changed it's contract to include the prefix in the hash calculation by default. This means that a CypherOrderedList and a CypherUnorderedList with the same content can be equal, but have different hashcodes. This breaks the equals / hashcode contract and is responsible for a TCK failure in Neo4j.
Unfortunately, the mechanism for including or excluding the prefix does not exist in Scala 2.12, so to ensure we can still cross build I have to pull out Scala API version specific calls to MurMurHash3.