### PR TITLE
Chaining of non arithmetic operators

### DIFF
--- a/cip/1.accepted/CIP2021-08-10-Operator-precedence.adoc
+++ b/cip/1.accepted/CIP2021-08-10-Operator-precedence.adoc
@@ -124,13 +124,13 @@ The higher the level number the higher the precedence.
 * https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ExistentialSubquery[Existential subqueries]
 * https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ParenthesizedExpression[Parenthesized expression]
 
-.2+|Non-arithmetic operators
+.2+|https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=NonArithmeticOperatorExpression[Non-arithmetic operators]
 .2+|11
-|https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=PropertyOrLabelsExpression[Graph element operators]
+|Graph element operators
 |
 
-* property lookup
-* label expressions
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=PropertyLookup[property lookup] (left-hand operand)
+* https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=NodeLabels[label expressions] (only as last operator in chain)
 
 |https://raw.githack.com/openCypher/openCypher/master/tools/grammar-production-links/grammarLink.html?p=ListOperatorExpression[List operators] (left-hand operand)
 |

--- a/grammar/basic-grammar.xml
+++ b/grammar/basic-grammar.xml
@@ -297,25 +297,25 @@
 
   <production name="UnaryAddOrSubtractExpression" rr:inline="true">
     <alt>
-      <non-terminal ref="ListOperatorExpression"/>
-      <seq><alt>+ -</alt> &WS; <non-terminal ref="ListOperatorExpression"/></seq>
+      <non-terminal ref="NonArithmeticOperatorExpression"/>
+      <seq><alt>+ -</alt> &WS; <non-terminal ref="NonArithmeticOperatorExpression"/></seq>
     </alt>
   </production>
 
-  <production name="ListOperatorExpression" rr:inline="true">
-    <non-terminal ref="PropertyOrLabelsExpression"/>
+  <production name="NonArithmeticOperatorExpression" rr:inline="true">
+    <non-terminal ref="Atom"/>
     <repeat><alt>
-      <seq>&WS; [ &expr; ] </seq>
-      <seq>&WS; [ <opt>&expr;</opt> .. <opt>&expr;</opt> ] </seq>
+      <seq>&WS; <non-terminal ref="ListOperatorExpression"/></seq>
+      <seq>&WS; <non-terminal ref="PropertyLookup"/></seq>
     </alt></repeat>
+    <opt>&WS; <non-terminal ref="NodeLabels"/></opt>
   </production>
 
-  <production name="PropertyOrLabelsExpression" rr:inline="true">
-    <non-terminal ref="Atom"/>
-    <repeat>
-      &WS; <non-terminal ref="PropertyLookup"/>
-    </repeat>
-    <opt>&WS; <non-terminal ref="NodeLabels"/></opt>
+  <production name="ListOperatorExpression" rr:inline="true">
+    <alt>
+      <seq>[ &expr; ] </seq>
+      <seq>[ <opt>&expr;</opt> .. <opt>&expr;</opt> ] </seq>
+    </alt>
   </production>
 
   <production name="PropertyLookup">


### PR DESCRIPTION
**This PR is based on #541.**

This PR proposes changes to the openCypher grammar for allowing chaining of non-arithmetic operators as a reaction to issue #539. With the PR, the grammar allows for instance 

```
RETURN foo()[1]:F, foo().x.y[1][4].name:F
```

as valid syntax, which was not the case before.

The PR also adjusts [CIP2021-08-10 Operator precedence](https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2021-08-10-Operator-precedence.adoc) ([rendered view](https://github.com/hvub/openCypher/blob/chaining-of-non-arithmatic-operators/cip/1.accepted/CIP2021-08-10-Operator-precedence.adoc)) to the changed grammar.