### PR TITLE
Update to use n as the grouping key, instead of m in Exists Aggregation Acceptance test

### DIFF
--- a/tck/features/expressions/existentialSubqueries/ExistentialSubquery2.feature
+++ b/tck/features/expressions/existentialSubqueries/ExistentialSubquery2.feature
@@ -64,7 +64,7 @@ Feature: ExistentialSubquery2 - Full existential subquery
       """
       MATCH (n) WHERE exists {
         MATCH (n)-->(m)
-        WITH m, count(*) AS numConnections
+        WITH n, count(*) AS numConnections
         WHERE numConnections = 3
         RETURN true
       }


### PR DESCRIPTION
This test is currently incorrect, when m is the grouping key, the max numConnections can be is 2, and not 3