### PR TITLE
Update and add tests with implicit grouping keys

### DIFF
--- a/tck/features/clauses/match/Match4.feature
+++ b/tck/features/clauses/match/Match4.feature
@@ -98,7 +98,7 @@ Feature: Match4 - Match variable length patterns scenarios
       WITH *
       UNWIND range(1, 20) AS i
       CREATE (n {var: i})
-      WITH [a] + collect(n) + [b] AS nodeList
+      WITH a, b, [a] + collect(n) + [b] AS nodeList
       UNWIND range(0, size(nodeList) - 2, 1) AS i
       WITH nodeList[i] AS n1, nodeList[i+1] AS n2
       CREATE (n1)-[:T]->(n2)

--- a/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
@@ -42,10 +42,10 @@ Feature: ReturnOrderBy6 - Aggregation expressions in order by
       """
     Then the result should be, in any order:
       | avgAge |
-      | null |
+      | null   |
     And no side effects
 
-  Scenario: [2] Handle variables, which are also return items themselves, inside an order by item which contains an aggregation expression
+  Scenario: [2] Handle returned aliases inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -57,7 +57,7 @@ Feature: ReturnOrderBy6 - Aggregation expressions in order by
       | age | cnt |
     And no side effects
 
-  Scenario: [3] Handle property accesses, which are also return items themselves, inside an order by item which contains an aggregation expression
+  Scenario: [3] Handle returned property accesses inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -69,7 +69,7 @@ Feature: ReturnOrderBy6 - Aggregation expressions in order by
       | age | cnt |
     And no side effects
 
-  Scenario: [4] Throw if a variable is used inside an order by item which contains an aggregation expression
+  Scenario: [4] Fail if not returned variables are used inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -79,7 +79,7 @@ Feature: ReturnOrderBy6 - Aggregation expressions in order by
       """
     Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
 
-  Scenario: [5] Throw if more complex expression, even though it is also a return item on its own, is used inside an order by item which contains an aggregation expression
+  Scenario: [5] Fail if more complex expressions, even if returned, are used inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """

--- a/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
@@ -1,0 +1,90 @@
+#
+# Copyright (c) 2015-2022 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Attribution Notice under the terms of the Apache License 2.0
+#
+# This work was created by the collective efforts of the openCypher community.
+# Without limiting the terms of Section 6, any Derivative Work that is not
+# approved by the public consensus process of the openCypher Implementers Group
+# should not be described as “Cypher” (and Cypher® is a registered trademark of
+# Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+# proposals for change that have been documented or implemented should only be
+# described as "implementation extensions to Cypher" or as "proposed changes to
+# Cypher that are not yet approved by the openCypher community".
+#
+
+#encoding: utf-8
+
+Feature: ReturnOrderBy6 - Aggregation expressions in order by
+
+  Scenario: [1] Handle constants and parameters inside an order by item which contains an aggregation expression
+    Given an empty graph
+    And parameters are:
+      | age | 38 |
+    When executing query:
+      """
+      MATCH (person)
+      RETURN avg(person.age) AS avgAge
+      ORDER BY $age + avg(person.age) - 1000
+      """
+    Then the result should be, in any order:
+      | avgAge |
+      | null |
+    And no side effects
+
+  Scenario: [2] Handle variables, which are also return items themselves, inside an order by item which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age AS age, count(you.age) AS cnt
+      ORDER BY age, age + count(you.age)
+      """
+    Then the result should be, in any order:
+      | age | cnt |
+    And no side effects
+
+  Scenario: [3] Handle property accesses, which are also return items themselves, inside an order by item which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age AS age, count(you.age) AS cnt
+      ORDER BY me.age + count(you.age)
+      """
+    Then the result should be, in any order:
+      | age | cnt |
+    And no side effects
+
+  Scenario: [4] Throw if a variable is used inside an order by item which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN count(you.age) AS agg
+      ORDER BY me.age + count(you.age)
+      """
+    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+
+  Scenario: [5] Throw if more complex expression, even though it is also a return item on its own, is used inside an order by item which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age + you.age, count(*) AS cnt
+      ORDER BY me.age + you.age + count(*)
+      """
+    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression

--- a/tck/features/clauses/return/Return6.feature
+++ b/tck/features/clauses/return/Return6.feature
@@ -118,10 +118,10 @@ Feature: Return6 - Implicit grouping with aggregates
     When executing query:
       """
       MATCH (a {name: 'Andres'})<-[:FATHER]-(child)
