### PR TITLE
Use COMPARE token for defining comparison operators in PartialComparisonExpression rule

### DIFF
--- a/tools/grammar-demo/src/main/resources/Cypher.g4
+++ b/tools/grammar-demo/src/main/resources/Cypher.g4
@@ -383,13 +383,10 @@ FALSE : ( 'F' | 'f' ) ( 'A' | 'a' ) ( 'L' | 'l' ) ( 'S' | 's' ) ( 'E' | 'e' )  ;
 oC_ListLiteral
            :  '[' SP? ( oC_Expression SP? ( ',' SP? oC_Expression SP? )* )? ']' ;
 
+COMPARE : ('=' | '<>' | '<' | '>' | '<=' | '>=') ;
+
 oC_PartialComparisonExpression
-                           :  ( '=' SP? oC_AddOrSubtractExpression )
-                               | ( '<>' SP? oC_AddOrSubtractExpression )
-                               | ( '<' SP? oC_AddOrSubtractExpression )
-                               | ( '>' SP? oC_AddOrSubtractExpression )
-                               | ( '<=' SP? oC_AddOrSubtractExpression )
-                               | ( '>=' SP? oC_AddOrSubtractExpression )
+                           :  ( COMPARE SP? oC_AddOrSubtractExpression )
                                ;
 
 oC_ParenthesizedExpression


### PR DESCRIPTION
Signed-off-by: 1sand0s <1sand0sardpi@gmail.com>

Using a `COMPARE` token to define the list of possible comparison operators before their usage in the `oC_PartialComparisonExpression` production rule makes it possible to easily identify which operator was used in the parsed Cypher query (by fetching the terminal node COMPARE). 