### PR TITLE
Fix bug in unordered rows comparison

### DIFF
--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
@@ -77,7 +77,7 @@ object CypherValueRecords {
 
   private def rowCounts[ROW <: Any](rows: Seq[ROW]): Map[ROW, Int] = {
     rows.foldLeft(Map.empty[ROW, Int]) {
-      case (acc, row) => acc.updatedWith(row)(_.map(count => count + 1).orElse(Some(1)))
+      case (acc, row) => acc + (row -> (acc.getOrElse(row, 0) + 1))
     }
   }
 }

--- a/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
+++ b/tools/tck-api/src/main/scala/org/opencypher/tools/tck/api/Result.scala
@@ -27,6 +27,7 @@
  */
 package org.opencypher.tools.tck.api
 
+import org.opencypher.tools.tck.api.CypherValueRecords.rowCounts
 import org.opencypher.tools.tck.values.CypherValue
 
 /**
@@ -46,7 +47,7 @@ case class CypherValueRecords(header: List[String], rows: List[Map[String, Cyphe
 
   def equalsUnordered(otherRecords: CypherValueRecords): Boolean = {
     def equalHeaders = header == otherRecords.header
-    def equalRows = rows.sortBy(_.hashCode()) == otherRecords.rows.sortBy(_.hashCode())
+    def equalRows = rowCounts(rows) == rowCounts(otherRecords.rows)
     equalHeaders && equalRows
   }
 
@@ -73,6 +74,12 @@ object CypherValueRecords {
 
   val empty = CypherValueRecords(List.empty, List.empty)
   def emptyWithHeader(header: List[String]) = CypherValueRecords(header, List.empty)
+
+  private def rowCounts[ROW <: Any](rows: Seq[ROW]): Map[ROW, Int] = {
+    rows.foldLeft(Map.empty[ROW, Int]) {
+      case (acc, row) => acc.updatedWith(row)(_.map(count => count + 1).orElse(Some(1)))
+    }
+  }
 }
 
 case class ExecutionFailed(errorType: String, phase: String, detail: String, exception: Option[Throwable] = None)

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 "Neo Technology,"
+ * Copyright (c) 2015-2023 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015-2022 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
+package org.opencypher.tools.tck.api
+
+import org.opencypher.tools.tck.values.CypherString
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class CypherValueRecordsTest extends AnyFunSuite with Matchers {
+
+  test("compare rows with equal hash code") {
+    val a = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("Aa")), Map("a" -> CypherString("BB"))))
+    val b = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("BB")), Map("a" -> CypherString("Aa"))))
+
+    a.hashCode() shouldBe b.hashCode() // If this fails, find another hash collision
+
+    a.equalsUnordered(b) shouldBe true
+  }
+
+  test("compare rows with equal hash code 2") {
+    val a = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("Aa")), Map("a" -> CypherString("BB"))))
+    val b = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("BB")), Map("a" -> CypherString("BB"))))
+
+    a.hashCode() shouldBe b.hashCode() // If this fails, find another hash collision
+
+    a.equalsUnordered(b) shouldBe false
+  }
+}

--- a/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
+++ b/tools/tck-api/src/test/scala/org/opencypher/tools/tck/api/CypherValueRecordsTest.scala
@@ -34,10 +34,11 @@ import org.scalatest.matchers.should.Matchers
 class CypherValueRecordsTest extends AnyFunSuite with Matchers {
 
   test("compare rows with equal hash code") {
-    val a = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("Aa")), Map("a" -> CypherString("BB"))))
-    val b = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("BB")), Map("a" -> CypherString("Aa"))))
+    val rows = List(Map("a" -> CypherString("Aa")), Map("a" -> CypherString("BB")))
+    val a = CypherValueRecords(List("a", "b"), rows)
+    val b = CypherValueRecords(List("a", "b"), rows.reverse)
 
-    a.hashCode() shouldBe b.hashCode() // If this fails, find another hash collision
+    rows.head.hashCode() shouldBe rows(1).hashCode() // If this fails, find another hash collision
 
     a.equalsUnordered(b) shouldBe true
   }
@@ -45,8 +46,6 @@ class CypherValueRecordsTest extends AnyFunSuite with Matchers {
   test("compare rows with equal hash code 2") {
     val a = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("Aa")), Map("a" -> CypherString("BB"))))
     val b = CypherValueRecords(List("a", "b"), List(Map("a" -> CypherString("BB")), Map("a" -> CypherString("BB"))))
-
-    a.hashCode() shouldBe b.hashCode() // If this fails, find another hash collision
 
     a.equalsUnordered(b) shouldBe false
   }


### PR DESCRIPTION
Fix bug in `CypherValueRecords.equalsUnordered` where rows with equal hash code could generate false negatives.