-      RETURN {foo: a.name='Andres', kids: collect(child.name)}
+      RETURN a.name, {foo: a.name='Andres', kids: collect(child.name)}
       """
     Then the result should be, in any order:
-      | {foo: a.name='Andres', kids: collect(child.name)} |
+      | a.name | {foo: a.name='Andres', kids: collect(child.name)} |
     And no side effects
 
   Scenario: [7] Aggregate on property

--- a/tck/features/clauses/return/Return6.feature
+++ b/tck/features/clauses/return/Return6.feature
@@ -308,10 +308,10 @@ Feature: Return6 - Implicit grouping with aggregates
       """
     Then the result should be, in any order:
       | $age + avg(person.age) - 1000 |
-      | null |
+      | null                          |
     And no side effects
 
-  Scenario: [18] Handle variables, which are also return items themselves, inside an expression which contains an aggregation expression
+  Scenario: [18] Handle returned variables inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -323,7 +323,7 @@ Feature: Return6 - Implicit grouping with aggregates
       | age | age + count(you.age) |
     And no side effects
 
-  Scenario: [19] Handle property accesses, which are also return items themselves, inside an expression which contains an aggregation expression
+  Scenario: [19] Handle returned property accesses inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -334,7 +334,7 @@ Feature: Return6 - Implicit grouping with aggregates
       | me.age | me.age + count(you.age) |
     And no side effects
 
-  Scenario: [20] Throw if a variable is used inside an expression which contains an aggregation expression
+  Scenario: [20] Fail if not returned variables are used inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -343,7 +343,7 @@ Feature: Return6 - Implicit grouping with aggregates
       """
     Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
 
-  Scenario: [21] Throw if more complex expression, even though it is also a return item on its own, is used inside expression which contains an aggregation expression
+  Scenario: [21] Fail if more complex expressions, even if returned, are used inside expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """

--- a/tck/features/clauses/return/Return6.feature
+++ b/tck/features/clauses/return/Return6.feature
@@ -296,3 +296,58 @@ Feature: Return6 - Implicit grouping with aggregates
       | ({name: 'Michael'}) | ({name: 'Andres'}) | -7  |
       | ({name: 'Michael'}) | ({name: 'Peter'})  | 0   |
     And no side effects
+
+  Scenario: [17] Handle constants and parameters inside an expression which contains an aggregation expression
+    Given an empty graph
+    And parameters are:
+      | age | 38 |
+    When executing query:
+      """
+      MATCH (person)
+      RETURN $age + avg(person.age) - 1000
+      """
+    Then the result should be, in any order:
+      | $age + avg(person.age) - 1000 |
+      | null |
+    And no side effects
+
+  Scenario: [18] Handle variables, which are also return items themselves, inside an expression which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      WITH me.age AS age, you
+      RETURN age, age + count(you.age)
+      """
+    Then the result should be, in any order:
+      | age | age + count(you.age) |
+    And no side effects
+
+  Scenario: [19] Handle property accesses, which are also return items themselves, inside an expression which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age, me.age + count(you.age)
+      """
+    Then the result should be, in any order:
+      | me.age | me.age + count(you.age) |
+    And no side effects
+
+  Scenario: [20] Throw if a variable is used inside an expression which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age + count(you.age)
+      """
+    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+
+  Scenario: [21] Throw if more complex expression, even though it is also a return item on its own, is used inside expression which contains an aggregation expression
+    Given an empty graph
+    When executing query:
+      """
+      MATCH (me: Person)--(you: Person)
+      RETURN me.age + you.age, me.age + you.age + count(*)
+      """
+    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression

--- a/tck/features/clauses/with-orderBy/WithOrderBy4.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy4.feature
@@ -411,10 +411,10 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       """
     Then the result should be, in any order:
       | avgAge |
