### PR TITLE
Update expected errors in TCK

### DIFF
--- a/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
+++ b/tck/features/clauses/return-orderby/ReturnOrderBy6.feature
@@ -77,7 +77,7 @@ Feature: ReturnOrderBy6 - Aggregation expressions in order by
       RETURN count(you.age) AS agg
       ORDER BY me.age + count(you.age)
       """
-    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+    Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   Scenario: [5] Fail if more complex expressions, even if returned, are used inside an order by item which contains an aggregation expression
     Given an empty graph

--- a/tck/features/clauses/with-orderBy/WithOrderBy4.feature
+++ b/tck/features/clauses/with-orderBy/WithOrderBy4.feature
@@ -353,7 +353,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
         LIMIT 2
       RETURN mod, min
       """
-    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+    Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   Scenario: [14] Fail on sorting by a non-projected aggregation on an expression
     Given an empty graph
@@ -373,7 +373,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
         LIMIT 2
       RETURN mod, min
       """
-    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+    Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   Scenario: [15] Sort by an aliased aggregate projection does allow subsequent matching
     Given an empty graph
@@ -449,7 +449,7 @@ Feature: WithOrderBy4 - Order by in combination with projection and aliasing
       ORDER BY me.age + count(you.age)
       RETURN *
       """
-    Then a SyntaxError should be raised at compile time: AmbiguousAggregationExpression
+    Then a SyntaxError should be raised at compile time: UndefinedVariable
 
   Scenario: [20] Fail if more complex expressions, even if projected, are used inside an order by item which contains an aggregation expression
     Given an empty graph


### PR DESCRIPTION
Background:
When referring to a concrete variable in an aggregation expresion in ORDER BY, e.g. referring to `you` in

```
WITH count(you.age) AS agg
ORDER BY me.age + count(you.age)
```

there are 2 errors:
* `you` is not in scope ("UndefinedVariable")
* It is not OK to use an aggregation function in ORDER BY ("AmbiguousAggregationExpression")

We are changing the way of our SemanticAnalysis such that the first error takes precedence.