### PR TITLE
Corrected assertion on error type

### DIFF
--- a/tck/features/clauses/delete/Delete1.feature
+++ b/tck/features/clauses/delete/Delete1.feature
@@ -127,7 +127,7 @@ Feature: Delete1 - Deleting nodes
       MATCH (n:X)
       DELETE n
       """
-    Then a ConstraintVerificationFailed should be raised at runtime: DeleteConnectedNode
+    Then a ConstraintValidationFailed should be raised at runtime: DeleteConnectedNode
 
   Scenario: [8] Failing when deleting a label
     Given any graph


### PR DESCRIPTION
[`tck/README.md`](https://github.com/opencypher/openCypher/blob/master/tck/README.adoc) details that `ConstraintVerificationFailed` is issued if data already in the database violates the constraint to be created, whereas here we want to change data to a state that would be violating a constraint in the database.