### PR TITLE
Update scenario to avoid illegally introducing variable in pattern predicate

### DIFF
--- a/tck/features/expressions/list/List6.feature
+++ b/tck/features/expressions/list/List6.feature
@@ -95,6 +95,7 @@ Feature: List6 - List size
     Given any graph
     When executing query:
       """
+      MATCH (a), (b), (c)
       RETURN size(<pattern>)
       """
     Then a SyntaxError should be raised at compile time: UnexpectedSyntax
@@ -106,9 +107,9 @@ Feature: List6 - List size
       | (a)-->()                                   |
       | (a)<--(a {})                               |
       | (a)-[:REL]->(b)                            |
-      | (a)-[r:REL]->(b)                           |
-      | (a)-[r:REL]->(:C)<-[s:REL]-(a {num: 5})    |
-      | ()-[r:REL*0..2]->()<-[s:REL]-(:A {num: 5}) |
+      | (a)-[:REL]->(b)                            |
+      | (a)-[:REL]->(:C)<-[:REL]-(a {num: 5})      |
+      | ()-[:REL*0..2]->()<-[:REL]-(:A {num: 5})   |
 
   Scenario: [7] Using size of pattern comprehension to test existence
     Given an empty graph


### PR DESCRIPTION
### Feature "List6 - List size", scenario "Fail for `size()` on pattern predicates"

Examples 1 to 7 use pattern predicates that introduce variables, which is forbidden (see below). https://github.com/opencypher/openCypher/blob/b0ea6c0de107cf0a9ff27d395adcb07d0baf492a/tck/features/expressions/pattern/Pattern1.feature#L197-L221

To avoid returning a `UndefinedVariable` (in adhearance with above scenario), I suggest we simply avoid introducing new variables in this scenario.