### PR TITLE
Add TCK expectation: the result should be, in order (ignoring element order for lists)

### DIFF
--- a/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy2.feature
@@ -256,7 +256,7 @@ Feature: ReturnOrderBy2 - Order by a single expression (order of projection)
       RETURN collect(nodes(p)) AS paths, length(p) AS l
       ORDER BY l
       """
-    Then the result should be, in order:
+    Then the result should be, in order (ignoring element order for lists):
       | paths                                                    | l |
       | [[(:A), (:B)], [(:C), (:D)], [(:D), (:E)], [(:E), (:F)]] | 1 |
       | [[(:C), (:D), (:E)], [(:D), (:E), (:F)]]                 | 2 |

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/CypherTCK.scala
@@ -244,6 +244,7 @@ object CypherTCK {
         case expectResultR()               => List(ExpectResult(parseTable(), step))
         case expectSortedResultR()         => List(ExpectResult(parseTable(), step, sorted = true))
         case expectResultUnorderedListsR() => List(ExpectResult(parseTable(orderedLists = false), step))
+        case expectSortedResultUnorderedListsR() => List(ExpectResult(parseTable(orderedLists = false), step, sorted = true))
         case expectErrorR(errorType, time, detail) =>
           val expectedError = ExpectError(errorType, time, detail, step)
           if (shouldValidate) {

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/constants/TCKStepDefinitions.scala
@@ -79,6 +79,9 @@ object TCKStepDefinitions {
   val EXPECT_RESULT_UNORDERED_LISTS = "^the result should be \\(ignoring element order for lists\\):$"
   val expectResultUnorderedListsR = EXPECT_RESULT_UNORDERED_LISTS.r
 
+  val EXPECT_SORTED_RESULT_UNORDERED_LISTS = "^the result should be, in order \\(ignoring element order for lists\\):$"
+  val expectSortedResultUnorderedListsR = EXPECT_SORTED_RESULT_UNORDERED_LISTS.r
+
   val EXPECT_EMPTY_RESULT = "^the result should be empty$"
   val expectEmptyResultR = EXPECT_EMPTY_RESULT.r
 


### PR DESCRIPTION
- Add TCK expectation: the result should be, in order (ignoring element order for lists)
- Do not assert on list elements order in [12] Aggregation of named paths scenario