-      | null |
+      | null   |
     And no side effects
 
-  Scenario: [17] Handle variables, which are also return items themselves, inside an order by item which contains an aggregation expression
+  Scenario: [17] Handle projected variables inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -427,7 +427,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       | age |
     And no side effects
 
-  Scenario: [18] Handle property accesses, which are also return items themselves, inside an order by item which contains an aggregation expression
+  Scenario: [18]  Handle projected property accesses inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -440,7 +440,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       | age |
     And no side effects
 
-  Scenario: [19] Throw if a variable is used inside an order by item which contains an aggregation expression
+  Scenario: [19] Fail if not projected variables are used inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -451,7 +451,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       """
     Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
 
-  Scenario: [20] Throw if more complex expression, even though it is also a return item on its own, is used inside an order by item which contains an aggregation expression
+  Scenario: [20] Fail if more complex expressions, even if projected, are used inside an order by item which contains an aggregation expression
     Given an empty graph
     When executing query:
       """

--- a/tck/features/clauses/with/With6.feature
+++ b/tck/features/clauses/with/With6.feature
@@ -124,11 +124,11 @@ Feature: With6 - Implicit grouping with aggregates
       RETURN *
       """
     Then the result should be, in any order:
-      | agg |
+      | agg  |
       | null |
     And no side effects
 
-  Scenario: [6] Handle variables, which are also return items themselves, inside an expression which contains an aggregation expression
+  Scenario: [6] Handle projected variables inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -141,7 +141,7 @@ Feature: With6 - Implicit grouping with aggregates
       | age | agg |
     And no side effects
 
-  Scenario: [7] Handle property accesses, which are also return items themselves, inside an expression which contains an aggregation expression
+  Scenario: [7] Handle projected property accesses inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -153,7 +153,7 @@ Feature: With6 - Implicit grouping with aggregates
       | age | agg |
     And no side effects
 
-  Scenario: [8] Throw if a variable is used inside an expression which contains an aggregation expression
+  Scenario: [8] Fail if not projected variables are used inside an expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """
@@ -163,7 +163,7 @@ Feature: With6 - Implicit grouping with aggregates
       """
     Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
 
-  Scenario: [9] Throw if more complex expression, even though it is also a return item on its own, is used inside expression which contains an aggregation expression
+  Scenario: [9] Fail if more complex expression, even if projected, are used inside expression which contains an aggregation expression
     Given an empty graph
     When executing query:
       """

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKErrorTypes.scala
@@ -103,6 +103,7 @@ object TCKErrorDetails {
   val PROCEDURE_NOT_FOUND = "ProcedureNotFound"
   val UNEXPECTED_SYNTAX = "UnexpectedSyntax"
   val INTEGER_OVERFLOW = "IntegerOverflow"
+  val AMBIGUOUS_AGGREGATION_EXPRESSION = "AmbiguousAggregationExpression"
   // wildcard error detail
   val ANY = "*"
 
@@ -148,5 +149,6 @@ object TCKErrorDetails {
                 DELETED_ENTITY_ACCESS,
                 UNEXPECTED_SYNTAX,
                 INTEGER_OVERFLOW,
+                AMBIGUOUS_AGGREGATION_EXPRESSION,
                 ANY)
 }


### PR DESCRIPTION
Expressions in WITH/RETURN/ORDER BY should not use implicit grouping keys.

In a RETURN/WITH expression that contains an aggregation or in a sort item where there is an aggregation in the preceding WITH/RETURN clause, the leaves of the expression must be one of:
- An aggregation
- A literal
- A Parameter
- Element property access on a variable - ONLY IF that property access is also a projection expression on its own
- Non nested static map access on a variable - ONLY IF that map access is also a projection expression on its own
- A variable - ONLY IF that variable is also a projection expression on its own (e.g. the n in RETURN n AS myNode, n.value + count(*))