### PR TITLE
Fix test assertions of labels function

### DIFF
--- a/tck/features/clauses/merge/Merge1.feature
+++ b/tck/features/clauses/merge/Merge1.feature
@@ -200,7 +200,7 @@ Feature: Merge1 - Merge node
       MERGE (test:L:B {num: 42})
       RETURN labels(test) AS labels
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels     |
       | ['L', 'B'] |
     And the side effects should be:

--- a/tck/features/clauses/merge/Merge2.feature
+++ b/tck/features/clauses/merge/Merge2.feature
@@ -38,7 +38,7 @@ Feature: Merge2 - Merge node - on create
         ON CREATE SET a:Foo
       RETURN labels(a)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(a)           |
       | ['TheLabel', 'Foo'] |
     And the side effects should be:

--- a/tck/features/clauses/merge/Merge3.feature
+++ b/tck/features/clauses/merge/Merge3.feature
@@ -57,7 +57,7 @@ Feature: Merge3 - Merge node - on match
         ON MATCH SET a:Foo
       RETURN labels(a)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(a)           |
       | ['TheLabel', 'Foo'] |
     And the side effects should be:

--- a/tck/features/clauses/set/Set3.feature
+++ b/tck/features/clauses/set/Set3.feature
@@ -132,7 +132,7 @@ Feature: Set3 - Set a Label
       SET n :Foo :Bar
       RETURN labels(n)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(n)      |
       | ['Foo', 'Bar'] |
     And the side effects should be:
@@ -150,7 +150,7 @@ Feature: Set3 - Set a Label
       SET n :Foo:Bar
       RETURN labels(n)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(n)      |
       | ['Foo', 'Bar'] |
     And the side effects should be:

--- a/tck/features/expressions/graph/Graph3.feature
+++ b/tck/features/expressions/graph/Graph3.feature
@@ -52,7 +52,7 @@ Feature: Graph3 - Node labels
       CREATE (node:Foo:Bar {name: 'Mattias'})
       RETURN labels(node)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(node)   |
       | ['Foo', 'Bar'] |
     And the side effects should be:
@@ -68,7 +68,7 @@ Feature: Graph3 - Node labels
       CREATE (node :Foo:Bar)
       RETURN labels(node)
       """
-    Then the result should be, in any order:
+    Then the result should be (ignoring element order for lists):
       | labels(node)   |
       | ['Foo', 'Bar'] |
     And the side effects should be:


### PR DESCRIPTION
We don't guarantee any ordering of the array returned by the `labels` function, right? These assertions causes failures in  https://github.com/neo-technology/neo4j/pull/17164.